### PR TITLE
Draft: Implements the logs sender for Jason

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,6 +1372,7 @@ version = "0.2.0-dev"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-cors 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-http 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-http-test 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ lto = "thin"
 
 [dependencies]
 actix = "0.8"
+actix-cors = "0.1"
 actix-web = "1.0"
 actix-web-actors = "1.0"
 bb8 = "0.3"

--- a/jason/Cargo.toml
+++ b/jason/Cargo.toml
@@ -46,12 +46,14 @@ wee_alloc = { version = "0.4", optional = true }
         "console", "ConstrainDomStringParameters",
         "CloseEvent",
         "Event", "EventTarget",
+        "Headers",
         "MediaDevices","MediaDeviceInfo", "MediaDeviceKind",
         "MediaTrackConstraints", "MediaTrackSettings",
         "MediaStream", "MediaStreamConstraints",
         "MediaStreamTrack", "MediaStreamTrackState",
         "MessageEvent",
         "Navigator",
+        "Request", "RequestInit", "RequestMode", "Response",
         "RtcConfiguration",
         "RtcIceCandidate", "RtcIceCandidateInit",
         "RtcIceConnectionState",
@@ -63,6 +65,7 @@ wee_alloc = { version = "0.4", optional = true }
         "RtcSdpType",
         "RtcSessionDescription", "RtcSessionDescriptionInit",
         "RtcTrackEvent",
+        "Storage",
         "WebSocket", "Window",
     ]
 

--- a/jason/Cargo.toml
+++ b/jason/Cargo.toml
@@ -46,7 +46,6 @@ wee_alloc = { version = "0.4", optional = true }
         "console", "ConstrainDomStringParameters",
         "CloseEvent",
         "Event", "EventTarget",
-        "Headers",
         "MediaDevices","MediaDeviceInfo", "MediaDeviceKind",
         "MediaTrackConstraints", "MediaTrackSettings",
         "MediaStream", "MediaStreamConstraints",

--- a/jason/Cargo.toml
+++ b/jason/Cargo.toml
@@ -46,6 +46,7 @@ wee_alloc = { version = "0.4", optional = true }
         "console", "ConstrainDomStringParameters",
         "CloseEvent",
         "Event", "EventTarget",
+        "Headers",
         "MediaDevices","MediaDeviceInfo", "MediaDeviceKind",
         "MediaTrackConstraints", "MediaTrackSettings",
         "MediaStream", "MediaStreamConstraints",

--- a/jason/demo/chart/medea-demo/conf/nginx.vh.conf
+++ b/jason/demo/chart/medea-demo/conf/nginx.vh.conf
@@ -21,6 +21,11 @@ server {
     proxy_pass    http://127.0.0.1:8000/control-api/;
   }
 
