### PR TITLE
Refactor turn::* package to more idiomatic async/.await (#77)

### DIFF
--- a/jason/demo/index.html
+++ b/jason/demo/index.html
@@ -17,6 +17,7 @@
     let inited = false;
     const controlUrl = document.location.protocol + "//" +
                        document.location.host + "/control-api/";
+    var isForceRelay = false;
 
     async function createRoom(roomId) {
       try {
@@ -40,7 +41,7 @@
         publish: {
           kind: 'WebRtcPublishEndpoint',
           p2p: 'Always',
-          force_relay: false,
+          force_relay: isForceRelay,
         },
       };
 
@@ -52,6 +53,7 @@
         pipeline["play-" + memberId] = {
           kind: 'WebRtcPlayEndpoint',
           src: 'local://' + roomId + '/' + memberId + "/publish",
+          force_relay: isForceRelay,
         };
       }
 
@@ -73,6 +75,7 @@
           data: {
             kind: 'WebRtcPlayEndpoint',
             src: 'local://' + roomId + '/' + memberId + '/publish',
+            force_relay: controlRoom.data.element.pipeline[id].pipeline.publish.force_relay,
           }
         })
       }
@@ -154,6 +157,7 @@
       let audioSelect = document.getElementById('connect__select-device_audio');
       let videoSelect = document.getElementById('connect__select-device_video');
       let localVideo = document.getElementById('local-video__video');
+      let isForceRelayCheckbox = document.getElementById("is_force_relay");
 
       let joinCallerButton = document.getElementById('join__join');
       let usernameInput = document.getElementById('join__username');
@@ -265,6 +269,9 @@
           let connectBtnsDiv = document.getElementById("join__join");
           connectBtnsDiv.style.display = 'none';
           controlBtns.style.display = 'block';
+
+          isForceRelay = isForceRelayCheckbox.checked;
+          isForceRelayCheckbox.disabled = true;
 
           try {
             let username = usernameInput.value;
@@ -388,6 +395,11 @@
         <div>
           <span>Connection state: </span>
           <span id="connection-state__state" class="badge badge-danger">Closed</span>
+        </div>
+
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" type="checkbox" id="is_force_relay" value="true">
+          <label class="form-check-label" for="is_force_relay">Force TURN relay</label>
         </div>
 
       </div>

--- a/jason/e2e-demo/js/index.js
+++ b/jason/e2e-demo/js/index.js
@@ -49,7 +49,8 @@ async function createMember(roomId, memberId) {
     memberIds.push(memberId);
     pipeline["play-" + memberId] = {
       kind: 'WebRtcPlayEndpoint',
-      src: 'local://' + roomId + '/' + memberId + "/publish"
+      src: 'local://' + roomId + '/' + memberId + "/publish",
+      force_relay: false
     }
   }
 
@@ -73,7 +74,8 @@ async function createMember(roomId, memberId) {
         url: controlUrl + roomId + "/" + id + '/' + 'play-' + memberId,
         data: {
           kind: 'WebRtcPlayEndpoint',
-          src: 'local://' + roomId + '/' + memberId + '/publish'
+          src: 'local://' + roomId + '/' + memberId + '/publish',
+          force_relay: false
         }
       })
     }

--- a/src/signalling/participants.rs
+++ b/src/signalling/participants.rs
@@ -243,22 +243,29 @@ impl ParticipantService {
                     .map(move |_| Ok(member)),
             ))
         } else {
+            let turn_service = self.turn_service.clone();
+            let cloned_member_id = member_id.clone();
+            let room_id = self.room_id.clone();
             Box::new(
-                wrap_future(self.turn_service.create(
-                    member_id.clone(),
-                    self.room_id.clone(),
-                    UnreachablePolicy::ReturnErr,
-                ))
-                .map(
-                    |result, room: &mut Room, _| match result {
+                wrap_future(async move {
+                    turn_service
+                        .create(
+                            cloned_member_id,
+                            room_id,
+                            UnreachablePolicy::ReturnErr,
+                        )
+                        .await
+                })
+                .map(move |result, room: &mut Room, _| {
+                    match result {
                         Ok(ice_user) => {
                             room.members.insert_connection(member_id, conn);
                             member.replace_ice_user(ice_user);
                             Ok(member)
                         }
                         Err(e) => Err(ParticipantServiceErr::from(e)),
-                    },
-                ),
+                    }
+                }),
             )
         }
     }
