### PR TITLE
Use refer to enum variants with Self::Variant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ ifeq ($(test-unit-crate),@all)
 else
 ifeq ($(crate),medea-jason)
 	cd $(crate-dir)/ && \
-    cargo test --target wasm32-unknown-unknown --features mockable
+    cargo test --target wasm32-unknown-unknown
 else
 	cd $(crate-dir)/ && \
 	cargo test

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ cargo.fmt:
 #	make cargo.lint
 
 cargo.lint:
-	cargo +nightly clippy --all -- -D clippy::pedantic -D warnings
+	cargo clippy --all -- -D clippy::pedantic -D warnings
 
 
 
@@ -228,8 +228,13 @@ ifeq ($(test-unit-crate),@all)
 	@make test.unit crate=medea-jason
 	@make test.unit crate=medea
 else
+ifeq ($(crate),medea-jason)
 	cd $(crate-dir)/ && \
-	cargo test -p $(test-unit-crate)
+    cargo test --target wasm32-unknown-unknown --features mockable
+else
+	cd $(crate-dir)/ && \
+	cargo test
+endif
 endif
 
 

--- a/jason/.cargo/config
+++ b/jason/.cargo/config
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'

--- a/jason/src/lib.rs
+++ b/jason/src/lib.rs
@@ -1,6 +1,3 @@
-// TODO: when using enum's Self will be in stable, remove it.
-#![allow(clippy::use_self)]
-
 pub mod api;
 pub mod media;
 pub mod peer;

--- a/jason/src/peer/conn.rs
+++ b/jason/src/peer/conn.rs
@@ -38,8 +38,8 @@ impl TransceiverKind {
     /// Returns string representation of a [`TransceiverKind`].
     pub fn as_str(self) -> &'static str {
         match self {
-            TransceiverKind::Audio => "audio",
-            TransceiverKind::Video => "video",
+            Self::Audio => "audio",
+            Self::Video => "video",
         }
     }
 }
@@ -58,8 +58,8 @@ impl From<TransceiverDirection> for RtcRtpTransceiverDirection {
     fn from(direction: TransceiverDirection) -> Self {
         use TransceiverDirection::*;
         match direction {
-            Sendonly => RtcRtpTransceiverDirection::Sendonly,
-            Recvonly => RtcRtpTransceiverDirection::Recvonly,
+            Sendonly => Self::Sendonly,
+            Recvonly => Self::Recvonly,
         }
     }
 }

