### PR TITLE
Fix OsSignal for GracefulShutdown, fix default shutdown.timeout in docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -94,4 +94,4 @@
 # Maximum duration given to shutdown the whole application gracefully.
 #
 # Default:
-#   timeout = "1s"
+#   timeout = "5s"

--- a/src/api/client/server.rs
+++ b/src/api/client/server.rs
@@ -131,7 +131,7 @@ impl Handler<ShutdownGracefully> for Server {
         _: ShutdownGracefully,
         _: &mut Self::Context,
     ) -> Self::Result {
-        info!("Shutting down Client API HTTP server");
+        info!("Server received ShutdownGracefully message so shutting down");
         Box::new(self.0.stop(true).into_actor(self))
     }
 }

--- a/src/signalling/room.rs
+++ b/src/signalling/room.rs
@@ -467,7 +467,10 @@ impl Handler<ShutdownGracefully> for Room {
         _: ShutdownGracefully,
         ctx: &mut Self::Context,
     ) -> Self::Result {
-        info!("Shutdown signal received for Room: {:?}", self.id);
+        info!(
+            "Room: {:?} received ShutdownGracefully message so shutting down",
+            self.id
+        );
         self.close_gracefully(ctx)
     }
 }


### PR DESCRIPTION
Resolves #29 

## Synopsis

1. Wrong default shutdown.timeout config.toml
2. Handler<OsSignal> for GracefulShutdown do not send messages to sub

## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains `WIP: ` prefix
    - [ ] Name contains issue reference
    - [ ] Has `k::` labels applied
    - [ ] Has assignee
- [ ] Documentation is updated (if required)
- [ ] Tests are updated (if required)
- [ ] Changes conform code style
- [ ] CHANGELOG entry is added (if required)
- [ ] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `WIP: ` prefix is removed
    - [ ] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
