### PR TITLE
Improve Medea's Dockerfile to cache built dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,21 +5,15 @@
 !Cargo.lock
 !src/
 
-# Medea uses this sub-crates.
+# Project sub-crates.
 !crates/
 !proto/
 
-# We don't need Jason while building Medea, but since it's in Medea's workspace,
-# Cargo should be able to see these files.
+# Jason sources, assets and manifest.
 !jason/Cargo.toml
 !jason/src/
 !jason/demo/chart/medea-demo/conf/
 !jason/demo/index.html
 
-# Medea dependencies cache.
-!.cache/cargo/
-
-# Makefile may be used in Dockerfile's.
+# Makefile may be used in Dockerfiles.
 !Makefile
-
-# !target/{mode} is added and removed dynamically to reduce image build times.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ ARG rust_ver=latest
 FROM rust:${rust_ver} AS dist
 ARG rustc_mode=release
 ARG rustc_opts=--release
-ARG cargo_home=/usr/local/cargo
 
 # Create user and group files, which will be used in a running container to
 # run the process as an unprivileged user.
@@ -20,17 +19,35 @@ RUN mkdir -p /out/etc/ \
  && echo 'nobody:x:65534:65534:nobody:/:' > /out/etc/passwd \
  && echo 'nobody:x:65534:' > /out/etc/group
 
-COPY / /app/
+# Prepare Cargo workspace for building dependencies only.
+COPY crates/medea-macro/Cargo.toml /app/crates/medea-macro/
+COPY proto/client-api/Cargo.toml /app/proto/client-api/
+COPY jason/Cargo.toml /app/jason/
+COPY Cargo.toml Cargo.lock /app/
+WORKDIR /app/
+RUN mkdir -p crates/medea-macro/src/ && touch crates/medea-macro/src/lib.rs \
+ && mkdir -p proto/client-api/src/ && touch proto/client-api/src/lib.rs \
+ && mkdir -p jason/src/ && touch jason/src/lib.rs \
+ && mkdir -p src/ && touch src/lib.rs
 
-# Build project distribution.
-RUN cd /app \
- # Compile project.
- && CARGO_HOME="${cargo_home}" \
-    # TODO: use --out-dir once stabilized
-    # TODO: https://github.com/rust-lang/cargo/issues/6790
-    cargo build --bin=medea ${rustc_opts} \
- # Prepare the binary and all dependent dynamic libraries.
- && cp /app/target/${rustc_mode}/medea /out/medea \
+# Build dependencies only.
+RUN cargo build --lib ${rustc_opts}
+# Remove fingreprints of pre-built empty project sub-crates
+# to rebuild them correctly later.
+RUN rm -rf /app/target/${rustc_mode}/.fingerprint/medea*
+
+# Prepare project sources for building.
+COPY crates/ /app/crates/
+COPY proto/ /app/proto/
+COPY src/ /app/src/
+
+# Build project distribution binary.
+# TODO: use --out-dir once stabilized
+# TODO: https://github.com/rust-lang/cargo/issues/6790
+RUN cargo build --bin=medea ${rustc_opts}
+
+# Prepare project distribution binary and all dependent dynamic libraries.
+RUN cp /app/target/${rustc_mode}/medea /out/medea \
  && ldd /out/medea \
     | awk 'BEGIN{ORS=" "}$1~/^\//{print $1}$3~/^\//{print $3}' \
     | sed 's/,$/\n/' \

--- a/Makefile
+++ b/Makefile
@@ -454,16 +454,6 @@ docker-build-medea-image-name = $(strip \
 	$(if $(call eq,$(registry),),,$(registry)/)$(MEDEA_IMAGE_NAME))
 
 docker.build.medea:
-ifneq ($(no-cache),yes)
-	docker run --rm --network=host -v "$(PWD)":/app -w /app \
-	           -u $(shell id -u):$(shell id -g) \
-	           -e CARGO_HOME=.cache/cargo \
-		rust:$(RUST_VER) \
-			cargo build --bin=medea \
-				$(if $(call eq,$(debug),no),--release,)
-endif
-	$(call docker.build.clean.ignore)
-	@echo "!target/$(if $(call eq,$(debug),no),release,debug)/" >> .dockerignore
 	$(docker-env) \
 	docker build $(if $(call eq,$(minikube),yes),,--network=host) --force-rm \
 		$(if $(call eq,$(no-cache),yes),\
@@ -475,11 +465,6 @@ endif
 			--build-arg rustc_opts=$(if \
 				$(call eq,$(debug),no),--release,),) \
 		-t $(docker-build-medea-image-name):$(if $(call eq,$(TAG),),dev,$(TAG)) .
-	$(call docker.build.clean.ignore)
-define docker.build.clean.ignore
-	@sed -i $(if $(call eq,$(shell uname -s),Darwin),'',) \
-		/^!target\/d .dockerignore
-endef
 
 
 # Stop Coturn STUN/TURN server in Docker Compose environment

--- a/Makefile
+++ b/Makefile
@@ -469,8 +469,7 @@ endif
 			--build-arg rustc_mode=$(if \
 				$(call eq,$(debug),no),release,debug) \
 			--build-arg rustc_opts=$(if \
-				$(call eq,$(debug),no),--release,) \
-			--build-arg cargo_home=.cache/cargo,) \
+				$(call eq,$(debug),no),--release,),) \
 		-t $(docker-build-medea-image-name):$(if $(call eq,$(TAG),),dev,$(TAG)) .
 	$(call docker.build.clean.ignore)
 define docker.build.clean.ignore


### PR DESCRIPTION
Part of #27 

Required for #33 




## Synopsis

We need to add caching of dependencies in Medea Dockerfile.




## Solution

Add building of Medea's deps in separate steps of Dockerfile.



## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `WIP: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `WIP: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
