### PR TITLE
Decompose IceCandidate

### DIFF
--- a/docs/rfc/0002-webrc-client-api.md
+++ b/docs/rfc/0002-webrc-client-api.md
@@ -540,7 +540,16 @@ This event is sent during SDP negotiation/re-negotiation.
 ```rust
 struct IceCandidateDiscovered {
     peer_id: u64,
+    candidate: IceCandidate,
+}
+```
+
+Related objects:
+```rust
+struct IceCandidate {
     candidate: String,
+    sdp_m_line_index: Option<u16>,
+    sdp_mid: Option<String>,
 }
 ```
 
@@ -895,7 +904,16 @@ struct MakeSdpAnswer {
 ```rust
 struct SetIceCandidate {
     peer_id: u64,
+    candidate: IceCandidate,
+}
+```
+
+Related objects:
+```rust
+struct IceCandidate {
     candidate: String,
+    sdp_m_line_index: Option<u16>,
+    sdp_mid: Option<String>,
 }
 ```
 
@@ -1183,7 +1201,11 @@ struct GetMembers {
           "command": "SetIceCandidate",
           "data": {
             "peer_id": 1,
-            "candidate": "user1_ice_candidate"
+            "candidate": {
+               "candidate": "user1_ice_candidate",
+               "sdp_m_line_index": 0,
+               "sdp_mid": "0"
+             }
           }
         }
         ```
@@ -1195,7 +1217,11 @@ struct GetMembers {
           "event": "IceCandidateDiscovered",
           "data": {
             "peer_id": 2,
-            "candidate": "user1_ice_candidate"
+            "candidate": {
+               "candidate": "user1_ice_candidate",
+               "sdp_m_line_index": 0,
+               "sdp_mid": "0"
+             }
           }
         }
         ```
@@ -1207,7 +1233,11 @@ struct GetMembers {
           "command": "SetIceCandidate",
           "data": {
             "peer_id": 2,
-            "candidate": "user2_ice_candidate"
+            "candidate": {
+               "candidate": "user2_ice_candidate",
+               "sdp_m_line_index": 0,
+               "sdp_mid": "0"
+             }
           }
         }
         ```
@@ -1219,7 +1249,11 @@ struct GetMembers {
           "event": "IceCandidateDiscovered",
           "data": {
             "peer_id": 1,
-            "candidate": "user2_ice_candidate"
+            "candidate": {
+               "candidate": "user2_ice_candidate",
+               "sdp_m_line_index": 0,
+               "sdp_mid": "0"
+             }
           }
         }
         ```
@@ -1503,7 +1537,11 @@ struct GetMembers {
           "command": "SetIceCandidate",
           "data": {
             "peer_id": 1,
-            "candidate": "user1_ice_candidate"
+            "candidate": {
+               "candidate": "user1_ice_candidate",
+               "sdp_m_line_index": 0,
+               "sdp_mid": "0"
+             }
           }
         }
         ```
@@ -1515,7 +1553,11 @@ struct GetMembers {
           "event": "IceCandidateDiscovered",
           "data": {
             "peer_id": 1,
-            "candidate": "server_ice_candidate"
+            "candidate": {
+               "candidate": "server_ice_candidate",
+               "sdp_m_line_index": 0,
+               "sdp_mid": "0"
+             }
           }
         }
         ```
@@ -1594,7 +1636,11 @@ struct GetMembers {
           "command": "SetIceCandidate",
           "data": {
             "peer_id": 2,
-            "candidate": "user2_ice_candidate"
+            "candidate": {
+               "candidate": "user2_ice_candidate",
+               "sdp_m_line_index": 0,
+               "sdp_mid": "0"
+             }
           }
         }
         ```
@@ -1606,7 +1652,11 @@ struct GetMembers {
           "event": "IceCandidateDiscovered",
           "data": {
             "peer_id": 2,
-            "candidate": "server_ice_candidate"
+            "candidate": {
+               "candidate": "server_ice_candidate",
+               "sdp_m_line_index": 0,
+               "sdp_mid": "0"
+             }
           }
         }
         ```
@@ -1729,7 +1779,11 @@ struct GetMembers {
           "command": "SetIceCandidate",
           "data": {
             "peer_id": 3,
-            "candidate": "user3_ice_candidate"
+            "candidate": {
+               "candidate": "user3_ice_candidate",
+               "sdp_m_line_index": 0,
+               "sdp_mid": "0"
+             }
           }
         }
         ```
@@ -1741,7 +1795,11 @@ struct GetMembers {
           "event": "IceCandidateDiscovered",
           "data": {
             "peer_id": 3,
-            "candidate": "server_ice_candidate"
+            "candidate": {
+               "candidate": "server_ice_candidate",
+               "sdp_m_line_index": 0,
+               "sdp_mid": "0"
+             }
           }
         }
         ```

--- a/signaling_test.html
+++ b/signaling_test.html
@@ -69,7 +69,6 @@
 
             var pc = pcs[msg.peer_id];
             pc.ontrack = function (e) {
-                console.log("ontrack");
                 partnervid.srcObject = e.streams[0];
             };
 
@@ -126,7 +125,11 @@
                         command: "SetIceCandidate",
                         data: {
                             peer_id: msg.peer_id,
-                            candidate: JSON.stringify(e.candidate)
+                            candidate: {
+                                candidate: e.candidate.candidate,
+                                sdp_mid: e.candidate.sdpMid,
+                                sdp_m_line_index: e.candidate.sdpMLineIndex
+                            }
                         }
                     }))
                 }
