### PR TITLE
WIP: Send reason of WebSocket close by server

### DIFF
--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use derive_more::Display;
+use derive_more::{Constructor, Display};
 use medea_macro::dispatchable;
 use serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize};
 
@@ -97,6 +97,25 @@ pub enum Command {
         peer_id: PeerId,
         candidate: IceCandidate,
     },
+}
+
+/// Reason of disconnecting client from the server.
+#[derive(Debug, Deserialize, Serialize)]
+pub enum RpcConnectionCloseReason {
+    /// Client session was finished on the server side.
+    Finished,
+
+    /// Old connection was closed due to client reconnection.
+    NewConnection,
+}
+
+/// Description which will be sent in [Close] WebSocket frame.
+///
+/// [Close]: https://tools.ietf.org/html/rfc6455#section-5.5.1
+#[derive(Constructor, Debug, Deserialize, Serialize)]
+pub struct CloseDescription {
+    /// Reason of why connection was closed.
+    pub reason: RpcConnectionCloseReason,
 }
 
 /// WebSocket message from Medea to Jason.

--- a/src/api/client/rpc_connection.rs
+++ b/src/api/client/rpc_connection.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use actix::Message;
 use derive_more::{From, Into};
 use futures::Future;
-use medea_client_api_proto::{Command, Event};
+use medea_client_api_proto::{CloseDescription, Command, Event};
 
 use crate::api::control::MemberId;
 
@@ -27,7 +27,10 @@ pub trait RpcConnection: fmt::Debug + Send {
     /// Closes [`RpcConnection`].
     /// No [`RpcConnectionClosed`] signals should be emitted.
     /// Always returns success.
-    fn close(&mut self) -> Box<dyn Future<Item = (), Error = ()>>;
+    fn close(
+        &mut self,
+        close_description: CloseDescription,
+    ) -> Box<dyn Future<Item = (), Error = ()>>;
 
     /// Sends [`Event`] to remote [`Member`].
     ///

--- a/src/api/client/session.rs
+++ b/src/api/client/session.rs
@@ -8,7 +8,7 @@ use actix::{
 };
 use actix_web_actors::ws::{self, CloseReason, WebsocketContext};
 use futures::future::Future;
-use medea_client_api_proto::{ClientMsg, ServerMsg};
+use medea_client_api_proto::{ClientMsg, CloseDescription, ServerMsg};
 
 use crate::{
     api::{
@@ -148,10 +148,19 @@ impl RpcConnection for Addr<WsSession> {
     /// Closes [`WsSession`] by sending itself "normal closure" close message.
     ///
     /// Never returns error.
-    fn close(&mut self) -> Box<dyn Future<Item = (), Error = ()>> {
+    fn close(
+        &mut self,
+        close_description: CloseDescription,
+    ) -> Box<dyn Future<Item = (), Error = ()>> {
+        let reason = CloseReason {
+            code: ws::CloseCode::Normal,
+            description: Some(
+                serde_json::to_string(&close_description).unwrap(),
+            ),
+        };
         let fut = self
             .send(Close {
-                reason: Some(ws::CloseCode::Normal.into()),
+                reason: Some(reason),
             })
             .or_else(|_| Ok(()));
         Box::new(fut)


### PR DESCRIPTION
Part of #27 

Required for #33 and #55 




## Synopsis

We need to send reason of WebSocket closing by server to client. 

Reasons which we have at this moment:

- `Finished` - client session was finished on the server side
- `NewConnection` - old connection was closed due to client reconnection

Also in #33 will be added `Evicted` reason.



## Solution

- [x] 1. Add reasons to `medea-client-api-proto`
- [x] 2. Send this reasons from Medea on WebSocket close




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `WIP: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [ ] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `WIP: ` prefix is removed
    - [ ] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