--- a/jason/src/rpc/websocket.rs
+++ b/jason/src/rpc/websocket.rs
@@ -28,7 +28,7 @@ impl State {
     /// Returns `true` if socket can be closed.
     pub fn can_close(&self) -> bool {
         match self {
-            State::CONNECTING | State::OPEN => true,
+            Self::CONNECTING | Self::OPEN => true,
             _ => false,
         }
     }
@@ -39,10 +39,10 @@ impl TryFrom<u16> for State {
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(State::CONNECTING),
-            1 => Ok(State::OPEN),
-            2 => Ok(State::CLOSING),
-            3 => Ok(State::CLOSED),
+            0 => Ok(Self::CONNECTING),
+            1 => Ok(Self::OPEN),
+            2 => Ok(Self::CLOSING),
+            3 => Ok(Self::CLOSED),
             _ => Err(WasmErr::Custom(
                 format!("Could not cast {} to State variant", value).into(),
             )),
@@ -212,8 +212,8 @@ impl From<&CloseEvent> for CloseMsg {
         let code: u16 = event.code();
         let body = format!("{}:{}", code, event.reason());
         match code {
-            1000 => CloseMsg::Normal(body),
-            _ => CloseMsg::Disconnect(body),
+            1000 => Self::Normal(body),
+            _ => Self::Disconnect(body),
         }
     }
 }

--- a/jason/src/utils/errors.rs
+++ b/jason/src/utils/errors.rs
@@ -24,21 +24,21 @@ impl WasmErr {
 
 impl From<&'static str> for WasmErr {
     fn from(msg: &'static str) -> Self {
-        WasmErr::Custom(Cow::Borrowed(msg))
+        Self::Custom(Cow::Borrowed(msg))
     }
 }
 
 impl From<String> for WasmErr {
     fn from(msg: String) -> Self {
-        WasmErr::Custom(Cow::Owned(msg))
+        Self::Custom(Cow::Owned(msg))
     }
 }
 
 impl From<JsValue> for WasmErr {
     fn from(val: JsValue) -> Self {
         match val.dyn_into::<js_sys::Error>() {
-            Ok(err) => WasmErr::JsError(err),
-            Err(val) => WasmErr::Untyped(val),
+            Ok(err) => Self::JsError(err),
+            Err(val) => Self::Untyped(val),
         }
     }
 }
@@ -56,11 +56,11 @@ impl From<WasmErr> for JsValue {
 impl fmt::Display for WasmErr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            WasmErr::JsError(err) => {
+            Self::JsError(err) => {
                 write!(f, "{}", String::from(err.to_string()))
             }
-            WasmErr::Custom(reason) => write!(f, "{}", reason),
-            WasmErr::Untyped(val) => match val.as_string() {
+            Self::Custom(reason) => write!(f, "{}", reason),
+            Self::Untyped(val) => match val.as_string() {
                 Some(reason) => write!(f, "{}", reason),
                 None => write!(f, "no str representation for JsError"),
             },
@@ -72,7 +72,7 @@ macro_rules! impl_from_error {
     ($error:ty) => {
         impl From<$error> for WasmErr {
             fn from(error: $error) -> Self {
-                WasmErr::Custom(format!("{}", error).into())
+                Self::Custom(format!("{}", error).into())
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 //! Medea media server application.
 
-// TODO: when using enum's Self will be in stable, remove it.
-#![allow(clippy::use_self)]
-
 #[macro_use]
 pub mod utils;
 pub mod api;

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -5,10 +5,11 @@ use std::{
     time::Duration,
 };
 
+#[cfg(unix)]
+use actix::AsyncContext;
 use actix::{
     prelude::{Actor, Context},
-    AsyncContext, Handler, Message, Recipient, ResponseActFuture, System,
-    WrapFuture as _,
+    Handler, Message, Recipient, ResponseActFuture, System, WrapFuture as _,
 };
 use failure::Fail;
 use futures::{future, stream::iter_ok, Future, Stream};
@@ -63,28 +64,21 @@ impl GracefulShutdown {
 impl Actor for GracefulShutdown {
     type Context = Context<Self>;
 
+    #[cfg(not(unix))]
+    fn started(&mut self, _: &mut Self::Context) {
+        info!("Graceful shutdown is disabled: only UNIX signals are supported");
+    }
+
+    #[cfg(unix)]
     fn started(&mut self, ctx: &mut Self::Context) {
-        #[cfg(not(unix))]
-        {
-            warning!(
-                "Graceful shutdown is disabled: only UNIX signals are \
-                 supported"
+        use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
+        for s in &[SIGHUP, SIGINT, SIGQUIT, SIGTERM] {
+            ctx.add_message_stream(
+                Signal::new(*s)
+                    .flatten_stream()
+                    .map(OsSignal)
+                    .map_err(|_| error!("Error getting shutdown signal")),
             );
-            return;
-        }
-        #[cfg(unix)]
-        {
-            use tokio_signal::unix::{
-                Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM,
-            };
-            for s in &[SIGHUP, SIGINT, SIGQUIT, SIGTERM] {
-                ctx.add_message_stream(
-                    Signal::new(*s)
-                        .flatten_stream()
-                        .map(OsSignal)
-                        .map_err(|_| error!("Error getting shutdown signal")),
-                );
-            }
         }
     }
 
@@ -97,12 +91,10 @@ impl Actor for GracefulShutdown {
 
 /// Message that is received by [`GracefulShutdown`] shutdown service when
 /// the process receives an OS signal.
-#[cfg(unix)]
 #[derive(Message)]
 #[rtype(result = "Result<(), ()>")]
 struct OsSignal(i32);
 
-#[cfg(unix)]
 impl Handler<OsSignal> for GracefulShutdown {
     type Result = ResponseActFuture<Self, (), ()>;
 

--- a/src/signalling/participants.rs
+++ b/src/signalling/participants.rs
@@ -56,13 +56,13 @@ pub enum ParticipantServiceErr {
 
 impl From<TurnServiceErr> for ParticipantServiceErr {
     fn from(err: TurnServiceErr) -> Self {
-        ParticipantServiceErr::TurnServiceErr(err)
+        Self::TurnServiceErr(err)
     }
 }
 
 impl From<MailboxError> for ParticipantServiceErr {
     fn from(err: MailboxError) -> Self {
-        ParticipantServiceErr::MailBoxErr(err)
+        Self::MailBoxErr(err)
     }
 }
 

--- a/src/turn/repo.rs
+++ b/src/turn/repo.rs
@@ -20,7 +20,7 @@ pub enum TurnDatabaseErr {
 
 impl From<RedisError> for TurnDatabaseErr {
     fn from(err: RedisError) -> Self {
-        TurnDatabaseErr::RedisError(err)
+        Self::RedisError(err)
     }
 }
 

--- a/src/turn/service.rs
+++ b/src/turn/service.rs
@@ -109,22 +109,22 @@ pub enum TurnServiceErr {
 
 impl From<TurnDatabaseErr> for TurnServiceErr {
     fn from(err: TurnDatabaseErr) -> Self {
-        TurnServiceErr::TurnAuthRepoErr(err)
+        Self::TurnAuthRepoErr(err)
     }
 }
 
 impl From<bb8::RunError<TurnDatabaseErr>> for TurnServiceErr {
     fn from(err: bb8::RunError<TurnDatabaseErr>) -> Self {
         match err {
-            RunError::User(error) => TurnServiceErr::TurnAuthRepoErr(error),
-            RunError::TimedOut => TurnServiceErr::TimedOut,
+            RunError::User(error) => Self::TurnAuthRepoErr(error),
+            RunError::TimedOut => Self::TimedOut,
         }
     }
 }
 
 impl From<MailboxError> for TurnServiceErr {
     fn from(err: MailboxError) -> Self {
-        TurnServiceErr::MailboxErr(err)
+        Self::MailboxErr(err)
     }
 }
 


### PR DESCRIPTION
## Synopsis

Make a linter is happy by use refer to enum variants with Self::Varisant

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `WIP: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [ ] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `WIP: ` prefix is removed
    - [ ] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