@@ -329,7 +336,9 @@ impl ParticipantService {
             None => future::ok(()).boxed_local(),
             Some(member) => {
                 if let Some(ice_user) = member.take_ice_user() {
-                    self.turn_service.delete(vec![ice_user])
+                    let turn_service = self.turn_service.clone();
+                    async move { turn_service.delete(&[ice_user]).await }
+                        .boxed_local()
                 } else {
                     future::ok(()).boxed_local()
                 }
@@ -363,16 +372,18 @@ impl ParticipantService {
             ));
 
         // deleting all IceUsers
-        let ice_users = self
+        let ice_users: Vec<_> = self
             .members
             .values()
             .filter_map(Member::take_ice_user)
             .collect();
 
-        let delete_ice_users = self
-            .turn_service
-            .delete(ice_users)
-            .map_err(|err| error!("Error removing IceUsers {:?}", err));
+        let turn_service = self.turn_service.clone();
+        let delete_ice_users = async move {
+            if let Err(e) = turn_service.delete(ice_users.as_slice()).await {
+                error!("Error removing IceUsers {:?}", e)
+            };
+        };
 
         future::join(close_rpc_connections, delete_ice_users)
             .map(|_| ())
@@ -402,12 +413,12 @@ impl ParticipantService {
 
         if let Some(member) = self.members.remove(member_id) {
             if let Some(ice_user) = member.take_ice_user() {
-                wrap_future::<_, Room>(
-                    self.turn_service
-                        .delete(vec![ice_user])
-                        .map_err(|e| error!("Error removing IceUser {:?}", e))
-                        .map(|_| ()),
-                )
+                let turn_service = self.turn_service.clone();
+                wrap_future::<_, Room>(async move {
+                    if let Err(e) = turn_service.delete(&[ice_user]).await {
+                        error!("Error removing IceUser {:?}", e)
+                    }
+                })
                 .spawn(ctx);
             }
         }

--- a/src/turn/service.rs
+++ b/src/turn/service.rs
@@ -97,7 +97,8 @@ impl Service {
 
 #[async_trait::async_trait]
 impl TurnAuthService for Service {
-    /// Sends [`CreateIceUser`] to [`Service`].
+    /// Generates [`IceUser`] with saved Turn address, provided [`MemberId`] and
+    /// random password. Inserts created [`IceUser`] into [`TurnDatabase`].
     async fn create(
         &self,
         member_id: MemberId,
@@ -120,7 +121,7 @@ impl TurnAuthService for Service {
         }
     }
 
-    /// Sends `DeleteRoom` to [`Service`].
+    /// Deletes provided [`IceUser`]s from [`TurnDatabase`].
     async fn delete(&self, users: &[IceUser]) -> Result<(), TurnServiceErr> {
         // leave only non static users
         let users: Vec<_> = users.iter().filter(|u| !u.is_static()).collect();

--- a/src/turn/service.rs
+++ b/src/turn/service.rs
@@ -123,7 +123,7 @@ impl TurnAuthService for Service {
     /// Sends `DeleteRoom` to [`Service`].
     async fn delete(&self, users: &[IceUser]) -> Result<(), TurnServiceErr> {
         // leave only non static users
-        let users: Vec<_>= users.iter().filter(|u| !u.is_static()).collect();
+        let users: Vec<_> = users.iter().filter(|u| !u.is_static()).collect();
 
         if users.is_empty() {
             Ok(())
@@ -190,10 +190,7 @@ pub mod test {
             ))
         }
 
-        async fn delete(
-            &self,
-            _: &[IceUser],
-        ) -> Result<(), TurnServiceErr> {
+        async fn delete(&self, _: &[IceUser]) -> Result<(), TurnServiceErr> {
             Ok(())
         }
     }

--- a/src/turn/service.rs
+++ b/src/turn/service.rs
@@ -5,15 +5,8 @@
 
 use std::{fmt, sync::Arc};
 
-use actix::{
-    fut, Actor, ActorFuture, Addr, Context, Handler, MailboxError, Message,
-    ResponseFuture, WrapFuture as _,
-};
 use derive_more::{Display, From};
 use failure::Fail;
-use futures::future::{
-    self, FutureExt as _, LocalBoxFuture, TryFutureExt as _,
-};
 use rand::{distributions::Alphanumeric, Rng};
 use redis::ConnectionInfo;
 
@@ -26,82 +19,11 @@ use crate::{
 
 static TURN_PASS_LEN: usize = 16;
 
-/// Manages Turn server credentials.
-pub trait TurnAuthService: fmt::Debug + Send + Sync {
-    /// Generates and registers Turn credentials.
-    fn create(
-        &self,
-        member_id: MemberId,
-        room_id: RoomId,
-        policy: UnreachablePolicy,
-    ) -> LocalBoxFuture<'static, Result<IceUser, TurnServiceErr>>;
-
-    /// Deletes batch of [`IceUser`]s.
-    fn delete(
-        &self,
-        users: Vec<IceUser>,
-    ) -> LocalBoxFuture<'static, Result<(), TurnServiceErr>>;
-}
-
-impl TurnAuthService for Addr<Service> {
-    /// Sends [`CreateIceUser`] to [`Service`].
-    fn create(
-        &self,
-        member_id: MemberId,
-        room_id: RoomId,
-        policy: UnreachablePolicy,
-    ) -> LocalBoxFuture<'static, Result<IceUser, TurnServiceErr>> {
-        let creating = self.send(CreateIceUser {
-            member_id,
-            room_id,
-            policy,
-        });
-        async {
-            match creating.await {
-                Ok(Ok(ice)) => Ok(ice),
-                Ok(Err(err)) => Err(err),
-                Err(err) => Err(err.into()),
-            }
-        }
-        .boxed_local()
-    }
-
-    /// Sends `DeleteRoom` to [`Service`].
-    fn delete(
-        &self,
-        users: Vec<IceUser>,
-    ) -> LocalBoxFuture<'static, Result<(), TurnServiceErr>> {
-        // leave only non static users
-        let users: Vec<IceUser> =
-            users.into_iter().filter(|u| !u.is_static()).collect();
-
-        if users.is_empty() {
-            future::ok(()).boxed_local()
-        } else {
-            let deleting = self.send(DeleteIceUsers(users));
-            async {
-                match deleting.await {
-                    Ok(Err(err)) => Err(err),
-                    Err(err) => Err(err.into()),
-                    _ => Ok(()),
-                }
-            }
-            .boxed_local()
-        }
-    }
-}
-
-/// Ergonomic type alias for using [`ActorFuture`] for [`AuthService`].
-type ActFuture<T> = Box<dyn ActorFuture<Actor = Service, Output = T>>;
-
 /// Error which can happen in [`TurnAuthService`].
 #[derive(Display, Debug, Fail, From)]
 pub enum TurnServiceErr {
     #[display(fmt = "Error accessing TurnAuthRepo: {}", _0)]
     TurnAuthRepoErr(TurnDatabaseErr),
-
-    #[display(fmt = "Mailbox error when accessing TurnAuthRepo: {}", _0)]
-    MailboxErr(MailboxError),
 
     #[display(fmt = "Timeout exceeded while trying to insert/delete IceUser")]
     #[from(ignore)]
@@ -118,6 +40,21 @@ pub enum UnreachablePolicy {
     /// Static member credentials will be returned if request to db fails cause
     /// it is unreachable.
     ReturnStatic,
+}
+
+/// Manages Turn server credentials.
+#[async_trait::async_trait]
+pub trait TurnAuthService: fmt::Debug + Send + Sync {
+    /// Generates and registers Turn credentials.
+    async fn create(
+        &self,
+        member_id: MemberId,
+        room_id: RoomId,
+        policy: UnreachablePolicy,
+    ) -> Result<IceUser, TurnServiceErr>;
+
+    /// Deletes batch of [`IceUser`]s.
+    async fn delete(&self, users: &[IceUser]) -> Result<(), TurnServiceErr>;
 }
 
 /// [`TurnAuthService`] implementation backed by Redis database.
@@ -137,9 +74,63 @@ struct Service {
 
     /// Turn server static user password.
     turn_password: String,
+}
 
-    /// Lazy static [`ICEUser`].
-    static_user: Option<IceUser>,
+impl Service {
+    /// Generates random alphanumeric string of specified length.
+    fn generate_pass(n: usize) -> String {
+        rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(n)
+            .collect()
+    }
+
+    /// Returns [`ICEUser`] with static credentials.
+    fn static_user(&self) -> IceUser {
+        IceUser::new(
+            self.turn_address.clone(),
+            self.turn_username.clone(),
+            self.turn_password.clone(),
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl TurnAuthService for Service {
+    /// Sends [`CreateIceUser`] to [`Service`].
+    async fn create(
+        &self,
+        member_id: MemberId,
+        room_id: RoomId,
+        policy: UnreachablePolicy,
+    ) -> Result<IceUser, TurnServiceErr> {
+        let ice_user = IceUser::build(
+            self.turn_address.clone(),
+            &room_id,
+            &member_id.0,
+            Self::generate_pass(TURN_PASS_LEN),
+        );
+
+        match self.turn_db.insert(&ice_user).await {
+            Ok(_) => Ok(ice_user),
+            Err(err) => match policy {
+                UnreachablePolicy::ReturnErr => Err(err.into()),
+                UnreachablePolicy::ReturnStatic => Ok(self.static_user()),
+            },
+        }
+    }
+
+    /// Sends `DeleteRoom` to [`Service`].
+    async fn delete(&self, users: &[IceUser]) -> Result<(), TurnServiceErr> {
+        // leave only non static users
+        let users: Vec<_>= users.iter().filter(|u| !u.is_static()).collect();
+
+        if users.is_empty() {
+            Ok(())
+        } else {
+            Ok(self.turn_db.remove(users.as_slice()).await?)
+        }
+    }
 }
 
 /// Create new instance [`TurnAuthService`].
@@ -168,95 +159,9 @@ pub fn new_turn_auth_service<'a>(
         turn_address: cf.addr(),
         turn_username: cf.user.clone(),
         turn_password: cf.pass.clone(),
-        static_user: None,
     };
 
-    Ok(Arc::new(turn_service.start()))
-}
-
-impl Service {
-    /// Generates random alphanumeric string of specified length.
-    fn generate_pass(n: usize) -> String {
-        rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(n)
-            .collect()
-    }
-
-    /// Returns [`ICEUser`] with static credentials.
-    fn static_user(&mut self) -> IceUser {
-        if self.static_user.is_none() {
-            self.static_user.replace(IceUser::new(
-                self.turn_address.clone(),
-                self.turn_username.clone(),
-                self.turn_password.clone(),
-            ));
-        };
-
-        self.static_user.clone().unwrap()
-    }
-}
-
-impl Actor for Service {
-    type Context = Context<Self>;
-}
-
-/// Creates credentials on Turn server for specified member.
-#[derive(Debug, Message)]
-#[rtype(result = "Result<IceUser, TurnServiceErr>")]
-struct CreateIceUser {
-    pub member_id: MemberId,
-    pub room_id: RoomId,
-    pub policy: UnreachablePolicy,
-}
-
-impl Handler<CreateIceUser> for Service {
-    type Result = ActFuture<Result<IceUser, TurnServiceErr>>;
-
-    /// Generates [`IceUser`] with saved Turn address, provided [`MemberId`] and
-    /// random password. Inserts created [`IceUser`] into [`TurnDatabase`].
-    fn handle(
-        &mut self,
-        msg: CreateIceUser,
-        _ctx: &mut Self::Context,
-    ) -> Self::Result {
-        let ice_user = IceUser::build(
-            self.turn_address.clone(),
-            &msg.room_id,
-            &msg.member_id.to_string(),
-            Self::generate_pass(TURN_PASS_LEN),
-        );
-
-        Box::new(self.turn_db.insert(&ice_user).into_actor(self).then(
-            move |result, this, _| match result {
-                Ok(_) => fut::ok(ice_user),
-                Err(err) => match msg.policy {
-                    UnreachablePolicy::ReturnErr => fut::err(err.into()),
-                    UnreachablePolicy::ReturnStatic => {
-                        fut::ok(this.static_user())
-                    }
-                },
-            },
-        ))
-    }
-}
-
-/// Deletes all users from given room in redis.
-#[derive(Debug, Message)]
-#[rtype(result = "Result<(), TurnServiceErr>")]
-struct DeleteIceUsers(Vec<IceUser>);
-
-impl Handler<DeleteIceUsers> for Service {
-    type Result = ResponseFuture<Result<(), TurnServiceErr>>;
-
-    /// Deletes all users with provided [`RoomId`]
-    fn handle(
-        &mut self,
-        msg: DeleteIceUsers,
-        _ctx: &mut Self::Context,
-    ) -> Self::Result {
-        self.turn_db.remove(&msg.0).err_into().boxed_local()
-    }
+    Ok(Arc::new(turn_service))
 }
 
 #[cfg(test)]
@@ -270,28 +175,26 @@ pub mod test {
     #[derive(Debug)]
     struct TurnAuthServiceMock {}
 
+    #[async_trait::async_trait]
     impl TurnAuthService for TurnAuthServiceMock {
-        fn create(
+        async fn create(
             &self,
             _: MemberId,
             _: RoomId,
             _: UnreachablePolicy,
-        ) -> LocalBoxFuture<'static, Result<IceUser, TurnServiceErr>> {
-            async {
-                Ok(IceUser::new(
-                    "5.5.5.5:1234".parse().unwrap(),
-                    "username".into(),
-                    "password".into(),
-                ))
-            }
-            .boxed_local()
+        ) -> Result<IceUser, TurnServiceErr> {
+            Ok(IceUser::new(
+                "5.5.5.5:1234".parse().unwrap(),
+                "username".into(),
+                "password".into(),
+            ))
         }
 
-        fn delete(
+        async fn delete(
             &self,
-            _: Vec<IceUser>,
-        ) -> LocalBoxFuture<'static, Result<(), TurnServiceErr>> {
-            future::ok(()).boxed_local()
+            _: &[IceUser],
+        ) -> Result<(), TurnServiceErr> {
+            Ok(())
         }
     }
 


### PR DESCRIPTION
Part of #77  

## Synopsis

#80 was more of an raw upgrade, now its time to refactor to use `async fn` as much as possible. Starting with everything in medea::turn::*.

## Solution

- [x] `async fn` in `turn::TurnDatabase::*`
- [x] `async_trait` for `TurnAuthService`
- [x] drop `impl Actor` for `turn::Service`
- [x] [`Vec<T> => &[T]`](https://github.com/instrumentisto/medea/pull/80#discussion_r370123883)




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `WIP: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `WIP: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