+  location ^~ /logs {
+    proxy_pass    http://127.0.0.1:8080/logs;
+    proxy_redirect off;
+  }
+
   # Disable unnecessary access logs.
   location = /favicon.ico {
     access_log       off;

--- a/jason/demo/index.html
+++ b/jason/demo/index.html
@@ -17,6 +17,8 @@
     let inited = false;
     const controlUrl = document.location.protocol + "//" +
                        document.location.host + "/control-api/";
+    const logsUrl = document.location.protocol + "//" +
+            document.location.host + "/logs";
 
     async function createRoom(roomId) {
       try {
@@ -86,6 +88,7 @@
       await init();
       inited = true;
       const jason = new Jason();
+      jason.init_log_sender(logsUrl, 5000);
 
       async function getDevices(audio_select, video_select, current_stream) {
         const current_audio = current_stream.getAudioTracks().pop().label
@@ -168,8 +171,8 @@
         }
       });
 
-      room.on_failed_local_stream(function (error) {
-        console.error(error);
+      room.on_failed_local_stream((e) => {
+        logError("Get local stream failed", e);
       });
 
       room.on_new_connection((connection) => {

--- a/jason/e2e-demo/js/index.js
+++ b/jason/e2e-demo/js/index.js
@@ -207,6 +207,7 @@ const controlDebugWindows = {
 window.onload = async function() {
   let rust = await import("../../pkg");
   let jason = new rust.Jason();
+  jason.init_log_sender();
   console.log(baseUrl);
 
   Object.values(controlDebugWindows).forEach(s => s());

--- a/jason/e2e-demo/js/index.js
+++ b/jason/e2e-demo/js/index.js
@@ -208,7 +208,7 @@ const controlDebugWindows = {
 window.onload = async function() {
   let rust = await import("../../pkg");
   let jason = new rust.Jason();
-  jason.init_log_sender(logslUrl, 5000);
+  jason.init_log_sender(logslUrl, 3000);
   console.log(baseUrl);
 
   Object.values(controlDebugWindows).forEach(s => s());

--- a/jason/e2e-demo/js/index.js
+++ b/jason/e2e-demo/js/index.js
@@ -1,4 +1,5 @@
 const controlUrl = "http://127.0.0.1:8000/control-api/";
+const logslUrl = "http://127.0.0.1:8080/logs";
 const baseUrl = 'ws://127.0.0.1:8080/ws/';
 
 let roomId = window.location.hash.replace("#", "");
@@ -207,7 +208,7 @@ const controlDebugWindows = {
 window.onload = async function() {
   let rust = await import("../../pkg");
   let jason = new rust.Jason();
-  jason.init_log_sender();
+  jason.init_log_sender(logslUrl, 5000);
   console.log(baseUrl);
 
   Object.values(controlDebugWindows).forEach(s => s());

--- a/jason/src/api/mod.rs
+++ b/jason/src/api/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     peer,
     rpc::{ClientDisconnect, RpcClient as _, WebSocketRpcClient},
     set_panic_hook,
-    utils::{JasonError, LogSender},
+    utils::{FetchHTTPClient, JasonError, LogSender},
 };
 
 #[doc(inline)]
@@ -51,7 +51,9 @@ impl Jason {
         url: &str,
         interval: i32,
     ) -> Result<(), JsValue> {
-        let sender = LogSender::new(url, interval).map_err(JasonError::from)?;
+        let client = Rc::new(FetchHTTPClient::new(url));
+        let sender =
+            LogSender::new(client, interval).map_err(JasonError::from)?;
         self.0.borrow_mut().logs_sender = Some(sender);
         Ok(())
     }

--- a/jason/src/api/mod.rs
+++ b/jason/src/api/mod.rs
@@ -76,7 +76,7 @@ impl Jason {
                 .drain(..)
                 .for_each(|room| room.close(reason.clone()));
             inner.borrow_mut().media_manager = Rc::default();
-            inner.logs_sender.take();
+            inner.borrow_mut().logs_sender.take();
         }));
 
         let room = Room::new(rpc, peer_repository);
@@ -94,10 +94,9 @@ impl Jason {
     /// streams etc.) respectively. All objects related to this [`Jason`] API
     /// object will be detached (you will still hold them, but unable to use).
     pub fn dispose(self) {
-        let inner = self.0.borrow_mut();
-        inner.rooms.drain(..).for_each(|room| {
+        self.0.borrow_mut().rooms.drain(..).for_each(|room| {
             room.close(ClientDisconnect::RoomClosed.into());
         });
-        inner.logs_sender.take();
+        self.0.borrow_mut().logs_sender.take();
     }
 }

--- a/jason/src/api/mod.rs
+++ b/jason/src/api/mod.rs
@@ -44,9 +44,14 @@ impl Jason {
         Self::default()
     }
 
-    pub fn init_log_sender(&self) -> Result<(), JsValue> {
-        let sender = LogSender::new("http://localhost:8080/logs", 5000)
-            .map_err(JasonError::from)?;
+    /// Instantiates new [`LogSender`] to send saved logs to the specified URL
+    /// at the specified interval.
+    pub fn init_log_sender(
+        &self,
+        url: &str,
+        interval: i32,
+    ) -> Result<(), JsValue> {
+        let sender = LogSender::new(url, interval).map_err(JasonError::from)?;
         self.0.borrow_mut().logs_sender = Some(sender);
         Ok(())
     }

--- a/jason/src/api/room.rs
+++ b/jason/src/api/room.rs
@@ -250,11 +250,12 @@ impl RoomHandle {
     ///
     /// Effectively returns `Result<(), JasonError>`.
     pub fn join(&self, token: String) -> Promise {
-        future_to_promise(
-            self.inner_join(token).map(|result| {
-                result.map(|_| JsValue::null()).map_err(Into::into)
-            }),
-        )
+        future_to_promise(self.inner_join(token).map(|result| {
+            result
+                .map(|_| JsValue::null())
+                .map_err(store_jason_error!(None))
+                .map_err(Into::into)
+        }))
     }
 
     /// Injects local media stream for all created and new [`PeerConnection`]s
@@ -518,8 +519,10 @@ impl InnerRoom {
                     .inject_local_stream(&injected_stream)
                     .await
                     .map_err(tracerr::map_from_and_wrap!(=> RoomError))
+                    .map_err(JasonError::from)
                 {
-                    error_callback.call(JasonError::from(err));
+                    store_jason_error!(&err, Some(peer.id()));
+                    error_callback.call(err);
                 }
             }
         });
@@ -553,10 +556,12 @@ impl EventHandler for InnerRoom {
                 self.enabled_video,
             )
             .map_err(tracerr::map_from_and_wrap!(=> RoomError))
+            .map_err(JasonError::from)
         {
             Ok(peer) => peer,
             Err(err) => {
-                JasonError::from(err).print();
+                store_jason_error!(&err, None);
+                err.print();
                 return;
             }
         };
@@ -596,7 +601,7 @@ impl EventHandler for InnerRoom {
                 };
                 Result::<_, Traced<RoomError>>::Ok(())
             }
-            .then(|result| {
+            .then(move |result| {
                 async move {
                     if let Err(err) = result {
                         let (err, trace) = err.into_parts();
@@ -604,6 +609,7 @@ impl EventHandler for InnerRoom {
                             RoomError::InvalidLocalStream(_)
                             | RoomError::CouldNotGetLocalMedia(_) => {
                                 let e = JasonError::from((err, trace));
+                                store_jason_error!(&e, Some(peer_id));
                                 e.print();
                                 error_callback.call(e);
                             }
@@ -623,8 +629,10 @@ impl EventHandler for InnerRoom {
                     .set_remote_answer(sdp_answer)
                     .await
                     .map_err(tracerr::map_from_and_wrap!(=> RoomError))
+                    .map_err(JasonError::from)
                 {
-                    JasonError::from(err).print()
+                    store_jason_error!(&err, Some(peer_id));
+                    err.print();
                 }
             });
         } else {
@@ -649,9 +657,11 @@ impl EventHandler for InnerRoom {
                         candidate.sdp_mid,
                     )
                     .await
-                    .map_err(tracerr::map_from_and_wrap!(=> RoomError));
+                    .map_err(tracerr::map_from_and_wrap!(=> RoomError))
+                    .map_err(JasonError::from);
                 if let Err(err) = add {
-                    JasonError::from(err).print();
+                    store_jason_error!(&err, Some(peer_id));
+                    err.print();
                 }
             });
         } else {
@@ -701,12 +711,13 @@ impl PeerEventHandler for InnerRoom {
         sender_id: PeerId,
         remote_stream: MediaStream,
     ) {
-        match self.connections.get(&sender_id) {
-            Some(conn) => conn.on_remote_stream(remote_stream.new_handle()),
-            None => {
-                JasonError::from(tracerr::new!(RoomError::UnknownRemotePeer))
-                    .print()
-            }
+        if let Some(conn) = self.connections.get(&sender_id) {
+            conn.on_remote_stream(remote_stream.new_handle());
+        } else {
+            let err =
+                JasonError::from(tracerr::new!(RoomError::UnknownRemotePeer));
+            store_jason_error!(&err, Some(sender_id));
+            err.print();
         }
     }
 

--- a/jason/src/media/manager.rs
+++ b/jason/src/media/manager.rs
@@ -263,8 +263,10 @@ impl MediaManagerHandle {
                             .into()
                     })
                     .map_err(tracerr::wrap!(=> MediaManagerError))
+                    .map_err(JasonError::from)
                     .map_err(|err| {
-                        store_error(JasonError::from(err), None).into()
+                        store_error(&err, None);
+                        err.into()
                     })
             }),
             Err(e) => future_to_promise(future::err(e)),
@@ -281,8 +283,10 @@ impl MediaManagerHandle {
                     .await
                     .map(|(stream, _)| stream.into())
                     .map_err(tracerr::wrap!(=> MediaManagerError))
+                    .map_err(JasonError::from)
                     .map_err(|err| {
-                        store_error(JasonError::from(err), None).into()
+                        store_error(&err, None);
+                        err.into()
                     })
             }),
             Err(err) => future_to_promise(future::err(err)),

--- a/jason/src/media/manager.rs
+++ b/jason/src/media/manager.rs
@@ -22,7 +22,7 @@ use web_sys::{
 
 use crate::{
     media::MediaStreamConstraints,
-    utils::{window, JasonError, JsCaused, JsError},
+    utils::{store_error, window, JasonError, JsCaused, JsError},
 };
 
 use super::InputDeviceInfo;
@@ -263,7 +263,9 @@ impl MediaManagerHandle {
                             .into()
                     })
                     .map_err(tracerr::wrap!(=> MediaManagerError))
-                    .map_err(|e| JasonError::from(e).into())
+                    .map_err(|err| {
+                        store_error(JasonError::from(err), None).into()
+                    })
             }),
             Err(e) => future_to_promise(future::err(e)),
         }
@@ -279,7 +281,9 @@ impl MediaManagerHandle {
                     .await
                     .map(|(stream, _)| stream.into())
                     .map_err(tracerr::wrap!(=> MediaManagerError))
-                    .map_err(|e| JasonError::from(e).into())
+                    .map_err(|err| {
+                        store_error(JasonError::from(err), None).into()
+                    })
             }),
             Err(err) => future_to_promise(future::err(err)),
         }

--- a/jason/src/peer/mod.rs
+++ b/jason/src/peer/mod.rs
@@ -15,7 +15,8 @@ use std::{cell::RefCell, collections::HashMap, convert::TryFrom, rc::Rc};
 use derive_more::{Display, From};
 use futures::{channel::mpsc, future};
 use medea_client_api_proto::{
-    Direction, IceConnectionState, IceServer, PeerId as Id, Track, TrackId,
+    Direction, IceConnectionState, IceServer, PeerId as Id, PeerId, Track,
+    TrackId,
 };
 use medea_macro::dispatchable;
 use tracerr::Traced;
@@ -237,6 +238,11 @@ impl PeerConnection {
             .map_err(tracerr::map_from_and_wrap!())?;
 
         Ok(peer)
+    }
+
+    /// Returns ID of [`PeerConnection`].
+    pub fn id(&self) -> PeerId {
+        self.id
     }
 
     /// Returns inner [`IceCandidate`]'s buffer len. Used in tests.

--- a/jason/src/utils/log_sender.rs
+++ b/jason/src/utils/log_sender.rs
@@ -2,6 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use derive_more as dm;
 use futures::future::LocalBoxFuture;
+use js_sys::JsString;
 use tracerr::Traced;
 use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_futures::{spawn_local, JsFuture};
@@ -10,24 +11,20 @@ use web_sys::{Request, RequestInit, RequestMode, Response};
 use super::{window, IntervalHandle, JasonError, JsCaused, JsError};
 
 /// Key in a local storage for storing logs.
-const JASON_LOG_KEY: &str = "jason_log";
-
-/// The key in local storage for body of request that could not be sent on the
-/// first try.
-const SEND_BODY_KEY: &str = "jason_send";
+pub const JASON_LOG_KEY: &str = "jason_log";
 
 #[wasm_bindgen(inline_js = "export const local_storage_get = (key) => { let \
                             value = window.localStorage.getItem(key); return \
                             value;}")]
 extern "C" {
-    fn local_storage_get(key: &str) -> Option<js_sys::JsString>;
+    fn local_storage_get(key: &str) -> Option<JsString>;
 }
 
 #[wasm_bindgen(inline_js = "export const local_storage_set = (key, value) => \
                             { window.localStorage.setItem(key, value); }")]
 extern "C" {
     #[allow(clippy::needless_pass_by_value)]
-    fn local_storage_set(key: &str, value: js_sys::JsString);
+    fn local_storage_set(key: &str, value: JsString);
 }
 
 #[wasm_bindgen(inline_js = "export const local_storage_remove = (key) => { \
@@ -47,22 +44,20 @@ pub enum Error {
     #[display(fmt = "cannot set callback for logs send: {}", _0)]
     SetIntervalHandler(JsError),
 
-    /// Occurs when a log request cannot be sent to the server.
+    /// Occurs when the log sending to the server fails.
     #[display(fmt = "cannot send logs")]
-    CannotSendLogs(JsError),
+    SendLogsFailed(#[js(caused)] HTTPClientError),
+}
 
-    /// Occurs when a remote server returns an error.
-    #[display(
-        fmt = "response error: [code = {}, message = {}]",
-        code,
-        message
-    )]
-    ServerFailed { code: u16, message: String },
+impl From<HTTPClientError> for Error {
+    fn from(err: HTTPClientError) -> Self {
+        Self::SendLogsFailed(err)
+    }
 }
 
 struct Inner {
-    /// Url of remote server for sending logs.
-    url: Rc<String>,
+    /// HTTP client for sending logs to remote server .
+    transport: Rc<dyn HTTPClient<Body = JsString>>,
     /// Handler of sending `logs` task. Task is dropped if you drop handler.
     logs_task: Option<LogsTaskHandler>,
 }
@@ -73,8 +68,11 @@ pub struct LogSender(Rc<RefCell<Inner>>);
 
 impl LogSender {
     /// Returns new instance of [`LogSender`] with given interval in
-    /// milliseconds for send logs to specified url.
-    pub fn new(url: &str, interval: i32) -> Result<Self, Traced<Error>> {
+    /// milliseconds for send logs by specified transport.
+    pub fn new(
+        transport: Rc<dyn HTTPClient<Body = JsString>>,
+        interval: i32,
+    ) -> Result<Self, Traced<Error>> {
         window()
             .local_storage()
             .map_err(JsError::from)
@@ -82,7 +80,7 @@ impl LogSender {
             .map_err(tracerr::wrap!())
             .and_then(|_| {
                 let inner = Rc::new(RefCell::new(Inner {
-                    url: Rc::new(url.to_string()),
+                    transport,
                     logs_task: None,
                 }));
                 let inner_rc = Rc::clone(&inner);
@@ -109,19 +107,13 @@ impl LogSender {
             })
     }
 
-    /// Stores given string value in local storage.
-    pub fn push_to_store(value: &str) {
+    /// Appends string to value stored in local storage with specified key.
+    pub fn push_to_store(value: JsString) {
         if let Ok(Some(_)) = window().local_storage() {
-            let pattern = js_sys::RegExp::new("\\n", "g");
-            let str_value = js_sys::JsString::from("\"")
-                .concat(&JsValue::from_str(value))
-                .concat(&JsValue::from_str("\""))
-                .replace_by_pattern(&pattern, "\\n");
             let logs = if let Some(log) = local_storage_get(JASON_LOG_KEY) {
-                log.concat(&JsValue::from_str(","))
-                    .concat(&str_value.into())
+                log.concat(&JsValue::from_str(",")).concat(&value.into())
             } else {
-                str_value
+                value
             };
             local_storage_set(JASON_LOG_KEY, logs);
         }
@@ -145,27 +137,22 @@ struct LogsTaskHandler {
 impl Inner {
     /// Runs async task for send logs from local storage to server.
     fn send_now(&self) {
-        let url = Rc::clone(&self.url);
+        let client = Rc::clone(&self.transport);
         spawn_local(async move {
             if let Err(e) = async move {
-                if let Some(body) = local_storage_get(SEND_BODY_KEY) {
-                    FetchHttpClient::post(&url, body)
-                        .await
-                        .map(|_| local_storage_remove(SEND_BODY_KEY))
-                        .map_err(tracerr::wrap!())?;
-                }
                 if let Some(logs) = local_storage_get(JASON_LOG_KEY) {
                     local_storage_remove(JASON_LOG_KEY);
-                    let body = js_sys::JsString::from("[")
-                        .concat(&logs.into())
+                    let body = JsString::from("[")
+                        .concat(&logs.clone().into())
                         .concat(&JsValue::from_str("]"));
-                    FetchHttpClient::post(&url, body.clone())
+                    client
+                        .send(body)
                         .await
                         .map_err(|e| {
-                            local_storage_set(SEND_BODY_KEY, body);
+                            LogSender::push_to_store(logs);
                             e
                         })
-                        .map_err(tracerr::wrap!())?;
+                        .map_err(tracerr::map_from_and_wrap!())?;
                 }
                 Ok::<_, Traced<Error>>(())
             }
@@ -178,30 +165,65 @@ impl Inner {
     }
 }
 
-#[cfg_attr(feature = "mockable", mockall::automock)]
-trait HttpClient {
-    /// Sends given body as a `text/plain` POST request to the specified URL.
-    fn post(
-        url: &str,
-        body: js_sys::JsString,
-    ) -> LocalBoxFuture<'static, Result<(), Traced<Error>>>;
+/// Errors that may occur in [`HTT`].
+#[derive(Debug, dm::Display, JsCaused)]
+pub enum HTTPClientError {
+    /// Occurs when a request cannot be sent to the server.
+    #[display(fmt = "cannot send request")]
+    InvalidRequest(JsError),
+
+    /// Occurs when a remote server returns an error.
+    #[display(
+        fmt = "response error: [code = {}, message = {}]",
+        code,
+        message
+    )]
+    ResponseFailed { code: u16, message: String },
 }
 
-struct FetchHttpClient {}
+/// HTTP client that uses the browser fetch API to send requests.
+#[cfg_attr(feature = "mockable", mockall::automock(type Body=JsString;))]
+pub trait HTTPClient {
+    /// Type of request body.
+    type Body: AsRef<JsValue>;
 
-impl HttpClient for FetchHttpClient {
-    /// Sends given body as a `application/json` POST request
-    /// to the specified URL.
-    fn post(
-        url: &str,
-        body: js_sys::JsString,
-    ) -> LocalBoxFuture<'static, Result<(), Traced<Error>>> {
+    /// Sends given body to remote server.
+    fn send(
+        &self,
+        body: Self::Body,
+    ) -> LocalBoxFuture<'static, Result<(), Traced<HTTPClientError>>>;
+}
+
+/// HTTP client that uses the browser fetch API to send requests.
+pub struct FetchHTTPClient {
+    /// Endpoint of remote server for sending request.
+    url: String,
+}
+
+impl FetchHTTPClient {
+    /// Returns new instance of [`FetchHTTPClient`] with specified url of remote
+    /// server.
+    pub fn new(url: &str) -> Self {
+        Self {
+            url: url.to_owned(),
+        }
+    }
+}
+
+impl HTTPClient for FetchHTTPClient {
+    type Body = JsString;
+
+    /// Sends given body as a `application/json` POST request to remote server.
+    fn send(
+        &self,
+        body: Self::Body,
+    ) -> LocalBoxFuture<'static, Result<(), Traced<HTTPClientError>>> {
         let mut opts = RequestInit::new();
         opts.method("POST");
         opts.mode(RequestMode::Cors);
-        opts.body(Some(&body.into()));
+        opts.body(Some(body.as_ref()));
 
-        let request = Request::new_with_str_and_init(url, &opts).unwrap();
+        let request = Request::new_with_str_and_init(&self.url, &opts).unwrap();
         request
             .headers()
             .set("Content-Type", "application/json")
@@ -211,16 +233,18 @@ impl HttpClient for FetchHttpClient {
             JsFuture::from(window().fetch_with_request(&request))
                 .await
                 .map_err(JsError::from)
-                .map_err(Error::CannotSendLogs)
+                .map_err(HTTPClientError::InvalidRequest)
                 .map_err(tracerr::wrap!())
                 .and_then(|resp_value| {
                     assert!(resp_value.is_instance_of::<Response>());
                     let resp: Response = resp_value.dyn_into().unwrap();
                     if !resp.ok() {
-                        return Err(tracerr::new!(Error::ServerFailed {
-                            code: resp.status(),
-                            message: resp.status_text(),
-                        }));
+                        return Err(tracerr::new!(
+                            HTTPClientError::ResponseFailed {
+                                code: resp.status(),
+                                message: resp.status_text(),
+                            }
+                        ));
                     }
                     Ok(())
                 })

--- a/jason/src/utils/logs_sender.rs
+++ b/jason/src/utils/logs_sender.rs
@@ -1,0 +1,156 @@
+use std::rc::Rc;
+
+use derive_more as dm;
+use tracerr::Traced;
+use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen_futures::{spawn_local, JsFuture};
+use web_sys::{Request, RequestInit, RequestMode, Response};
+
+use super::{window, IntervalHandle, JasonError, JsCaused, JsError};
+use wasm_bindgen::__rt::core::cell::RefCell;
+
+/// Errors that may occur in [`LogSender`].
+#[derive(Debug, dm::Display, JsCaused)]
+pub enum Error {
+    /// Occurs when a local storage unavailable.
+    #[display(fmt = "local storage unavailable: {}", _0)]
+    NotAccessLocalStorage(JsError),
+
+    /// Occurs when a handler cannot be set to send `logs`.
+    #[display(fmt = "cannot set callback for logs send: {}", _0)]
+    SetIntervalHandler(JsError),
+
+    #[display(fmt = "cannot send logs")]
+    CannotSendLogs(JsError),
+
+    #[display(
+        fmt = "response error: [code = {}, message = {}]",
+        code,
+        message
+    )]
+    ServerFailed { code: u16, message: String },
+}
+
+struct Inner {
+    url: String,
+    /// Handler of sending `logs` task. Task is dropped if you drop handler.
+    logs_task: Option<LogsTaskHandler>,
+}
+
+pub struct LogSender(Rc<RefCell<Inner>>);
+
+impl LogSender {
+    /// Returns new instance of [`LogSender`] with given interval in
+    /// milliseconds for send logs to specified url.
+    pub fn new(url: &str, interval: i32) -> Result<Self, Traced<Error>> {
+        let inner = Rc::new(RefCell::new(Inner {
+            url: url.to_string(),
+            logs_task: None,
+        }));
+        let inner_rc = Rc::clone(&inner);
+        let do_send = Closure::wrap(Box::new(move || {
+            inner_rc.borrow().send_now();
+        }) as Box<dyn FnMut()>);
+
+        let interval_id = window()
+            .set_interval_with_callback_and_timeout_and_arguments_0(
+                do_send.as_ref().unchecked_ref(),
+                interval,
+            )
+            .map_err(JsError::from)
+            .map_err(Error::SetIntervalHandler)
+            .map_err(tracerr::wrap!())?;
+
+        inner.borrow_mut().logs_task = Some(LogsTaskHandler {
+            _closure: do_send,
+            _interval_handler: IntervalHandle(interval_id),
+        });
+
+        Ok(Self(inner))
+    }
+}
+
+impl Drop for LogSender {
+    /// Stops [`LogSender`] task.
+    fn drop(&mut self) {
+        self.0.borrow_mut().logs_task.take();
+    }
+}
+
+/// Handler for binding closure that repeatedly calls a closure with a fixed
+/// time delay between each call.
+struct LogsTaskHandler {
+    _closure: Closure<dyn FnMut()>,
+    _interval_handler: IntervalHandle,
+}
+
+impl Inner {
+    fn send_now(&self) {
+        let url = self.url.clone();
+        spawn_local(async move {
+            if let Err(e) = async move {
+                if let Some(store) = window()
+                    .local_storage()
+                    .map_err(JsError::from)
+                    .map_err(Error::NotAccessLocalStorage)
+                    .map_err(tracerr::wrap!())?
+                {
+                    if let Ok(Some(logs)) = store.get("send_log") {
+                        send(&url, &logs)
+                            .await
+                            .map(|_| store.delete("send_log").unwrap())
+                            .map_err(tracerr::wrap!())?;
+                    }
+                    if let Ok(Some(logs)) = store.get("jason_log") {
+                        store.delete("jason_log").unwrap();
+                        let json = format!("{{\"errors\":{}}}", logs);
+                        send(&url, &json)
+                            .await
+                            .map_err(|e| {
+                                store.set("send_log", &json).unwrap();
+                                e
+                            })
+                            .map_err(tracerr::wrap!())?;
+                    }
+                }
+                Ok::<_, Traced<Error>>(())
+            }
+            .await
+            {
+                JasonError::from(e).print();
+            }
+        })
+    }
+}
+
+pub async fn send(url: &str, body: &str) -> Result<(), Traced<Error>> {
+    let mut opts = RequestInit::new();
+    opts.method("POST");
+    opts.mode(RequestMode::Cors);
+    let js_value = JsValue::from_str(body);
+    opts.body(Some(&js_value));
+
+    let request = Request::new_with_str_and_init(url, &opts).unwrap();
+
+    request
+        .headers()
+        .set("Content-Type", "application/json")
+        .unwrap();
+
+    JsFuture::from(window().fetch_with_request(&request))
+        .await
+        .map_err(JsError::from)
+        .map_err(Error::CannotSendLogs)
+        .map_err(tracerr::wrap!())
+        .and_then(|resp_value| {
+            assert!(resp_value.is_instance_of::<Response>());
+            let resp: Response = resp_value.dyn_into().unwrap();
+            if !resp.ok() {
+                return Err(tracerr::new!(Error::ServerFailed {
+                    code: resp.status(),
+                    message: resp.status_text(),
+                }));
+            }
+            Ok(())
+        })
+}

--- a/jason/src/utils/logs_sender.rs
+++ b/jason/src/utils/logs_sender.rs
@@ -1,6 +1,7 @@
 use std::{cell::RefCell, rc::Rc};
 
 use derive_more as dm;
+use futures::future::LocalBoxFuture;
 use tracerr::Traced;
 use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_futures::{spawn_local, JsFuture};
@@ -11,8 +12,29 @@ use super::{window, IntervalHandle, JasonError, JsCaused, JsError};
 /// Key in a local storage for storing logs.
 const JASON_LOG_KEY: &str = "jason_log";
 
-/// The key in local storage for logs that could not be sent on the first try.
-const SEND_LOG_KEY: &str = "jason_send";
+/// The key in local storage for body of request that could not be sent on the
+/// first try.
+const SEND_BODY_KEY: &str = "jason_send";
+
+#[wasm_bindgen(inline_js = "export const local_storage_get = (key) => { let \
+                            value = window.localStorage.getItem(key); return \
+                            value;}")]
+extern "C" {
+    fn local_storage_get(key: &str) -> Option<js_sys::JsString>;
+}
+
+#[wasm_bindgen(inline_js = "export const local_storage_set = (key, value) => \
+                            { window.localStorage.setItem(key, value); }")]
+extern "C" {
+    #[allow(clippy::needless_pass_by_value)]
+    fn local_storage_set(key: &str, value: js_sys::JsString);
+}
+
+#[wasm_bindgen(inline_js = "export const local_storage_remove = (key) => { \
+                            window.localStorage.removeItem(key); }")]
+extern "C" {
+    fn local_storage_remove(key: &str);
+}
 
 /// Errors that may occur in [`LogSender`].
 #[derive(Debug, dm::Display, JsCaused)]
@@ -53,43 +75,55 @@ impl LogSender {
     /// Returns new instance of [`LogSender`] with given interval in
     /// milliseconds for send logs to specified url.
     pub fn new(url: &str, interval: i32) -> Result<Self, Traced<Error>> {
-        let inner = Rc::new(RefCell::new(Inner {
-            url: Rc::new(url.to_string()),
-            logs_task: None,
-        }));
-        let inner_rc = Rc::clone(&inner);
-        let do_send = Closure::wrap(Box::new(move || {
-            inner_rc.borrow().send_now();
-        }) as Box<dyn Fn()>);
-
-        let interval_id = window()
-            .set_interval_with_callback_and_timeout_and_arguments_0(
-                do_send.as_ref().unchecked_ref(),
-                interval,
-            )
+        window()
+            .local_storage()
             .map_err(JsError::from)
-            .map_err(Error::SetIntervalHandler)
-            .map_err(tracerr::wrap!())?;
+            .map_err(Error::NotAccessLocalStorage)
+            .map_err(tracerr::wrap!())
+            .and_then(|_| {
+                let inner = Rc::new(RefCell::new(Inner {
+                    url: Rc::new(url.to_string()),
+                    logs_task: None,
+                }));
+                let inner_rc = Rc::clone(&inner);
+                let do_send = Closure::wrap(Box::new(move || {
+                    inner_rc.borrow().send_now();
+                })
+                    as Box<dyn Fn()>);
 
-        inner.borrow_mut().logs_task = Some(LogsTaskHandler {
-            _closure: do_send,
-            _interval_handler: IntervalHandle(interval_id),
-        });
+                let interval_id = window()
+                    .set_interval_with_callback_and_timeout_and_arguments_0(
+                        do_send.as_ref().unchecked_ref(),
+                        interval,
+                    )
+                    .map_err(JsError::from)
+                    .map_err(Error::SetIntervalHandler)
+                    .map_err(tracerr::wrap!())?;
 
-        Ok(Self(inner))
+                inner.borrow_mut().logs_task = Some(LogsTaskHandler {
+                    _closure: do_send,
+                    _interval_handler: IntervalHandle(interval_id),
+                });
+
+                Ok(Self(inner))
+            })
     }
 
     /// Stores given string value in local storage.
     pub fn push_to_store(value: &str) {
-        if let Ok(Some(store)) = window().local_storage() {
-            let mut log = store
-                .get("jason_log")
-                .unwrap()
-                .map_or("[".to_string(), |s: String| {
-                    format!("{},", s.trim_end_matches(']'))
-                });
-            log = format!("{}{}]", log, value);
-            store.set("jason_log", &log).unwrap();
+        if let Ok(Some(_)) = window().local_storage() {
+            let pattern = js_sys::RegExp::new("\\n", "g");
+            let str_value = js_sys::JsString::from("\"")
+                .concat(&JsValue::from_str(value))
+                .concat(&JsValue::from_str("\""))
+                .replace_by_pattern(&pattern, "\\n");
+            let logs = if let Some(log) = local_storage_get(JASON_LOG_KEY) {
+                log.concat(&JsValue::from_str(","))
+                    .concat(&str_value.into())
+            } else {
+                str_value
+            };
+            local_storage_set(JASON_LOG_KEY, logs);
         }
     }
 }
@@ -114,28 +148,24 @@ impl Inner {
         let url = Rc::clone(&self.url);
         spawn_local(async move {
             if let Err(e) = async move {
-                if let Some(store) = window()
-                    .local_storage()
-                    .map_err(JsError::from)
-                    .map_err(Error::NotAccessLocalStorage)
-                    .map_err(tracerr::wrap!())?
-                {
-                    if let Ok(Some(logs)) = store.get(SEND_LOG_KEY) {
-                        send(&url, &logs)
-                            .await
-                            .map(|_| store.delete(SEND_LOG_KEY).unwrap())
-                            .map_err(tracerr::wrap!())?;
-                    }
-                    if let Ok(Some(logs)) = store.get(JASON_LOG_KEY) {
-                        store.delete(JASON_LOG_KEY).unwrap();
-                        send(&url, &logs)
-                            .await
-                            .map_err(|e| {
-                                store.set(SEND_LOG_KEY, &logs).unwrap();
-                                e
-                            })
-                            .map_err(tracerr::wrap!())?;
-                    }
+                if let Some(body) = local_storage_get(SEND_BODY_KEY) {
+                    FetchHttpClient::post(&url, body)
+                        .await
+                        .map(|_| local_storage_remove(SEND_BODY_KEY))
+                        .map_err(tracerr::wrap!())?;
+                }
+                if let Some(logs) = local_storage_get(JASON_LOG_KEY) {
+                    local_storage_remove(JASON_LOG_KEY);
+                    let body = js_sys::JsString::from("[")
+                        .concat(&logs.into())
+                        .concat(&JsValue::from_str("]"));
+                    FetchHttpClient::post(&url, body.clone())
+                        .await
+                        .map_err(|e| {
+                            local_storage_set(SEND_BODY_KEY, body);
+                            e
+                        })
+                        .map_err(tracerr::wrap!())?;
                 }
                 Ok::<_, Traced<Error>>(())
             }
@@ -148,30 +178,52 @@ impl Inner {
     }
 }
 
-/// Sends given body as a `text/plain` POST request to the specified URL.
-pub async fn send(url: &str, body: &str) -> Result<(), Traced<Error>> {
-    let mut opts = RequestInit::new();
-    opts.method("POST");
-    opts.mode(RequestMode::Cors);
-    let js_value = JsValue::from_str(body);
-    opts.body(Some(&js_value));
+#[cfg_attr(feature = "mockable", mockall::automock)]
+trait HttpClient {
+    /// Sends given body as a `text/plain` POST request to the specified URL.
+    fn post(
+        url: &str,
+        body: js_sys::JsString,
+    ) -> LocalBoxFuture<'static, Result<(), Traced<Error>>>;
+}
 
-    let request = Request::new_with_str_and_init(url, &opts).unwrap();
+struct FetchHttpClient {}
 
-    JsFuture::from(window().fetch_with_request(&request))
-        .await
-        .map_err(JsError::from)
-        .map_err(Error::CannotSendLogs)
-        .map_err(tracerr::wrap!())
-        .and_then(|resp_value| {
-            assert!(resp_value.is_instance_of::<Response>());
-            let resp: Response = resp_value.dyn_into().unwrap();
-            if !resp.ok() {
-                return Err(tracerr::new!(Error::ServerFailed {
-                    code: resp.status(),
-                    message: resp.status_text(),
-                }));
-            }
-            Ok(())
+impl HttpClient for FetchHttpClient {
+    /// Sends given body as a `application/json` POST request
+    /// to the specified URL.
+    fn post(
+        url: &str,
+        body: js_sys::JsString,
+    ) -> LocalBoxFuture<'static, Result<(), Traced<Error>>> {
+        let mut opts = RequestInit::new();
+        opts.method("POST");
+        opts.mode(RequestMode::Cors);
+        opts.body(Some(&body.into()));
+
+        let request = Request::new_with_str_and_init(url, &opts).unwrap();
+        request
+            .headers()
+            .set("Content-Type", "application/json")
+            .unwrap();
+
+        Box::pin(async move {
+            JsFuture::from(window().fetch_with_request(&request))
+                .await
+                .map_err(JsError::from)
+                .map_err(Error::CannotSendLogs)
+                .map_err(tracerr::wrap!())
+                .and_then(|resp_value| {
+                    assert!(resp_value.is_instance_of::<Response>());
+                    let resp: Response = resp_value.dyn_into().unwrap();
+                    if !resp.ok() {
+                        return Err(tracerr::new!(Error::ServerFailed {
+                            code: resp.status(),
+                            message: resp.status_text(),
+                        }));
+                    }
+                    Ok(())
+                })
         })
+    }
 }

--- a/jason/src/utils/mod.rs
+++ b/jason/src/utils/mod.rs
@@ -20,7 +20,9 @@ pub use self::{
     callback::{Callback, Callback2},
     errors::{HandlerDetachedError, JasonError, JsCaused, JsError},
     event_listener::{EventListener, EventListenerBindError},
-    log_sender::{FetchHTTPClient, HTTPClient, LogSender, JASON_LOG_KEY},
+    log_sender::{
+        FetchHTTPClient, HTTPClient, HTTPClientError, LogSender, JASON_LOG_KEY,
+    },
 };
 
 /// Returns [`Window`] object.

--- a/jason/tests/utils/log_sender.rs
+++ b/jason/tests/utils/log_sender.rs
@@ -8,7 +8,9 @@ use mockall::predicate;
 use wasm_bindgen_test::*;
 
 use crate::resolve_after;
-use medea_jason::utils::{window, LogSender, MockHTTPClient, JASON_LOG_KEY};
+use medea_jason::utils::{
+    window, HTTPClientError, LogSender, MockHTTPClient, JASON_LOG_KEY,
+};
 
 wasm_bindgen_test_configure!(run_in_browser);
 
@@ -44,4 +46,32 @@ async fn send_log_if_exists_in_store() {
     let value = JsString::from(log);
     LogSender::push_to_store(value);
     resolve_after(120).await.unwrap();
+}
+
+#[wasm_bindgen_test]
+async fn back_log_to_store_if_send_fail() {
+    let store = window().local_storage().unwrap().unwrap();
+    store.clear().unwrap();
+    let mut client = MockHTTPClient::new();
+    let log = "test_log";
+    let expected_body = format!("[{}]", log);
+    client
+        .expect_send()
+        .withf(move |s| {
+            assert_eq!(*s, expected_body);
+            let local = window().local_storage().unwrap().unwrap();
+            assert_eq!(local.get_item(JASON_LOG_KEY).unwrap(), None);
+            true
+        })
+        .return_once(|_| {
+            future::ready(Err(tracerr::new!(HTTPClientError::ResponseFailed {
+                code: 400,
+                message: "error".to_string(),
+            })))
+            .boxed()
+        });
+    let sender = LogSender::new(Rc::new(client), 100);
+    LogSender::push_to_store(JsString::from(log));
+    resolve_after(150).await.unwrap();
+    assert_eq!(store.get_item(JASON_LOG_KEY).unwrap().unwrap(), "test_log");
 }

--- a/jason/tests/utils/log_sender.rs
+++ b/jason/tests/utils/log_sender.rs
@@ -1,0 +1,47 @@
+//! Tests for [`medea_jason::utils::LogSender`].
+
+use std::rc::Rc;
+
+use futures::{future, FutureExt as _};
+use js_sys::JsString;
+use mockall::predicate;
+use wasm_bindgen_test::*;
+
+use crate::resolve_after;
+use medea_jason::utils::{window, LogSender, MockHTTPClient, JASON_LOG_KEY};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn push_to_store() {
+    let store = window().local_storage().unwrap().unwrap();
+    store.clear().unwrap();
+    store.set_item(JASON_LOG_KEY, "exists_value").unwrap();
+    let value = JsString::from("new_value");
+    LogSender::push_to_store(value);
+    let store = window().local_storage().unwrap().unwrap();
+    assert_eq!(
+        &store.get_item(JASON_LOG_KEY).unwrap().unwrap(),
+        "exists_value,new_value"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn send_log_if_exists_in_store() {
+    let store = window().local_storage().unwrap().unwrap();
+    store.clear().unwrap();
+    let mut client = MockHTTPClient::new();
+    let log = "test_log";
+    let expected_body = format!("[{}]", log);
+    client
+        .expect_send()
+        .withf(move |s| {
+            assert_eq!(*s, expected_body);
+            true
+        })
+        .return_once(|_| future::pending().boxed());
+    let sender = LogSender::new(Rc::new(client), 100);
+    let value = JsString::from(log);
+    LogSender::push_to_store(value);
+    resolve_after(120).await.unwrap();
+}

--- a/jason/tests/utils/mod.rs
+++ b/jason/tests/utils/mod.rs
@@ -1,0 +1,1 @@
+mod log_sender;

--- a/jason/tests/web.rs
+++ b/jason/tests/web.rs
@@ -78,6 +78,7 @@ mod api;
 mod media;
 mod peer;
 mod rpc;
+mod utils;
 
 use futures::{channel::oneshot, future::Either};
 use js_sys::Promise;

--- a/src/api/client/server.rs
+++ b/src/api/client/server.rs
@@ -30,6 +30,7 @@ use crate::{
     shutdown::ShutdownGracefully,
     signalling::room_repo::RoomRepository,
 };
+use actix_web::web::Json;
 
 /// Parameters of new WebSocket connection creation HTTP request.
 #[derive(Debug, Deserialize)]
@@ -84,8 +85,8 @@ fn ws_index(
 
 /// Handles POST `/logs` HTTP requests and logs body.
 #[allow(clippy::needless_pass_by_value)]
-fn log_index(body: String) -> HttpResponse {
-    info!("client logs: {}", body);
+fn log_index(body: Json<Vec<String>>) -> HttpResponse {
+    info!("client logs: {:?}", body.into_inner());
 
     HttpResponse::Ok().body("Ok")
 }

--- a/src/api/client/server.rs
+++ b/src/api/client/server.rs
@@ -86,7 +86,9 @@ fn ws_index(
 /// Handles POST `/logs` HTTP requests and logs body.
 #[allow(clippy::needless_pass_by_value)]
 fn log_index(body: Json<Vec<String>>) -> HttpResponse {
-    info!("client logs: {:?}", body.into_inner());
+    for log in body.into_inner() {
+        info!("client log: {}", log);
+    }
 
     HttpResponse::Ok().body("Ok")
 }


### PR DESCRIPTION
## Synopsis

Need implements send errors, debug info or any other string info to media server.

## Solution

Save the information that you want to send to the server in the local storage of the browser.
Run Log Sender in the background, which periodically checks the local storage and, if there is information to send, sends it a POST request to the server.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [ ] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `Draft: ` prefix is removed
    - [ ] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