@@ -141,7 +144,11 @@
 
         async function handleIceCandidateDiscovered(msg) {
             var pc = pcs[msg.peer_id];
-            pc.addIceCandidate(JSON.parse(msg.candidate));
+            pc.addIceCandidate(            {
+                candidate:msg.candidate.candidate,
+                sdpMid:msg.candidate.sdp_mid,
+                sdpMLineIndex: msg.candidate.sdp_m_line_index,
+            });
         }
 
     </script>

--- a/src/api/client/rpc_connection.rs
+++ b/src/api/client/rpc_connection.rs
@@ -82,6 +82,7 @@ pub mod test {
     };
     use futures::future::Future;
 
+    use crate::api::protocol::IceCandidate;
     use crate::{
         api::{
             client::rpc_connection::{
@@ -158,7 +159,11 @@ pub mod test {
                     }
                     self.room.do_send(Command::SetIceCandidate {
                         peer_id,
-                        candidate: "ice_candidate".into(),
+                        candidate: IceCandidate {
+                            candidate: "ice_candidate".to_owned(),
+                            sdp_m_line_index: None,
+                            sdp_mid: None,
+                        },
                     })
                 }
                 Event::IceCandidateDiscovered {

--- a/src/api/protocol.rs
+++ b/src/api/protocol.rs
@@ -38,7 +38,10 @@ pub enum Command {
     /// Web Client sends SDP Answer.
     MakeSdpAnswer { peer_id: u64, sdp_answer: String },
     /// Web Client sends Ice Candidate.
-    SetIceCandidate { peer_id: u64, candidate: String },
+    SetIceCandidate {
+        peer_id: u64,
+        candidate: IceCandidate,
+    },
 }
 
 /// WebSocket message from Medea to Jason.
@@ -60,11 +63,22 @@ pub enum Event {
 
     /// Media Server notifies Web Client about necessity to apply specified
     /// ICE Candidate.
-    IceCandidateDiscovered { peer_id: u64, candidate: String },
+    IceCandidateDiscovered {
+        peer_id: u64,
+        candidate: IceCandidate,
+    },
 
     /// Media Server notifies Web Client about necessity of RTCPeerConnection
     /// close.
     PeersRemoved { peer_ids: Vec<u64> },
+}
+
+/// Represents [`RtcIceCandidateInit`] object.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct IceCandidate {
+    pub candidate: String,
+    pub sdp_m_line_index: Option<u16>,
+    pub sdp_mid: Option<String>,
 }
 
 /// [`Track] with specified direction.

--- a/src/api/protocol.rs
+++ b/src/api/protocol.rs
@@ -81,7 +81,7 @@ pub struct IceCandidate {
     pub sdp_mid: Option<String>,
 }
 
-/// [`Track] with specified direction.
+/// [`Track`] with specified direction.
 #[derive(Deserialize, Serialize, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Directional {

--- a/src/conf/mod.rs
+++ b/src/conf/mod.rs
@@ -170,6 +170,8 @@ mod conf_parse_spec {
         assert_ne!(new_config.rpc.idle_timeout, defaults.rpc.idle_timeout);
     }
 
+    // TODO: This test seems to pollute environment and might
+    //       fail from time to time.
     #[test]
     #[serial]
     fn env_overrides_defaults() {

--- a/src/signalling/room.rs
+++ b/src/signalling/room.rs
@@ -18,7 +18,7 @@ use crate::{
             RpcConnectionEstablished,
         },
         control::{Member, MemberId},
-        protocol::{Command, Event},
+        protocol::{Command, Event, IceCandidate},
     },
     log::prelude::*,
     media::{
@@ -193,7 +193,7 @@ impl Room {
     fn handle_set_ice_candidate(
         &mut self,
         from_peer_id: PeerId,
-        candidate: String,
+        candidate: IceCandidate,
     ) -> Result<ActFuture<(), RoomError>, RoomError> {
         let from_peer = self.peers.get_peer(from_peer_id)?;
         if let PeerStateMachine::New(_) = from_peer {
@@ -412,10 +412,7 @@ impl Handler<RpcConnectionClosed> for Room {
 
 #[cfg(test)]
 mod test {
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc, Mutex,
-    };
+    use std::sync::{atomic::AtomicUsize, Arc, Mutex};
 
     use actix::{Addr, Arbiter, System};
 
@@ -494,7 +491,11 @@ mod test {
                 .unwrap(),
                 serde_json::to_string(&Event::IceCandidateDiscovered {
                     peer_id: 1,
-                    candidate: "ice_candidate".into(),
+                    candidate: IceCandidate {
+                        candidate: "ice_candidate".to_owned(),
+                        sdp_m_line_index: None,
+                        sdp_mid: None
+                    },
                 })
                 .unwrap(),
             ]
@@ -522,7 +523,11 @@ mod test {
                 .unwrap(),
                 serde_json::to_string(&Event::IceCandidateDiscovered {
                     peer_id: 2,
-                    candidate: "ice_candidate".into(),
+                    candidate: IceCandidate {
+                        candidate: "ice_candidate".to_owned(),
+                        sdp_m_line_index: None,
+                        sdp_mid: None
+                    },
                 })
                 .unwrap(),
             ]


### PR DESCRIPTION
В текущей реализации, ICE кандидаты в `Event(IceCandidateDiscovered)` и `Command(SetIceCandidates)` хранятся в сериализованном виде. Дабы избежать лишних сериализаций/десериализаций/валидаций на стороне клиента, предлагается передавать кандидатов в трех полях. 
Было:

```rust
struct IceCandidateDiscovered {
    peer_id: u64,
    candidate: IceCandidate,
}
```
```json
{
  "event": "IceCandidateDiscovered",
  "data": {
    "peer_id": 1,
    "candidate": "user2_ice_candidate"
  }
}
```
Стало:
```rust
struct IceCandidateDiscovered {
    peer_id: u64,
    candidate: IceCandidate,
}

struct IceCandidate {
    candidate: String,
    sdp_m_line_index: Option<u16>,
    sdp_mid: Option<String>,
}
```
```json
{
  "event": "IceCandidateDiscovered",
  "data": {
    "peer_id": 1,
    "candidate": {
       "candidate": "user2_ice_candidate",
       "sdp_m_line_index": 0,
       "sdp_mid": "0"
     }
  }
}
```