### PR TITLE
Refactor PeersService to more idiomatic async/.await (#27)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
  "pin-project",
  "rand 0.7.3",
  "regex",
- "serde 1.0.112",
+ "serde 1.0.114",
  "serde_json",
  "serde_urlencoded",
  "sha1",
@@ -148,7 +148,7 @@ dependencies = [
  "http",
  "log",
  "regex",
- "serde 1.0.112",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -288,7 +288,7 @@ dependencies = [
  "net2",
  "pin-project",
  "regex",
- "serde 1.0.112",
+ "serde 1.0.114",
  "serde_json",
  "serde_urlencoded",
  "time",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 dependencies = [
  "gimli",
 ]
@@ -349,9 +349,9 @@ checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+checksum = "c259a748ac706ba73d609b73fc13469e128337f9a6b2fb3cc82d100f8dd8d511"
 dependencies = [
  "memchr",
 ]
@@ -462,7 +462,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "rand 0.7.3",
- "serde 1.0.112",
+ "serde 1.0.114",
  "serde_json",
  "serde_urlencoded",
 ]
@@ -636,7 +636,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.112",
+ "serde 1.0.114",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -791,7 +791,7 @@ dependencies = [
  "config",
  "crossbeam-queue",
  "num_cpus",
- "serde 1.0.112",
+ "serde 1.0.114",
  "tokio",
 ]
 
@@ -807,7 +807,7 @@ dependencies = [
  "futures 0.3.5",
  "log",
  "redis 0.15.1",
- "serde 1.0.112",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -1236,7 +1236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c57351e2c81b7a03e82a6c8f4198b309c158f6d67c4adb707af6af7d91465a"
 dependencies = [
  "humantime",
- "serde 1.0.112",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -1480,7 +1480,7 @@ dependencies = [
  "redis 0.15.1",
  "redis 0.15.2-alpha.0",
  "rust-crypto",
- "serde 1.0.112",
+ "serde 1.0.114",
  "serde_json",
  "serde_yaml",
  "serial_test",
@@ -1505,7 +1505,7 @@ version = "0.2.0-dev"
 dependencies = [
  "derive_more",
  "medea-macro",
- "serde 1.0.112",
+ "serde 1.0.114",
  "serde_json",
  "serde_with",
 ]
@@ -1523,7 +1523,7 @@ dependencies = [
  "humantime-serde",
  "medea-control-api-proto",
  "protobuf",
- "serde 1.0.112",
+ "serde 1.0.114",
  "slog",
  "slog-async",
  "slog-envlogger",
@@ -1574,7 +1574,7 @@ dependencies = [
  "medea-reactive",
  "mockall",
  "predicates-tree",
- "serde 1.0.112",
+ "serde 1.0.114",
  "serde_json",
  "tracerr",
  "wasm-bindgen",
@@ -1974,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e86d370532557ae7573551a1ec8235a0f8d6cb276c7c9e6aa490b511c447485"
+checksum = "3e2ccb6b8f7e175f2d2401e7a5988b0630000164d221262c4fe50ae729513202"
 
 [[package]]
 name = "quick-error"
@@ -2282,9 +2282,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
 ]
@@ -2304,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2321,7 +2321,7 @@ checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.112",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -2341,7 +2341,7 @@ checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
  "dtoa",
  "itoa",
- "serde 1.0.112",
+ "serde 1.0.114",
  "url",
 ]
 
@@ -2351,7 +2351,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d3d595d64120bbbc70b7f6d5ae63298b62a3d9f373ec2f56acf5365ca8a444"
 dependencies = [
- "serde 1.0.112",
+ "serde 1.0.114",
  "serde_with_macros",
 ]
 
@@ -2374,7 +2374,7 @@ checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
 dependencies = [
  "dtoa",
  "linked-hash-map 0.5.3",
- "serde 1.0.112",
+ "serde 1.0.114",
  "yaml-rust",
 ]
 
@@ -2462,7 +2462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
 dependencies = [
  "chrono",
- "serde 1.0.112",
+ "serde 1.0.114",
  "serde_json",
  "slog",
 ]
@@ -2552,9 +2552,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
+checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2713,7 +2713,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
- "serde 1.0.112",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -3135,7 +3135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
 dependencies = [
  "cfg-if",
- "serde 1.0.112",
+ "serde 1.0.114",
  "serde_json",
  "wasm-bindgen-macro",
 ]

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -8,7 +8,7 @@ pub mod track;
 pub use self::{
     ice_user::{IceUser, IceUsername},
     peer::{
-        Peer, PeerError, PeerStateMachine, Stable, WaitLocalHaveRemote,
+        New, Peer, PeerError, PeerStateMachine, WaitLocalHaveRemote,
         WaitLocalSdp, WaitRemoteSdp,
     },
     track::MediaTrack,

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -8,7 +8,7 @@ pub mod track;
 pub use self::{
     ice_user::{IceUser, IceUsername},
     peer::{
-        New, Peer, PeerError, PeerStateMachine, WaitLocalHaveRemote,
+        Peer, PeerError, PeerStateMachine, Stable, WaitLocalHaveRemote,
         WaitLocalSdp, WaitRemoteSdp,
     },
     track::MediaTrack,

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -205,7 +205,7 @@ pub struct Context {
     /// Weak references to the [`Endpoint`]s related to this [`Peer`].
     endpoints: Vec<WeakEndpoint>,
 
-    /// If `true` then this [`Peer`] is known to client (`Event::PeerCreated`
+    /// If `true` then this [`Peer`] is known to client (`Event::PeerCreated`]
     /// for this [`Peer`] was sent to the client).
     is_known_to_remote: bool,
 
@@ -371,7 +371,7 @@ impl<T> Peer<T> {
     /// Resets `pending_changes` buffer.
     ///
     /// Should be called when renegotiation was finished.
-    fn renegotiation_finished(&mut self) {
+    fn negotiation_finished(&mut self) {
         self.context.is_known_to_remote = true;
         self.context.pending_track_updates.clear();
     }
@@ -424,7 +424,7 @@ impl Peer<WaitLocalSdp> {
 impl Peer<WaitRemoteSdp> {
     /// Sets remote description and transitions [`Peer`] to [`Stable`] state.
     pub fn set_remote_sdp(mut self, sdp_answer: &str) -> Peer<Stable> {
-        self.renegotiation_finished();
+        self.negotiation_finished();
         self.context.sdp_answer = Some(sdp_answer.to_string());
 
         Peer {
@@ -437,7 +437,7 @@ impl Peer<WaitRemoteSdp> {
 impl Peer<WaitLocalHaveRemote> {
     /// Sets local description and transitions [`Peer`] to [`Stable`] state.
     pub fn set_local_sdp(mut self, sdp_answer: String) -> Peer<Stable> {
-        self.renegotiation_finished();
+        self.negotiation_finished();
         self.context.sdp_answer = Some(sdp_answer);
 
         Peer {
@@ -557,25 +557,6 @@ impl Peer<Stable> {
             );
         }
         Ok(mids)
-    }
-
-    /// Changes [`Peer`] state to [`WaitLocalSdp`] and discards previously saved
-    /// [SDP] Offer and Answer.
-    ///
-    /// Sets [`Context::is_renegotiate`] to `true`.
-    ///
-    /// Resets [`Context::sdp_offer`] and [`Context::sdp_answer`].
-    ///
-    /// [SDP]: https://tools.ietf.org/html/rfc4317
-    pub fn start_renegotiation(self) -> Peer<WaitLocalSdp> {
-        let mut context = self.context;
-        context.sdp_answer = None;
-        context.sdp_offer = None;
-
-        Peer {
-            context,
-            state: WaitLocalSdp {},
-        }
     }
 
     /// Adds [`Track`] to [`Peer`] send tracks list.

--- a/src/signalling/elements/endpoints/mod.rs
+++ b/src/signalling/elements/endpoints/mod.rs
@@ -17,6 +17,7 @@ use crate::signalling::elements::endpoints::webrtc::{
 ///
 /// [Medea]: https://github.com/instrumentisto/medea
 #[enum_delegate(pub fn is_force_relayed(&self) -> bool)]
+#[enum_delegate(pub fn has_traffic_callback(&self) -> bool)]
 #[derive(Clone, Debug, From)]
 pub enum Endpoint {
     WebRtcPublishEndpoint(webrtc::WebRtcPublishEndpoint),
@@ -24,18 +25,6 @@ pub enum Endpoint {
 }
 
 impl Endpoint {
-    /// Returns `true` if `on_start` or `on_stop` callback is set.
-    #[allow(clippy::unused_self)]
-    #[inline]
-    pub fn has_traffic_callback(&self) -> bool {
-        match self {
-            Endpoint::WebRtcPlayEndpoint(play) => play.has_traffic_callback(),
-            Endpoint::WebRtcPublishEndpoint(publish) => {
-                publish.has_traffic_callback()
-            }
-        }
-    }
-
     /// Returns [`Weak`] reference to this [`Endpoint`].
     pub fn downgrade(&self) -> WeakEndpoint {
         match self {

--- a/src/signalling/elements/endpoints/mod.rs
+++ b/src/signalling/elements/endpoints/mod.rs
@@ -28,10 +28,12 @@ impl Endpoint {
     #[allow(clippy::unused_self)]
     #[inline]
     pub fn has_traffic_callback(&self) -> bool {
-        // TODO: Delegate this call to
-        //       `WebRtcPublishEndpoint`/`WebRtcPlayEndpoint`.
-
-        false
+        match self {
+            Endpoint::WebRtcPlayEndpoint(play) => play.has_traffic_callback(),
+            Endpoint::WebRtcPublishEndpoint(publish) => {
+                publish.has_traffic_callback()
+            }
+        }
     }
 
     /// Returns [`Weak`] reference to this [`Endpoint`].

--- a/src/signalling/elements/endpoints/webrtc/play_endpoint.rs
+++ b/src/signalling/elements/endpoints/webrtc/play_endpoint.rs
@@ -171,11 +171,9 @@ impl WebRtcPlayEndpoint {
     /// Returns `true` if `on_start` or `on_stop` callback is set.
     #[allow(clippy::unused_self)]
     pub fn has_traffic_callback(&self) -> bool {
-        // TODO: should be implement in the on-start-on-stop branch
-        #[cfg(test)]
-        return true;
-        #[cfg(not(test))]
-        return false;
+        // TODO: Must depend on on_start/on_stop endpoint callbacks, when those
+        //       will be added (#91).
+        true
     }
 
     /// Downgrades [`WebRtcPlayEndpoint`] to [`WeakWebRtcPlayEndpoint`] weak

--- a/src/signalling/elements/endpoints/webrtc/play_endpoint.rs
+++ b/src/signalling/elements/endpoints/webrtc/play_endpoint.rs
@@ -168,6 +168,16 @@ impl WebRtcPlayEndpoint {
         self.0.borrow().is_force_relayed
     }
 
+    /// Returns `true` if `on_start` or `on_stop` callback is set.
+    #[allow(clippy::unused_self)]
+    pub fn has_traffic_callback(&self) -> bool {
+        // TODO: should be implement in the on-start-on-stop branch
+        #[cfg(test)]
+        return true;
+        #[cfg(not(test))]
+        return false;
+    }
+
     /// Downgrades [`WebRtcPlayEndpoint`] to [`WeakWebRtcPlayEndpoint`] weak
     /// pointer.
     pub fn downgrade(&self) -> WeakWebRtcPlayEndpoint {

--- a/src/signalling/elements/endpoints/webrtc/play_endpoint.rs
+++ b/src/signalling/elements/endpoints/webrtc/play_endpoint.rs
@@ -170,6 +170,7 @@ impl WebRtcPlayEndpoint {
 
     /// Returns `true` if `on_start` or `on_stop` callback is set.
     #[allow(clippy::unused_self)]
+    #[inline]
     pub fn has_traffic_callback(&self) -> bool {
         // TODO: Must depend on on_start/on_stop endpoint callbacks, when those
         //       will be added (#91).

--- a/src/signalling/elements/endpoints/webrtc/publish_endpoint.rs
+++ b/src/signalling/elements/endpoints/webrtc/publish_endpoint.rs
@@ -215,6 +215,7 @@ impl WebRtcPublishEndpoint {
 
     /// Returns `true` if `on_start` or `on_stop` callback is set.
     #[allow(clippy::unused_self)]
+    #[inline]
     pub fn has_traffic_callback(&self) -> bool {
         // TODO: Must depend on on_start/on_stop endpoint callbacks, when those
         //       will be added (#91).

--- a/src/signalling/elements/endpoints/webrtc/publish_endpoint.rs
+++ b/src/signalling/elements/endpoints/webrtc/publish_endpoint.rs
@@ -216,11 +216,9 @@ impl WebRtcPublishEndpoint {
     /// Returns `true` if `on_start` or `on_stop` callback is set.
     #[allow(clippy::unused_self)]
     pub fn has_traffic_callback(&self) -> bool {
-        // TODO: should be implement in the on-start-on-stop branch
-        #[cfg(test)]
-        return true;
-        #[cfg(not(test))]
-        return false;
+        // TODO: Must depend on on_start/on_stop endpoint callbacks, when those
+        //       will be added (#91).
+        true
     }
 
     /// Returns [`AudioSettings`] of this [`WebRtcPublishEndpoint`].

--- a/src/signalling/elements/endpoints/webrtc/publish_endpoint.rs
+++ b/src/signalling/elements/endpoints/webrtc/publish_endpoint.rs
@@ -213,6 +213,16 @@ impl WebRtcPublishEndpoint {
         self.0.borrow().is_force_relayed
     }
 
+    /// Returns `true` if `on_start` or `on_stop` callback is set.
+    #[allow(clippy::unused_self)]
+    pub fn has_traffic_callback(&self) -> bool {
+        // TODO: should be implement in the on-start-on-stop branch
+        #[cfg(test)]
+        return true;
+        #[cfg(not(test))]
+        return false;
+    }
+
     /// Returns [`AudioSettings`] of this [`WebRtcPublishEndpoint`].
     pub fn audio_settings(&self) -> AudioSettings {
         self.0.borrow().audio_settings

--- a/src/signalling/peers/metrics.rs
+++ b/src/signalling/peers/metrics.rs
@@ -104,7 +104,7 @@ impl PeersMetricsService {
     ///
     /// Sends [`PeersMetricsEvent::NoTrafficFlow`] message if it determines that
     /// some track is not flowing.
-    pub fn check_peers(&mut self) {
+    pub fn check_peers(&self) {
         for peer in self
             .peers
             .values()
@@ -202,7 +202,7 @@ impl PeersMetricsService {
     /// [`PeersMetricsEvent::WrongTrafficFlowing`] or [`PeersMetricsEvent::
     /// TrackTrafficStarted`] to the [`Room`] if some
     /// [`MediaType`]/[`Direction`] was stopped.
-    pub fn add_stats(&mut self, peer_id: PeerId, stats: Vec<RtcStat>) {
+    pub fn add_stats(&self, peer_id: PeerId, stats: Vec<RtcStat>) {
         if let Some(peer) = self.peers.get(&peer_id) {
             let mut peer_ref = peer.borrow_mut();
 
@@ -1033,7 +1033,7 @@ mod tests {
         /// Generates [`RtcStats`] and adds them to inner
         /// [`PeersMetricsService`] for `PeerId(1)`.
         pub fn add_stats(
-            &mut self,
+            &self,
             send_audio: u32,
             send_video: u32,
             recv_audio: u32,
@@ -1136,7 +1136,7 @@ mod tests {
         }
 
         /// Calls [`PeerMetricsService::check_peers`].
-        pub fn check_peers(&mut self) {
+        pub fn check_peers(&self) {
             self.metrics.check_peers();
         }
 

--- a/src/signalling/peers/metrics.rs
+++ b/src/signalling/peers/metrics.rs
@@ -409,7 +409,7 @@ pub enum PeersMetricsEvent {
 ///
 /// This spec is compared with [`Peer`]s actual stats, to calculate difference
 /// between expected and actual [`Peer`] state.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 struct PeerTracks {
     /// Count of the [`MediaTrack`]s with the [`Direction::Publish`] and
     /// [`MediaType::Audio`].
@@ -859,6 +859,30 @@ mod tests {
     };
 
     use super::PeersMetricsService;
+
+    impl PeersMetricsService {
+        /// Returns `true` if `Peer` with a provided [`PeerId`] isn't registered
+        /// in the [`PeersMetricsService`].
+        pub fn is_peer_registered(&self, peer_id: PeerId) -> bool {
+            self.peers.contains_key(&peer_id)
+        }
+
+        /// Returns count of the `MediaTrack` which are registerd in the
+        /// [`PeersMetricsService`].
+        pub fn peer_tracks_count(&self, peer_id: PeerId) -> usize {
+            if let Some(peer) = self.peers.get(&peer_id) {
+                let peer_tracks = peer.borrow().tracks_spec;
+                let mut tracks_count = 0;
+                tracks_count += peer_tracks.audio_recv;
+                tracks_count += peer_tracks.video_recv;
+                tracks_count += peer_tracks.audio_send;
+                tracks_count += peer_tracks.video_send;
+                tracks_count
+            } else {
+                0
+            }
+        }
+    }
 
     /// Returns [`RtcOutboundRtpStreamStats`] with a provided number of
     /// `packets_sent` and [`RtcOutboundRtpStreamMediaType`] based on

--- a/src/signalling/peers/metrics.rs
+++ b/src/signalling/peers/metrics.rs
@@ -861,13 +861,14 @@ mod tests {
     use super::PeersMetricsService;
 
     impl PeersMetricsService {
-        /// Returns `true` if `Peer` with a provided [`PeerId`] isn't registered
-        /// in the [`PeersMetricsService`].
+        /// Returns `true` if [`Peer`] with a provided [`PeerId`] isn't
+        /// registered in the [`PeersMetricsService`].
+        #[inline]
         pub fn is_peer_registered(&self, peer_id: PeerId) -> bool {
             self.peers.contains_key(&peer_id)
         }
 
-        /// Returns count of the `MediaTrack` which are registerd in the
+        /// Returns count of the [`MediaTrack`] which are registered in the
         /// [`PeersMetricsService`].
         pub fn peer_tracks_count(&self, peer_id: PeerId) -> usize {
             if let Some(peer) = self.peers.get(&peer_id) {

--- a/src/signalling/peers/mod.rs
+++ b/src/signalling/peers/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     api::control::{MemberId, RoomId},
     conf,
     log::prelude::*,
-    media::{Peer, PeerError, PeerStateMachine, Stable},
+    media::{New, Peer, PeerStateMachine},
     signalling::{
         elements::endpoints::{
             webrtc::{WebRtcPlayEndpoint, WebRtcPublishEndpoint},
@@ -41,6 +41,431 @@ pub use self::{
         PeerConnectionStateEventsHandler, PeerTrafficWatcher,
     },
 };
+
+#[derive(Debug)]
+pub struct PeersService {
+    /// [`RoomId`] of the [`Room`] which owns this [`PeerRepository`].
+    room_id: RoomId,
+
+    /// [`TurnAuthService`] that [`IceUser`]s for the [`PeerConnection`]s from
+    /// this [`PeerRepository`] will be created with.
+    turn_service: Arc<dyn TurnAuthService>,
+
+    /// [`Peer`]s of [`Member`]s in this [`Room`].
+    ///
+    /// [`Member`]: crate::signalling::elements::member::Member
+    /// [`Room`]: crate::signalling::Room
+    peers: PeerRepository,
+
+    /// Count of [`Peer`]s in this [`Room`].
+    ///
+    /// [`Room`]: crate::signalling::room::Room
+    peers_count: Counter<PeerId>,
+
+    /// Count of [`MediaTrack`]s in this [`Room`].
+    ///
+    /// [`MediaTrack`]: crate::media::track::MediaTrack
+    /// [`Room`]: crate::signalling::room::Room
+    tracks_count: Counter<TrackId>,
+
+    /// [`PeerTrafficWatcher`] which analyzes [`Peer`]s traffic metrics.
+    peers_traffic_watcher: Arc<dyn PeerTrafficWatcher>,
+
+    /// Service which responsible for this [`Room`]'s [`RtcStat`]s processing.
+    peer_metrics_service: RefCell<PeersMetricsService>,
+
+    /// Duration, after which [`Peer`]s stats will be considered as stale.
+    /// Passed to [`PeersMetricsService`] when registering new [`Peer`]s.
+    peer_stats_ttl: Duration,
+}
+
+/// Simple ID counter.
+#[derive(Default, Debug, Clone, Display)]
+pub struct Counter<T: Copy> {
+    count: Cell<T>,
+}
+
+impl<T: Incrementable + Copy> Counter<T> {
+    /// Returns id and increase counter.
+    pub fn next_id(&self) -> T {
+        let id = self.count.get();
+        self.count.set(id.incr());
+        id
+    }
+}
+
+/// Result of the [`PeersService::get_or_create_peers`] function.
+#[derive(Debug, Clone, Copy)]
+enum GetOrCreatePeersResult {
+    /// Requested [`Peer`] pair was created.
+    Created(PeerId, PeerId),
+
+    /// Requested [`Peer`] pair already existed.
+    AlreadyExisted(PeerId, PeerId),
+}
+
+impl PeersService {
+    /// Returns new [`PeerRepository`] for a [`Room`] with the provided
+    /// [`RoomId`].
+    pub fn new(
+        room_id: RoomId,
+        turn_service: Arc<dyn TurnAuthService>,
+        peers_traffic_watcher: Arc<dyn PeerTrafficWatcher>,
+        media_conf: &conf::Media,
+    ) -> Rc<Self> {
+        Rc::new(Self {
+            room_id: room_id.clone(),
+            turn_service,
+            peers: PeerRepository::new(),
+            peers_count: Counter::default(),
+            tracks_count: Counter::default(),
+            peers_traffic_watcher: peers_traffic_watcher.clone(),
+            peer_metrics_service: RefCell::new(PeersMetricsService::new(
+                room_id,
+                peers_traffic_watcher,
+            )),
+            peer_stats_ttl: media_conf.max_lag,
+        })
+    }
+
+    /// Store [`Peer`] in [`Room`].
+    ///
+    /// [`Room`]: crate::signalling::Room
+    #[inline]
+    pub fn add_peer<S: Into<PeerStateMachine>>(&self, peer: S) {
+        self.peers.add_peer(peer)
+    }
+
+    /// Applies a function to the [`PeerStateMachine`] reference with provided
+    /// [`PeerId`] (if any found).
+    ///
+    /// # Errors
+    ///
+    /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
+    /// exist in [`PeerRepository`].
+    #[inline]
+    pub fn map_peer_by_id<T>(
+        &self,
+        peer_id: PeerId,
+        f: impl FnOnce(&PeerStateMachine) -> T,
+    ) -> Result<T, RoomError> {
+        self.peers.map_peer_by_id(peer_id, f)
+    }
+
+    /// Creates interconnected [`Peer`]s for provided endpoints and saves them
+    /// in [`PeerService`].
+    ///
+    /// Returns [`PeerId`]s of the created [`Peer`]s.
+    fn create_peers(
+        &self,
+        src: &WebRtcPublishEndpoint,
+        sink: &WebRtcPlayEndpoint,
+    ) -> (PeerId, PeerId) {
+        let src_member_id = src.owner().id();
+        let sink_member_id = sink.owner().id();
+
+        let src_peer_id = self.peers_count.next_id();
+        let sink_peer_id = self.peers_count.next_id();
+
+        debug!(
+            "Created peers:[{}, {}] between {} and {}.",
+            src_peer_id, sink_peer_id, src_member_id, sink_member_id,
+        );
+
+        let mut src_peer = Peer::new(
+            src_peer_id,
+            src_member_id.clone(),
+            sink_peer_id,
+            sink_member_id.clone(),
+            src.is_force_relayed(),
+        );
+        src_peer.add_endpoint(&src.clone().into());
+
+        let mut sink_peer = Peer::new(
+            sink_peer_id,
+            sink_member_id,
+            src_peer_id,
+            src_member_id,
+            sink.is_force_relayed(),
+        );
+        sink_peer.add_endpoint(&sink.clone().into());
+
+        src_peer.add_publisher(&src, &mut sink_peer, &self.tracks_count);
+
+        let src_peer = PeerStateMachine::from(src_peer);
+        let sink_peer = PeerStateMachine::from(sink_peer);
+
+        self.peer_metrics_service
+            .borrow_mut()
+            .register_peer(&src_peer, self.peer_stats_ttl);
+        self.peer_metrics_service
+            .borrow_mut()
+            .register_peer(&sink_peer, self.peer_stats_ttl);
+
+        self.add_peer(src_peer);
+        self.add_peer(sink_peer);
+
+        (src_peer_id, sink_peer_id)
+    }
+
+    /// Lookups [`Peer`] of [`Member`] with ID `member_id` which
+    /// connected with `partner_member_id`.
+    ///
+    /// Returns `Some(peer_id, partner_peer_id)` if [`Peer`] has been found,
+    /// otherwise returns `None`.
+    #[inline]
+    pub fn get_peers_between_members(
+        &self,
+        member_id: &MemberId,
+        partner_member_id: &MemberId,
+    ) -> Option<(PeerId, PeerId)> {
+        self.peers
+            .get_peers_between_members(member_id, partner_member_id)
+    }
+
+    /// Returns owned [`Peer`] by its ID.
+    ///
+    /// # Errors
+    ///
+    /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
+    /// exist in [`PeerRepository`].
+    pub fn take_inner_peer<S>(
+        &self,
+        peer_id: PeerId,
+    ) -> Result<Peer<S>, RoomError>
+    where
+        Peer<S>: TryFrom<PeerStateMachine>,
+        <Peer<S> as TryFrom<PeerStateMachine>>::Error: Into<RoomError>,
+    {
+        self.peers.take_inner_peer(peer_id)
+    }
+
+    /// Deletes [`PeerStateMachine`]s from this [`PeerRepository`] and send
+    /// [`Event::PeersRemoved`] to [`Member`]s.
+    ///
+    /// __Note:__ this also deletes partner peers.
+    ///
+    /// [`Event::PeersRemoved`]: medea_client_api_proto::Event::PeersRemoved
+    pub fn remove_peers<'a, Peers: IntoIterator<Item = &'a PeerId>>(
+        &self,
+        member_id: &MemberId,
+        peer_ids: Peers,
+    ) -> HashMap<MemberId, Vec<PeerStateMachine>> {
+        let mut removed_peers = HashMap::new();
+        for peer_id in peer_ids {
+            if let Some(peer) = self.peers.remove(*peer_id) {
+                let partner_peer_id = peer.partner_peer_id();
+                let partner_member_id = peer.partner_member_id();
+                if let Some(partner_peer) = self.peers.remove(partner_peer_id) {
+                    removed_peers
+                        .entry(partner_member_id)
+                        .or_insert_with(Vec::new)
+                        .push(partner_peer);
+                }
+                removed_peers
+                    .entry(member_id.clone())
+                    .or_insert_with(Vec::new)
+                    .push(peer);
+            }
+        }
+
+        let peers_to_unregister: Vec<_> = removed_peers
+            .values()
+            .flat_map(|peer| peer.iter().map(PeerStateMachine::id))
+            .collect();
+        self.peer_metrics_service
+            .borrow_mut()
+            .unregister_peers(&peers_to_unregister);
+        self.peers_traffic_watcher
+            .unregister_peers(self.room_id.clone(), peers_to_unregister);
+
+        removed_peers
+    }
+
+    /// Returns already created [`Peer`] pair's [`PeerId`]s as
+    /// [`CreatedOrGottenPeer::Gotten`] variant.
+    ///
+    /// Returns newly created [`Peer`] pair's [`PeerId`]s as
+    /// [`CreatedOrGottenPeer::Created`] variant.
+    async fn get_or_create_peers(
+        &self,
+        src: WebRtcPublishEndpoint,
+        sink: WebRtcPlayEndpoint,
+    ) -> Result<GetOrCreatePeersResult, RoomError> {
+        if let Some((first_peer_id, second_peer_id)) = self
+            .get_peers_between_members(&src.owner().id(), &sink.owner().id())
+        {
+            Ok(GetOrCreatePeersResult::AlreadyExisted(
+                first_peer_id,
+                second_peer_id,
+            ))
+        } else {
+            let (src_peer_id, sink_peer_id) = self.create_peers(&src, &sink);
+
+            self.peer_post_construct(src_peer_id, &src.into()).await?;
+            self.peer_post_construct(sink_peer_id, &sink.into()).await?;
+
+            Ok(GetOrCreatePeersResult::Created(src_peer_id, sink_peer_id))
+        }
+    }
+
+    /// Creates [`Peer`] for endpoints if [`Peer`] between endpoint's members
+    /// doesn't exist.
+    ///
+    /// Adds `send` track to source member's [`Peer`] and `recv` to
+    /// sink member's [`Peer`]. Registers TURN credentials for created
+    /// [`Peer`]s.
+    ///
+    /// Returns [`PeerId`]s of newly created [`Peer`] if it has been created.
+    ///
+    /// # Errors
+    ///
+    /// Errors if could not save [`IceUser`] in [`TurnAuthService`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if provided endpoints already have interconnected [`Peer`]s.
+    pub async fn connect_endpoints(
+        self: Rc<Self>,
+        src: WebRtcPublishEndpoint,
+        sink: WebRtcPlayEndpoint,
+    ) -> Result<Option<(PeerId, PeerId)>, RoomError> {
+        debug!(
+            "Connecting endpoints of Member [id = {}] with Member [id = {}]",
+            src.owner().id(),
+            sink.owner().id(),
+        );
+        match self.get_or_create_peers(src.clone(), sink.clone()).await? {
+            GetOrCreatePeersResult::Created(src_peer_id, sink_peer_id) => {
+                Ok(Some((src_peer_id, sink_peer_id)))
+            }
+            GetOrCreatePeersResult::AlreadyExisted(
+                src_peer_id,
+                sink_peer_id,
+            ) => {
+                if sink.peer_id().is_some()
+                    || src.peer_ids().contains(&src_peer_id)
+                {
+                    // already connected, so no-op
+                    Ok(None)
+                } else {
+                    let mut futs = Vec::new();
+                    // TODO: here we assume that peers are stable,
+                    //       which might not be the case, e.g. Control
+                    //       Service creates multiple endpoints in quick
+                    //       succession.
+                    let mut src_peer: Peer<New> =
+                        self.peers.take_inner_peer(src_peer_id).unwrap();
+                    let mut sink_peer: Peer<New> =
+                        self.peers.take_inner_peer(sink_peer_id).unwrap();
+
+                    src_peer.add_publisher(
+                        &src,
+                        &mut sink_peer,
+                        &self.tracks_count,
+                    );
+
+                    if src.has_traffic_callback() {
+                        futs.push(self.peers_traffic_watcher.register_peer(
+                            self.room_id.clone(),
+                            src_peer_id,
+                            src.is_force_relayed(),
+                        ));
+                    }
+                    if sink.has_traffic_callback() {
+                        futs.push(self.peers_traffic_watcher.register_peer(
+                            self.room_id.clone(),
+                            sink_peer_id,
+                            sink.is_force_relayed(),
+                        ));
+                    }
+
+                    sink_peer.add_endpoint(&sink.into());
+                    src_peer.add_endpoint(&src.into());
+
+                    let src_peer = PeerStateMachine::from(src_peer);
+                    let sink_peer = PeerStateMachine::from(sink_peer);
+
+                    self.peer_metrics_service
+                        .borrow_mut()
+                        .update_peer_tracks(&src_peer);
+                    self.peer_metrics_service
+                        .borrow_mut()
+                        .update_peer_tracks(&sink_peer);
+
+                    self.peers.add_peer(src_peer);
+                    self.peers.add_peer(sink_peer);
+
+                    future::try_join_all(futs)
+                        .await
+                        .map_err(RoomError::PeerTrafficWatcherMailbox)?;
+
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    /// Creates and sets [`IceUser`], registers [`Peer`] in
+    /// [`PeerTrafficWatcher`].
+    async fn peer_post_construct(
+        &self,
+        peer_id: PeerId,
+        endpoint: &Endpoint,
+    ) -> Result<(), RoomError> {
+        let has_traffic_callback = endpoint.has_traffic_callback();
+        let is_force_relayed = endpoint.is_force_relayed();
+
+        let ice_user = self
+            .turn_service
+            .create(self.room_id.clone(), peer_id, UnreachablePolicy::ReturnErr)
+            .await?;
+
+        let _ = self
+            .peers
+            .map_peer_by_id_mut(peer_id, move |p| p.set_ice_user(ice_user));
+
+        if has_traffic_callback {
+            self.peers_traffic_watcher
+                .register_peer(self.room_id.clone(), peer_id, is_force_relayed)
+                .await
+                .map_err(RoomError::PeerTrafficWatcherMailbox)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Removes all [`Peer`]s related to given [`Member`].
+    /// Note, that this function will also remove all partners [`Peer`]s.
+    ///
+    /// Returns [`HashMap`] with all removed [`Peer`]s:
+    /// key - [`Peer`]'s owner [`MemberId`],
+    /// value - removed [`Peer`]'s [`PeerId`].
+    // TODO: remove in #91.
+    #[inline]
+    pub fn remove_peers_related_to_member(
+        &self,
+        member_id: &MemberId,
+    ) -> HashMap<MemberId, Vec<PeerId>> {
+        self.peers.remove_peers_related_to_member(member_id)
+    }
+
+    /// Updates [`PeerTracks`] of the [`Peer`] with provided [`PeerId`] in the
+    /// [`PeerMetricsService`].
+    ///
+    /// # Errors
+    ///
+    /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
+    /// exist in [`PeerRepository`].
+    pub fn sync_peer_spec(&self, peer_id: PeerId) -> Result<(), RoomError> {
+        self.peers.map_peer_by_id(peer_id, |peer| {
+            self.peer_metrics_service
+                .borrow_mut()
+                .update_peer_tracks(&peer);
+        })?;
+        Ok(())
+    }
+}
 
 /// Repository which stores all [`PeerStateMachine`]s of the [`PeersService`].
 #[derive(Debug)]
@@ -124,17 +549,9 @@ impl PeerRepository {
     ) -> Result<Peer<S>, RoomError>
     where
         Peer<S>: TryFrom<PeerStateMachine>,
-        <Peer<S> as TryFrom<PeerStateMachine>>::Error:
-            Into<(PeerError, PeerStateMachine)>,
+        <Peer<S> as TryFrom<PeerStateMachine>>::Error: Into<RoomError>,
     {
-        match self.take(peer_id)?.try_into() {
-            Ok(peer) => Ok(peer),
-            Err(err) => {
-                let (err, peer) = err.into();
-                self.add_peer(peer);
-                Err(RoomError::from(err))
-            }
-        }
+        self.take(peer_id)?.try_into().map_err(Into::into)
     }
 
     /// Store [`Peer`] in [`Room`].
@@ -213,498 +630,6 @@ impl PeerRepository {
             });
 
         peers_to_remove
-    }
-}
-
-#[derive(Debug)]
-pub struct PeersServiceInner {
-    /// [`RoomId`] of the [`Room`] which owns this [`PeerRepository`].
-    room_id: RoomId,
-
-    /// [`TurnAuthService`] that [`IceUser`]s for the [`PeerConnection`]s from
-    /// this [`PeerRepository`] will be created with.
-    turn_service: Arc<dyn TurnAuthService>,
-
-    /// [`Peer`]s of [`Member`]s in this [`Room`].
-    ///
-    /// [`Member`]: crate::signalling::elements::member::Member
-    /// [`Room`]: crate::signalling::Room
-    peers: PeerRepository,
-
-    /// Count of [`Peer`]s in this [`Room`].
-    ///
-    /// [`Room`]: crate::signalling::room::Room
-    peers_count: Counter<PeerId>,
-
-    /// Count of [`MediaTrack`]s in this [`Room`].
-    ///
-    /// [`MediaTrack`]: crate::media::track::MediaTrack
-    /// [`Room`]: crate::signalling::room::Room
-    tracks_count: Counter<TrackId>,
-
-    /// [`PeerTrafficWatcher`] which analyzes [`Peer`]s traffic metrics.
-    peers_traffic_watcher: Arc<dyn PeerTrafficWatcher>,
-
-    /// Service which responsible for this [`Room`]'s [`RtcStat`]s processing.
-    peer_metrics_service: RefCell<PeersMetricsService>,
-
-    /// Duration, after which [`Peer`]s stats will be considered as stale.
-    /// Passed to [`PeersMetricsService`] when registering new [`Peer`]s.
-    peer_stats_ttl: Duration,
-}
-
-#[derive(Clone, Debug)]
-pub struct PeersService(Rc<PeersServiceInner>);
-
-/// Simple ID counter.
-#[derive(Default, Debug, Clone, Display)]
-pub struct Counter<T: Copy> {
-    count: Cell<T>,
-}
-
-impl<T: Incrementable + Copy> Counter<T> {
-    /// Returns id and increase counter.
-    pub fn next_id(&self) -> T {
-        let id = self.count.get();
-        self.count.set(id.incr());
-
-        id
-    }
-}
-
-/// Result of the [`PeersService::get_or_create_peers`] function.
-#[derive(Debug, Clone, Copy)]
-enum GetOrCreatePeersResult {
-    /// Requested [`Peer`] pair was created.
-    Created(PeerId, PeerId),
-
-    /// Requested [`Peer`] pair already existed.
-    AlreadyExisted(PeerId, PeerId),
-}
-
-/// Result of the [`PeersService::connect_endpoints`] function.
-#[derive(Debug, Clone, Copy)]
-pub enum ConnectEndpointsResult {
-    /// New [`Peer`] pair was created.
-    Created(PeerId, PeerId),
-
-    /// [`Peer`] pair was updated.
-    Updated(PeerId, PeerId),
-
-    /// Nothing was done because endpoints already interconnected.
-    NoOp(PeerId, PeerId),
-}
-
-impl PeersService {
-    /// Returns new [`PeerRepository`] for a [`Room`] with the provided
-    /// [`RoomId`].
-    pub fn new(
-        room_id: RoomId,
-        turn_service: Arc<dyn TurnAuthService>,
-        peers_traffic_watcher: Arc<dyn PeerTrafficWatcher>,
-        media_conf: &conf::Media,
-    ) -> Self {
-        Self(Rc::new(PeersServiceInner {
-            room_id: room_id.clone(),
-            turn_service,
-            peers: PeerRepository::new(),
-            peers_count: Counter::default(),
-            tracks_count: Counter::default(),
-            peers_traffic_watcher: peers_traffic_watcher.clone(),
-            peer_metrics_service: RefCell::new(PeersMetricsService::new(
-                room_id,
-                peers_traffic_watcher,
-            )),
-            peer_stats_ttl: media_conf.max_lag,
-        }))
-    }
-
-    /// Store [`Peer`] in [`Room`].
-    ///
-    /// [`Room`]: crate::signalling::Room
-    #[inline]
-    pub fn add_peer<S: Into<PeerStateMachine>>(&self, peer: S) {
-        self.0.peers.add_peer(peer)
-    }
-
-    /// Applies a function to the [`PeerStateMachine`] reference with provided
-    /// [`PeerId`] (if any found).
-    ///
-    /// # Errors
-    ///
-    /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
-    /// exist in [`PeerRepository`].
-    #[inline]
-    pub fn map_peer_by_id<T>(
-        &self,
-        peer_id: PeerId,
-        f: impl FnOnce(&PeerStateMachine) -> T,
-    ) -> Result<T, RoomError> {
-        self.0.peers.map_peer_by_id(peer_id, f)
-    }
-
-    /// Creates interconnected [`Peer`]s for provided endpoints and saves them
-    /// in [`PeerService`].
-    ///
-    /// Returns [`PeerId`]s of the created [`Peer`]s.
-    fn create_peers(
-        &self,
-        src: &WebRtcPublishEndpoint,
-        sink: &WebRtcPlayEndpoint,
-    ) -> (PeerId, PeerId) {
-        let src_member_id = src.owner().id();
-        let sink_member_id = sink.owner().id();
-
-        let src_peer_id = self.0.peers_count.next_id();
-        let sink_peer_id = self.0.peers_count.next_id();
-
-        debug!(
-            "Created peers:[{}, {}] between {} and {}.",
-            src_peer_id, sink_peer_id, src_member_id, sink_member_id,
-        );
-
-        let mut src_peer = Peer::new(
-            src_peer_id,
-            src_member_id.clone(),
-            sink_peer_id,
-            sink_member_id.clone(),
-            src.is_force_relayed(),
-        );
-        src_peer.add_endpoint(&src.clone().into());
-
-        let mut sink_peer = Peer::new(
-            sink_peer_id,
-            sink_member_id,
-            src_peer_id,
-            src_member_id,
-            sink.is_force_relayed(),
-        );
-        sink_peer.add_endpoint(&sink.clone().into());
-
-        src_peer.add_publisher(&src, &mut sink_peer, &self.0.tracks_count);
-
-        let src_peer = PeerStateMachine::from(src_peer);
-        let sink_peer = PeerStateMachine::from(sink_peer);
-
-        self.0
-            .peer_metrics_service
-            .borrow_mut()
-            .register_peer(&src_peer, self.0.peer_stats_ttl);
-        self.0
-            .peer_metrics_service
-            .borrow_mut()
-            .register_peer(&sink_peer, self.0.peer_stats_ttl);
-
-        self.add_peer(src_peer);
-        self.add_peer(sink_peer);
-
-        (src_peer_id, sink_peer_id)
-    }
-
-    /// Lookups [`Peer`] of [`Member`] with ID `member_id` which
-    /// connected with `partner_member_id`.
-    ///
-    /// Returns `Some(peer_id, partner_peer_id)` if [`Peer`] has been found,
-    /// otherwise returns `None`.
-    #[inline]
-    pub fn get_peers_between_members(
-        &self,
-        member_id: &MemberId,
-        partner_member_id: &MemberId,
-    ) -> Option<(PeerId, PeerId)> {
-        self.0
-            .peers
-            .get_peers_between_members(member_id, partner_member_id)
-    }
-
-    /// Returns owned [`Peer`] by its ID.
-    ///
-    /// # Errors
-    ///
-    /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
-    /// exist in [`PeerRepository`].
-    ///
-    /// Errors with [`RoomError::PeerError`] if [`Peer`] is found, but not in
-    /// requested state.
-    pub fn take_inner_peer<S>(
-        &self,
-        peer_id: PeerId,
-    ) -> Result<Peer<S>, RoomError>
-    where
-        Peer<S>: TryFrom<PeerStateMachine>,
-        <Peer<S> as TryFrom<PeerStateMachine>>::Error:
-            Into<(PeerError, PeerStateMachine)>,
-    {
-        self.0.peers.take_inner_peer(peer_id)
-    }
-
-    /// Deletes [`PeerStateMachine`]s from this [`PeerRepository`] and send
-    /// [`Event::PeersRemoved`] to [`Member`]s.
-    ///
-    /// __Note:__ this also deletes partner peers.
-    ///
-    /// [`Event::PeersRemoved`]: medea_client_api_proto::Event::PeersRemoved
-    pub fn remove_peers<'a, Peers: IntoIterator<Item = &'a PeerId>>(
-        &self,
-        member_id: &MemberId,
-        peer_ids: Peers,
-    ) -> HashMap<MemberId, Vec<PeerStateMachine>> {
-        let mut removed_peers = HashMap::new();
-        for peer_id in peer_ids {
-            if let Some(peer) = self.0.peers.remove(*peer_id) {
-                let partner_peer_id = peer.partner_peer_id();
-                let partner_member_id = peer.partner_member_id();
-                if let Some(partner_peer) = self.0.peers.remove(partner_peer_id)
-                {
-                    removed_peers
-                        .entry(partner_member_id)
-                        .or_insert_with(Vec::new)
-                        .push(partner_peer);
-                }
-                removed_peers
-                    .entry(member_id.clone())
-                    .or_insert_with(Vec::new)
-                    .push(peer);
-            }
-        }
-
-        let peers_to_unregister: Vec<_> = removed_peers
-            .values()
-            .flat_map(|peer| peer.iter().map(PeerStateMachine::id))
-            .collect();
-        self.0
-            .peer_metrics_service
-            .borrow_mut()
-            .unregister_peers(&peers_to_unregister);
-        self.0
-            .peers_traffic_watcher
-            .unregister_peers(self.0.room_id.clone(), peers_to_unregister);
-
-        removed_peers
-    }
-
-    /// Returns already created [`Peer`] pair's [`PeerId`]s as
-    /// [`CreatedOrGottenPeer::Gotten`] variant.
-    ///
-    /// Returns newly created [`Peer`] pair's [`PeerId`]s as
-    /// [`CreatedOrGottenPeer::Created`] variant.
-    async fn get_or_create_peers(
-        self,
-        src: WebRtcPublishEndpoint,
-        sink: WebRtcPlayEndpoint,
-    ) -> Result<GetOrCreatePeersResult, RoomError> {
-        if let Some((first_peer_id, second_peer_id)) = self
-            .get_peers_between_members(&src.owner().id(), &sink.owner().id())
-        {
-            Ok(GetOrCreatePeersResult::AlreadyExisted(
-                first_peer_id,
-                second_peer_id,
-            ))
-        } else {
-            let (src_peer_id, sink_peer_id) = self.create_peers(&src, &sink);
-
-            self.clone()
-                .peer_post_construct(src_peer_id, &src.into())
-                .await?;
-            self.clone()
-                .peer_post_construct(sink_peer_id, &sink.into())
-                .await?;
-
-            Ok(GetOrCreatePeersResult::Created(src_peer_id, sink_peer_id))
-        }
-    }
-
-    /// Creates and sets [`IceUser`], registers [`Peer`] in
-    /// [`PeerTrafficWatcher`].
-    async fn peer_post_construct(
-        self,
-        peer_id: PeerId,
-        endpoint: &Endpoint,
-    ) -> Result<(), RoomError> {
-        let has_traffic_callback = endpoint.has_traffic_callback();
-        let is_force_relayed = endpoint.is_force_relayed();
-
-        let ice_user = self
-            .0
-            .turn_service
-            .create(
-                self.0.room_id.clone(),
-                peer_id,
-                UnreachablePolicy::ReturnErr,
-            )
-            .await?;
-
-        let _ = self
-            .0
-            .peers
-            .map_peer_by_id_mut(peer_id, move |p| p.set_ice_user(ice_user));
-
-        if has_traffic_callback {
-            self.0
-                .peers_traffic_watcher
-                .register_peer(
-                    self.0.room_id.clone(),
-                    peer_id,
-                    is_force_relayed,
-                )
-                .await
-                .map_err(RoomError::PeerTrafficWatcherMailbox)
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Creates [`Peer`] for endpoints if [`Peer`] between endpoint's members
-    /// doesn't exist.
-    ///
-    /// Adds `send` track to source member's [`Peer`] and `recv` to
-    /// sink member's [`Peer`]. Registers TURN credentials for created
-    /// [`Peer`]s.
-    ///
-    /// Returns [`PeerId`]s of newly created [`Peer`] if it has been created.
-    ///
-    /// # Errors
-    ///
-    /// Errors if could not save [`IceUser`] in [`TurnAuthService`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if provided endpoints already have interconnected [`Peer`]s.
-    pub async fn connect_endpoints(
-        self,
-        src: WebRtcPublishEndpoint,
-        sink: WebRtcPlayEndpoint,
-    ) -> Result<ConnectEndpointsResult, RoomError> {
-        use ConnectEndpointsResult::{Created, NoOp, Updated};
-
-        debug!(
-            "Connecting endpoints of Member [id = {}] with Member [id = {}]",
-            src.owner().id(),
-            sink.owner().id(),
-        );
-        let get_or_create_peers =
-            self.clone().get_or_create_peers(src.clone(), sink.clone());
-        match get_or_create_peers.await? {
-            GetOrCreatePeersResult::Created(src_peer_id, sink_peer_id) => {
-                Ok(Created(src_peer_id, sink_peer_id))
-            }
-            GetOrCreatePeersResult::AlreadyExisted(
-                src_peer_id,
-                sink_peer_id,
-            ) => {
-                if sink.peer_id().is_some()
-                    || src.peer_ids().contains(&src_peer_id)
-                {
-                    // already connected, so no-op
-                    Ok(NoOp(src_peer_id, sink_peer_id))
-                } else {
-                    let mut futs = Vec::new();
-                    // TODO: here we assume that peers are stable,
-                    //       which might not be the case, e.g. Control
-                    //       Service creates multiple endpoints in quick
-                    //       succession.
-                    let mut src_peer: Peer<Stable> =
-                        self.0.peers.take_inner_peer(src_peer_id).unwrap();
-                    let mut sink_peer: Peer<Stable> =
-                        self.0.peers.take_inner_peer(sink_peer_id).unwrap();
-
-                    src_peer.add_publisher(
-                        &src,
-                        &mut sink_peer,
-                        &self.0.tracks_count,
-                    );
-
-                    if src.has_traffic_callback() {
-                        futs.push(self.0.peers_traffic_watcher.register_peer(
-                            self.0.room_id.clone(),
-                            src_peer_id,
-                            src.is_force_relayed(),
-                        ));
-                    }
-                    if sink.has_traffic_callback() {
-                        futs.push(self.0.peers_traffic_watcher.register_peer(
-                            self.0.room_id.clone(),
-                            sink_peer_id,
-                            sink.is_force_relayed(),
-                        ));
-                    }
-
-                    sink_peer.add_endpoint(&sink.into());
-                    src_peer.add_endpoint(&src.into());
-
-                    let src_peer = PeerStateMachine::from(src_peer);
-                    let sink_peer = PeerStateMachine::from(sink_peer);
-
-                    self.0
-                        .peer_metrics_service
-                        .borrow_mut()
-                        .update_peer_tracks(&src_peer);
-                    self.0
-                        .peer_metrics_service
-                        .borrow_mut()
-                        .update_peer_tracks(&sink_peer);
-
-                    self.0.peers.add_peer(src_peer);
-                    self.0.peers.add_peer(sink_peer);
-
-                    future::try_join_all(futs)
-                        .await
-                        .map_err(RoomError::PeerTrafficWatcherMailbox)?;
-
-                    Ok(Updated(src_peer_id, sink_peer_id))
-                }
-            }
-        }
-    }
-
-    /// Removes all [`Peer`]s related to given [`Member`].
-    /// Note, that this function will also remove all partners [`Peer`]s.
-    ///
-    /// Returns [`HashMap`] with all removed [`Peer`]s:
-    /// key - [`Peer`]'s owner [`MemberId`],
-    /// value - removed [`Peer`]'s [`PeerId`].
-    // TODO: remove in #91.
-    #[inline]
-    pub fn remove_peers_related_to_member(
-        &self,
-        member_id: &MemberId,
-    ) -> HashMap<MemberId, Vec<PeerId>> {
-        self.0.peers.remove_peers_related_to_member(member_id)
-    }
-
-    /// Adds new [`WebRtcPlayEndpoint`] to the [`Peer`] with a provided
-    /// [`PeerId`].
-    pub fn add_sink(&self, peer_id: PeerId, sink: WebRtcPlayEndpoint) {
-        let mut peer: Peer<Stable> = self.take_inner_peer(peer_id).unwrap();
-        let mut partner_peer: Peer<Stable> =
-            self.take_inner_peer(peer.partner_peer_id()).unwrap();
-
-        peer.add_publisher(
-            &sink.src(),
-            &mut partner_peer,
-            &self.0.tracks_count,
-        );
-        peer.add_endpoint(&Endpoint::from(sink));
-
-        self.0.peers.add_peer(peer);
-        self.0.peers.add_peer(partner_peer);
-    }
-
-    /// Updates [`PeerTracks`] of the [`Peer`] with provided [`PeerId`] in the
-    /// [`PeerMetricsService`].
-    ///
-    /// # Errors
-    ///
-    /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
-    /// exist in [`PeerRepository`].
-    pub fn sync_peer_spec(&mut self, peer_id: PeerId) -> Result<(), RoomError> {
-        self.0.peers.map_peer_by_id(peer_id, |peer| {
-            self.0
-                .peer_metrics_service
-                .borrow_mut()
-                .update_peer_tracks(&peer);
-        })?;
-        Ok(())
     }
 }
 
@@ -795,12 +720,10 @@ mod tests {
         register_peer_done.await.unwrap().unwrap();
 
         assert!(peers_service
-            .0
             .peer_metrics_service
             .borrow()
             .is_peer_registered(PeerId(0)));
         assert!(peers_service
-            .0
             .peer_metrics_service
             .borrow()
             .is_peer_registered(PeerId(1)));
@@ -873,13 +796,11 @@ mod tests {
             .unwrap();
 
         let first_peer_tracks_count = peers_service
-            .0
             .peer_metrics_service
             .borrow()
             .peer_tracks_count(PeerId(0));
         assert_eq!(first_peer_tracks_count, 2);
         let second_peer_tracks_count = peers_service
-            .0
             .peer_metrics_service
             .borrow()
             .peer_tracks_count(PeerId(1));
@@ -909,13 +830,11 @@ mod tests {
             .unwrap();
 
         let first_peer_tracks_count = peers_service
-            .0
             .peer_metrics_service
             .borrow()
             .peer_tracks_count(PeerId(0));
         assert_eq!(first_peer_tracks_count, 4);
         let second_peer_tracks_count = peers_service
-            .0
             .peer_metrics_service
             .borrow()
             .peer_tracks_count(PeerId(1));

--- a/src/signalling/peers/mod.rs
+++ b/src/signalling/peers/mod.rs
@@ -715,7 +715,10 @@ mod tests {
 
     use crate::{
         api::control::{
-            endpoints::webrtc_publish_endpoint::P2pMode, refs::SrcUri,
+            endpoints::webrtc_publish_endpoint::{
+                AudioSettings, P2pMode, VideoSettings,
+            },
+            refs::SrcUri,
         },
         signalling::{
             elements::Member, peers::traffic_watcher::MockPeerTrafficWatcher,
@@ -724,9 +727,6 @@ mod tests {
     };
 
     use super::*;
-    use crate::api::control::endpoints::webrtc_publish_endpoint::{
-        AudioSettings, VideoSettings,
-    };
 
     /// Checks that newly created [`Peer`] will be created in the
     /// [`PeerMetricsService`] and [`PeerTrafficWatcher`].

--- a/src/signalling/peers/mod.rs
+++ b/src/signalling/peers/mod.rs
@@ -5,28 +5,29 @@ mod metrics;
 mod traffic_watcher;
 
 use std::{
+    cell::{Cell, RefCell},
     collections::HashMap,
     convert::{TryFrom, TryInto},
+    rc::Rc,
     sync::Arc,
     time::Duration,
 };
 
-use actix::{fut::wrap_future, ActorFuture, WrapFuture as _};
 use derive_more::Display;
+use futures::future;
 use medea_client_api_proto::{Incrementable, PeerId, TrackId};
 
 use crate::{
     api::control::{MemberId, RoomId},
     conf,
     log::prelude::*,
-    media::{IceUser, New, Peer, PeerStateMachine},
+    media::{Peer, PeerError, PeerStateMachine, Stable},
     signalling::{
         elements::endpoints::{
             webrtc::{WebRtcPlayEndpoint, WebRtcPublishEndpoint},
             Endpoint,
         },
-        room::{ActFuture, RoomError},
-        Room,
+        room::RoomError,
     },
     turn::{TurnAuthService, UnreachablePolicy},
 };
@@ -41,8 +42,182 @@ pub use self::{
     },
 };
 
+/// Repository which stores all [`PeerStateMachine`]s of the [`PeersService`].
 #[derive(Debug)]
-pub struct PeersService {
+struct PeerRepository(RefCell<HashMap<PeerId, PeerStateMachine>>);
+
+impl PeerRepository {
+    /// Returns empty [`PeerRepository`].
+    pub fn new() -> Self {
+        Self(RefCell::new(HashMap::new()))
+    }
+
+    /// Applies a function to the [`PeerStateMachine`] reference with provided
+    /// [`PeerId`] (if any found).
+    ///
+    /// # Errors
+    ///
+    /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
+    /// exist in [`PeerRepository`].
+    pub fn map_peer_by_id<T>(
+        &self,
+        peer_id: PeerId,
+        f: impl FnOnce(&PeerStateMachine) -> T,
+    ) -> Result<T, RoomError> {
+        Ok(f(self
+            .0
+            .borrow()
+            .get(&peer_id)
+            .ok_or_else(|| RoomError::PeerNotFound(peer_id))?))
+    }
+
+    /// Applies a function to the mutable [`PeerStateMachine`] reference with
+    /// provided [`PeerId`] (if any found).
+    ///
+    /// # Errors
+    ///
+    /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
+    /// exist in [`PeerRepository`].
+    pub fn map_peer_by_id_mut<T>(
+        &self,
+        peer_id: PeerId,
+        f: impl FnOnce(&mut PeerStateMachine) -> T,
+    ) -> Result<T, RoomError> {
+        Ok(f(self
+            .0
+            .borrow_mut()
+            .get_mut(&peer_id)
+            .ok_or_else(|| RoomError::PeerNotFound(peer_id))?))
+    }
+
+    /// Removes [`PeerStateMachine`] with a provided [`PeerId`].
+    ///
+    /// Returns removed [`PeerStateMachine`] if it existed.
+    pub fn remove(&self, peer_id: PeerId) -> Option<PeerStateMachine> {
+        self.0.borrow_mut().remove(&peer_id)
+    }
+
+    /// Removes [`PeerStateMachine`] with a provided [`PeerId`] and returns
+    /// removed [`PeerStateMachine`] if it existed.
+    ///
+    /// # Errors
+    ///
+    /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
+    /// exist in [`PeerRepository`].
+    pub fn take(&self, peer_id: PeerId) -> Result<PeerStateMachine, RoomError> {
+        self.remove(peer_id)
+            .ok_or_else(|| RoomError::PeerNotFound(peer_id))
+    }
+
+    /// Returns owned [`Peer`] by its ID.
+    ///
+    /// # Errors
+    ///
+    /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
+    /// exist in [`PeerRepository`].
+    ///
+    /// Errors with [`RoomError::PeerError`] if [`Peer`] is found, but not in
+    /// requested state.
+    pub fn take_inner_peer<S>(
+        &self,
+        peer_id: PeerId,
+    ) -> Result<Peer<S>, RoomError>
+    where
+        Peer<S>: TryFrom<PeerStateMachine>,
+        <Peer<S> as TryFrom<PeerStateMachine>>::Error:
+            Into<(PeerError, PeerStateMachine)>,
+    {
+        match self.take(peer_id)?.try_into() {
+            Ok(peer) => Ok(peer),
+            Err(err) => {
+                let (err, peer) = err.into();
+                self.add_peer(peer);
+                Err(RoomError::from(err))
+            }
+        }
+    }
+
+    /// Store [`Peer`] in [`Room`].
+    ///
+    /// [`Room`]: crate::signalling::Room
+    pub fn add_peer<S: Into<PeerStateMachine>>(&self, peer: S) {
+        let peer = peer.into();
+        self.0.borrow_mut().insert(peer.id(), peer);
+    }
+
+    /// Lookups [`Peer`] of [`Member`] with ID `member_id` which
+    /// connected with `partner_member_id`.
+    ///
+    /// Returns `Some(peer_id, partner_peer_id)` if [`Peer`] has been found,
+    /// otherwise returns `None`.
+    pub fn get_peers_between_members(
+        &self,
+        member_id: &MemberId,
+        partner_member_id: &MemberId,
+    ) -> Option<(PeerId, PeerId)> {
+        for peer in self.0.borrow().values() {
+            if &peer.member_id() == member_id
+                && &peer.partner_member_id() == partner_member_id
+            {
+                return Some((peer.id(), peer.partner_peer_id()));
+            }
+        }
+
+        None
+    }
+
+    /// Removes all [`Peer`]s related to given [`Member`].
+    /// Note, that this function will also remove all partners [`Peer`]s.
+    ///
+    /// Returns [`HashMap`] with all removed [`Peer`]s:
+    /// key - [`Peer`]'s owner [`MemberId`],
+    /// value - removed [`Peer`]'s [`PeerId`].
+    // TODO: remove in #91.
+    pub fn remove_peers_related_to_member(
+        &self,
+        member_id: &MemberId,
+    ) -> HashMap<MemberId, Vec<PeerId>> {
+        let mut peers_to_remove: HashMap<MemberId, Vec<PeerId>> =
+            HashMap::new();
+
+        self.0
+            .borrow()
+            .values()
+            .filter(|p| &p.member_id() == member_id)
+            .for_each(|peer| {
+                self.0
+                    .borrow()
+                    .values()
+                    .filter(|p| p.member_id() == peer.partner_member_id())
+                    .filter(|partner_peer| {
+                        &partner_peer.partner_member_id() == member_id
+                    })
+                    .for_each(|partner_peer| {
+                        peers_to_remove
+                            .entry(partner_peer.member_id())
+                            .or_insert_with(Vec::new)
+                            .push(partner_peer.id());
+                    });
+
+                peers_to_remove
+                    .entry(peer.member_id())
+                    .or_insert_with(Vec::new)
+                    .push(peer.id());
+            });
+
+        peers_to_remove
+            .values()
+            .flat_map(|peer_ids| peer_ids.iter())
+            .for_each(|id| {
+                self.0.borrow_mut().remove(id);
+            });
+
+        peers_to_remove
+    }
+}
+
+#[derive(Debug)]
+pub struct PeersServiceInner {
     /// [`RoomId`] of the [`Room`] which owns this [`PeerRepository`].
     room_id: RoomId,
 
@@ -54,7 +229,7 @@ pub struct PeersService {
     ///
     /// [`Member`]: crate::signalling::elements::member::Member
     /// [`Room`]: crate::signalling::Room
-    peers: HashMap<PeerId, PeerStateMachine>,
+    peers: PeerRepository,
 
     /// Count of [`Peer`]s in this [`Room`].
     ///
@@ -71,26 +246,53 @@ pub struct PeersService {
     peers_traffic_watcher: Arc<dyn PeerTrafficWatcher>,
 
     /// Service which responsible for this [`Room`]'s [`RtcStat`]s processing.
-    peer_metrics_service: PeersMetricsService,
+    peer_metrics_service: RefCell<PeersMetricsService>,
 
     /// Duration, after which [`Peer`]s stats will be considered as stale.
     /// Passed to [`PeersMetricsService`] when registering new [`Peer`]s.
     peer_stats_ttl: Duration,
 }
 
+#[derive(Clone, Debug)]
+pub struct PeersService(Rc<PeersServiceInner>);
+
 /// Simple ID counter.
-#[derive(Default, Debug, Clone, Copy, Display)]
-pub struct Counter<T> {
-    count: T,
+#[derive(Default, Debug, Clone, Display)]
+pub struct Counter<T: Copy> {
+    count: Cell<T>,
 }
 
 impl<T: Incrementable + Copy> Counter<T> {
     /// Returns id and increase counter.
-    pub fn next_id(&mut self) -> T {
-        let id = self.count;
-        self.count = self.count.incr();
+    pub fn next_id(&self) -> T {
+        let id = self.count.get();
+        self.count.set(id.incr());
+
         id
     }
+}
+
+/// Result of the [`PeersService::get_or_create_peers`] function.
+#[derive(Debug, Clone, Copy)]
+enum GetOrCreatePeersResult {
+    /// Requested [`Peer`] pair was created.
+    Created(PeerId, PeerId),
+
+    /// Requested [`Peer`] pair already existed.
+    AlreadyExisted(PeerId, PeerId),
+}
+
+/// Result of the [`PeersService::connect_endpoints`] function.
+#[derive(Debug, Clone, Copy)]
+pub enum ConnectEndpointsResult {
+    /// New [`Peer`] pair was created.
+    Created(PeerId, PeerId),
+
+    /// [`Peer`] pair was updated.
+    Updated(PeerId, PeerId),
+
+    /// Nothing was done because endpoints already interconnected.
+    NoOp(PeerId, PeerId),
 }
 
 impl PeersService {
@@ -102,57 +304,43 @@ impl PeersService {
         peers_traffic_watcher: Arc<dyn PeerTrafficWatcher>,
         media_conf: &conf::Media,
     ) -> Self {
-        Self {
+        Self(Rc::new(PeersServiceInner {
             room_id: room_id.clone(),
             turn_service,
-            peers: HashMap::new(),
+            peers: PeerRepository::new(),
             peers_count: Counter::default(),
             tracks_count: Counter::default(),
             peers_traffic_watcher: peers_traffic_watcher.clone(),
-            peer_metrics_service: PeersMetricsService::new(
+            peer_metrics_service: RefCell::new(PeersMetricsService::new(
                 room_id,
                 peers_traffic_watcher,
-            ),
+            )),
             peer_stats_ttl: media_conf.max_lag,
-        }
+        }))
     }
 
     /// Store [`Peer`] in [`Room`].
     ///
     /// [`Room`]: crate::signalling::Room
-    pub fn add_peer<S: Into<PeerStateMachine>>(&mut self, peer: S) {
-        let peer = peer.into();
-        self.peers.insert(peer.id(), peer);
+    #[inline]
+    pub fn add_peer<S: Into<PeerStateMachine>>(&self, peer: S) {
+        self.0.peers.add_peer(peer)
     }
 
-    /// Returns borrowed [`PeerStateMachine`] by its ID.
+    /// Applies a function to the [`PeerStateMachine`] reference with provided
+    /// [`PeerId`] (if any found).
     ///
     /// # Errors
     ///
     /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
     /// exist in [`PeerRepository`].
-    pub fn get_peer_by_id(
+    #[inline]
+    pub fn map_peer_by_id<T>(
         &self,
         peer_id: PeerId,
-    ) -> Result<&PeerStateMachine, RoomError> {
-        self.peers
-            .get(&peer_id)
-            .ok_or_else(|| RoomError::PeerNotFound(peer_id))
-    }
-
-    /// Returns mutably borrowed [`PeerStateMachine`] by its ID.
-    ///
-    /// # Errors
-    ///
-    /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
-    /// exist in [`PeerRepository`].
-    pub fn get_mut_peer_by_id(
-        &mut self,
-        peer_id: PeerId,
-    ) -> Result<&mut PeerStateMachine, RoomError> {
-        self.peers
-            .get_mut(&peer_id)
-            .ok_or_else(|| RoomError::PeerNotFound(peer_id))
+        f: impl FnOnce(&PeerStateMachine) -> T,
+    ) -> Result<T, RoomError> {
+        self.0.peers.map_peer_by_id(peer_id, f)
     }
 
     /// Creates interconnected [`Peer`]s for provided endpoints and saves them
@@ -160,15 +348,15 @@ impl PeersService {
     ///
     /// Returns [`PeerId`]s of the created [`Peer`]s.
     fn create_peers(
-        &mut self,
+        &self,
         src: &WebRtcPublishEndpoint,
         sink: &WebRtcPlayEndpoint,
     ) -> (PeerId, PeerId) {
         let src_member_id = src.owner().id();
         let sink_member_id = sink.owner().id();
 
-        let src_peer_id = self.peers_count.next_id();
-        let sink_peer_id = self.peers_count.next_id();
+        let src_peer_id = self.0.peers_count.next_id();
+        let sink_peer_id = self.0.peers_count.next_id();
 
         debug!(
             "Created peers:[{}, {}] between {} and {}.",
@@ -193,7 +381,19 @@ impl PeersService {
         );
         sink_peer.add_endpoint(&sink.clone().into());
 
-        src_peer.add_publisher(&src, &mut sink_peer, self.get_tracks_counter());
+        src_peer.add_publisher(&src, &mut sink_peer, &self.0.tracks_count);
+
+        let src_peer = PeerStateMachine::from(src_peer);
+        let sink_peer = PeerStateMachine::from(sink_peer);
+
+        self.0
+            .peer_metrics_service
+            .borrow_mut()
+            .register_peer(&src_peer, self.0.peer_stats_ttl);
+        self.0
+            .peer_metrics_service
+            .borrow_mut()
+            .register_peer(&sink_peer, self.0.peer_stats_ttl);
 
         self.add_peer(src_peer);
         self.add_peer(sink_peer);
@@ -201,62 +401,20 @@ impl PeersService {
         (src_peer_id, sink_peer_id)
     }
 
-    /// Returns mutable reference to track counter.
-    pub fn get_tracks_counter(&mut self) -> &mut Counter<TrackId> {
-        &mut self.tracks_count
-    }
-
     /// Lookups [`Peer`] of [`Member`] with ID `member_id` which
     /// connected with `partner_member_id`.
     ///
     /// Returns `Some(peer_id, partner_peer_id)` if [`Peer`] has been found,
     /// otherwise returns `None`.
-    pub fn get_peer_by_members_ids(
+    #[inline]
+    pub fn get_peers_between_members(
         &self,
         member_id: &MemberId,
         partner_member_id: &MemberId,
     ) -> Option<(PeerId, PeerId)> {
-        for peer in self.peers.values() {
-            if &peer.member_id() == member_id
-                && &peer.partner_member_id() == partner_member_id
-            {
-                return Some((peer.id(), peer.partner_peer_id()));
-            }
-        }
-
-        None
-    }
-
-    /// Returns borrowed [`Peer`] by its ID.
-    ///
-    /// # Errors
-    ///
-    /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
-    /// exist in [`PeerRepository`].
-    pub fn get_inner_peer_by_id<'a, S>(
-        &'a self,
-        peer_id: PeerId,
-    ) -> Result<&'a Peer<S>, RoomError>
-    where
-        &'a Peer<S>: std::convert::TryFrom<&'a PeerStateMachine>,
-        <&'a Peer<S> as TryFrom<&'a PeerStateMachine>>::Error: Into<RoomError>,
-    {
-        match self.peers.get(&peer_id) {
-            Some(peer) => peer.try_into().map_err(Into::into),
-            None => Err(RoomError::PeerNotFound(peer_id)),
-        }
-    }
-
-    /// Returns all [`Peer`]s of specified [`Member`].
-    ///
-    /// [`Member`]: crate::signalling::elements::member::Member
-    pub fn get_peers_by_member_id<'a>(
-        &'a self,
-        member_id: &'a MemberId,
-    ) -> impl Iterator<Item = &'a PeerStateMachine> {
-        self.peers
-            .values()
-            .filter(move |peer| &peer.member_id() == member_id)
+        self.0
+            .peers
+            .get_peers_between_members(member_id, partner_member_id)
     }
 
     /// Returns owned [`Peer`] by its ID.
@@ -265,18 +423,19 @@ impl PeersService {
     ///
     /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
     /// exist in [`PeerRepository`].
+    ///
+    /// Errors with [`RoomError::PeerError`] if [`Peer`] is found, but not in
+    /// requested state.
     pub fn take_inner_peer<S>(
-        &mut self,
+        &self,
         peer_id: PeerId,
     ) -> Result<Peer<S>, RoomError>
     where
         Peer<S>: TryFrom<PeerStateMachine>,
-        <Peer<S> as TryFrom<PeerStateMachine>>::Error: Into<RoomError>,
+        <Peer<S> as TryFrom<PeerStateMachine>>::Error:
+            Into<(PeerError, PeerStateMachine)>,
     {
-        match self.peers.remove(&peer_id) {
-            Some(peer) => peer.try_into().map_err(Into::into),
-            None => Err(RoomError::PeerNotFound(peer_id)),
-        }
+        self.0.peers.take_inner_peer(peer_id)
     }
 
     /// Deletes [`PeerStateMachine`]s from this [`PeerRepository`] and send
@@ -286,16 +445,16 @@ impl PeersService {
     ///
     /// [`Event::PeersRemoved`]: medea_client_api_proto::Event::PeersRemoved
     pub fn remove_peers<'a, Peers: IntoIterator<Item = &'a PeerId>>(
-        &mut self,
+        &self,
         member_id: &MemberId,
         peer_ids: Peers,
     ) -> HashMap<MemberId, Vec<PeerStateMachine>> {
         let mut removed_peers = HashMap::new();
         for peer_id in peer_ids {
-            if let Some(peer) = self.peers.remove(&peer_id) {
+            if let Some(peer) = self.0.peers.remove(*peer_id) {
                 let partner_peer_id = peer.partner_peer_id();
                 let partner_member_id = peer.partner_member_id();
-                if let Some(partner_peer) = self.peers.remove(&partner_peer_id)
+                if let Some(partner_peer) = self.0.peers.remove(partner_peer_id)
                 {
                     removed_peers
                         .entry(partner_member_id)
@@ -313,12 +472,86 @@ impl PeersService {
             .values()
             .flat_map(|peer| peer.iter().map(PeerStateMachine::id))
             .collect();
-        self.peer_metrics_service
+        self.0
+            .peer_metrics_service
+            .borrow_mut()
             .unregister_peers(&peers_to_unregister);
-        self.peers_traffic_watcher
-            .unregister_peers(self.room_id.clone(), peers_to_unregister);
+        self.0
+            .peers_traffic_watcher
+            .unregister_peers(self.0.room_id.clone(), peers_to_unregister);
 
         removed_peers
+    }
+
+    /// Returns already created [`Peer`] pair's [`PeerId`]s as
+    /// [`CreatedOrGottenPeer::Gotten`] variant.
+    ///
+    /// Returns newly created [`Peer`] pair's [`PeerId`]s as
+    /// [`CreatedOrGottenPeer::Created`] variant.
+    async fn get_or_create_peers(
+        self,
+        src: WebRtcPublishEndpoint,
+        sink: WebRtcPlayEndpoint,
+    ) -> Result<GetOrCreatePeersResult, RoomError> {
+        if let Some((first_peer_id, second_peer_id)) = self
+            .get_peers_between_members(&src.owner().id(), &sink.owner().id())
+        {
+            Ok(GetOrCreatePeersResult::AlreadyExisted(
+                first_peer_id,
+                second_peer_id,
+            ))
+        } else {
+            let (src_peer_id, sink_peer_id) = self.create_peers(&src, &sink);
+
+            self.clone()
+                .peer_post_construct(src_peer_id, &src.into())
+                .await?;
+            self.clone()
+                .peer_post_construct(sink_peer_id, &sink.into())
+                .await?;
+
+            Ok(GetOrCreatePeersResult::Created(src_peer_id, sink_peer_id))
+        }
+    }
+
+    /// Creates and sets [`IceUser`], registers [`Peer`] in
+    /// [`PeerTrafficWatcher`].
+    async fn peer_post_construct(
+        self,
+        peer_id: PeerId,
+        endpoint: &Endpoint,
+    ) -> Result<(), RoomError> {
+        let has_traffic_callback = endpoint.has_traffic_callback();
+        let is_force_relayed = endpoint.is_force_relayed();
+
+        let ice_user = self
+            .0
+            .turn_service
+            .create(
+                self.0.room_id.clone(),
+                peer_id,
+                UnreachablePolicy::ReturnErr,
+            )
+            .await?;
+
+        let _ = self
+            .0
+            .peers
+            .map_peer_by_id_mut(peer_id, move |p| p.set_ice_user(ice_user));
+
+        if has_traffic_callback {
+            self.0
+                .peers_traffic_watcher
+                .register_peer(
+                    self.0.room_id.clone(),
+                    peer_id,
+                    is_force_relayed,
+                )
+                .await
+                .map_err(RoomError::PeerTrafficWatcherMailbox)
+        } else {
+            Ok(())
+        }
     }
 
     /// Creates [`Peer`] for endpoints if [`Peer`] between endpoint's members
@@ -337,126 +570,91 @@ impl PeersService {
     /// # Panics
     ///
     /// Panics if provided endpoints already have interconnected [`Peer`]s.
-    pub fn connect_endpoints(
-        &mut self,
+    pub async fn connect_endpoints(
+        self,
         src: WebRtcPublishEndpoint,
         sink: WebRtcPlayEndpoint,
-    ) -> ActFuture<Result<Option<(PeerId, PeerId)>, RoomError>> {
+    ) -> Result<ConnectEndpointsResult, RoomError> {
+        use ConnectEndpointsResult::{Created, NoOp, Updated};
+
         debug!(
             "Connecting endpoints of Member [id = {}] with Member [id = {}]",
             src.owner().id(),
             sink.owner().id(),
         );
-        let src_owner = src.owner();
-        let sink_owner = sink.owner();
+        let get_or_create_peers =
+            self.clone().get_or_create_peers(src.clone(), sink.clone());
+        match get_or_create_peers.await? {
+            GetOrCreatePeersResult::Created(src_peer_id, sink_peer_id) => {
+                Ok(Created(src_peer_id, sink_peer_id))
+            }
+            GetOrCreatePeersResult::AlreadyExisted(
+                src_peer_id,
+                sink_peer_id,
+            ) => {
+                if sink.peer_id().is_some()
+                    || src.peer_ids().contains(&src_peer_id)
+                {
+                    // already connected, so no-op
+                    Ok(NoOp(src_peer_id, sink_peer_id))
+                } else {
+                    let mut futs = Vec::new();
+                    // TODO: here we assume that peers are stable,
+                    //       which might not be the case, e.g. Control
+                    //       Service creates multiple endpoints in quick
+                    //       succession.
+                    let mut src_peer: Peer<Stable> =
+                        self.0.peers.take_inner_peer(src_peer_id).unwrap();
+                    let mut sink_peer: Peer<Stable> =
+                        self.0.peers.take_inner_peer(sink_peer_id).unwrap();
 
-        if let Some((src_peer_id, sink_peer_id)) =
-            self.get_peer_by_members_ids(&src_owner.id(), &sink_owner.id())
-        {
-            // TODO: when dynamic patching of [`Room`] will be done then we need
-            //       rewrite this code to updating [`Peer`]s in not
-            //       [`Peer<New>`] state.
-            //       Also, don't forget to update `PeerSpec` in the
-            //       [`PeerMetricsService`].
-            let mut src_peer: Peer<New> =
-                self.take_inner_peer(src_peer_id).unwrap();
-            let mut sink_peer: Peer<New> =
-                self.take_inner_peer(sink_peer_id).unwrap();
+                    src_peer.add_publisher(
+                        &src,
+                        &mut sink_peer,
+                        &self.0.tracks_count,
+                    );
 
-            src_peer.add_publisher(
-                &src,
-                &mut sink_peer,
-                self.get_tracks_counter(),
-            );
-
-            sink_peer.add_endpoint(&sink.into());
-            src_peer.add_endpoint(&src.into());
-
-            let src_peer = PeerStateMachine::from(src_peer);
-            let sink_peer = PeerStateMachine::from(sink_peer);
-
-            self.peer_metrics_service
-                .register_peer(&src_peer, self.peer_stats_ttl);
-            self.peer_metrics_service
-                .register_peer(&sink_peer, self.peer_stats_ttl);
-
-            self.add_peer(src_peer);
-            self.add_peer(sink_peer);
-
-            Box::new(actix::fut::ok(None))
-        } else {
-            let (src_peer_id, sink_peer_id) = self.create_peers(&src, &sink);
-
-            Box::new(self.peer_post_construct(src_peer_id, src.into()).then(
-                move |res, room, _| {
-                    match res {
-                        Ok(_) => Box::new(
-                            room.peers
-                                .peer_post_construct(sink_peer_id, sink.into())
-                                .map(move |res, _, _| {
-                                    res.map(|_| {
-                                        Some((src_peer_id, sink_peer_id))
-                                    })
-                                }),
-                        ),
-                        Err(err) => {
-                            Box::new(actix::fut::err(err)) as ActFuture<_>
-                        }
+                    if src.has_traffic_callback() {
+                        futs.push(self.0.peers_traffic_watcher.register_peer(
+                            self.0.room_id.clone(),
+                            src_peer_id,
+                            src.is_force_relayed(),
+                        ));
                     }
-                },
-            ))
-        }
-    }
+                    if sink.has_traffic_callback() {
+                        futs.push(self.0.peers_traffic_watcher.register_peer(
+                            self.0.room_id.clone(),
+                            sink_peer_id,
+                            sink.is_force_relayed(),
+                        ));
+                    }
 
-    /// Creates and sets [`IceUser`], registers [`Peer`] in
-    /// [`PeerTrafficWatcher`].
-    fn peer_post_construct(
-        &self,
-        peer_id: PeerId,
-        endpoint: Endpoint,
-    ) -> ActFuture<Result<(), RoomError>> {
-        let room_id = self.room_id.clone();
-        let turn_service = self.turn_service.clone();
-        Box::new(
-            wrap_future(async move {
-                Ok(turn_service
-                    .create(room_id, peer_id, UnreachablePolicy::ReturnErr)
-                    .await?)
-            })
-            .map(move |res: Result<IceUser, RoomError>, room: &mut Room, _| {
-                res.map(|ice_user| {
-                    if let Ok(peer) = room.peers.get_mut_peer_by_id(peer_id) {
-                        peer.set_ice_user(ice_user)
-                    }
-                })
-            })
-            .then(move |res, room: &mut Room, _| {
-                let room_id = room.id().clone();
-                let traffic_watcher = room.peers.peers_traffic_watcher.clone();
-                async move {
-                    match res {
-                        Ok(_) => {
-                            if endpoint.has_traffic_callback() {
-                                traffic_watcher
-                                    .register_peer(
-                                        room_id,
-                                        peer_id,
-                                        endpoint.is_force_relayed(),
-                                    )
-                                    .await
-                                    .map_err(
-                                        RoomError::PeerTrafficWatcherMailbox,
-                                    )
-                            } else {
-                                Ok(())
-                            }
-                        }
-                        Err(err) => Err(err),
-                    }
+                    sink_peer.add_endpoint(&sink.into());
+                    src_peer.add_endpoint(&src.into());
+
+                    let src_peer = PeerStateMachine::from(src_peer);
+                    let sink_peer = PeerStateMachine::from(sink_peer);
+
+                    self.0
+                        .peer_metrics_service
+                        .borrow_mut()
+                        .update_peer_tracks(&src_peer);
+                    self.0
+                        .peer_metrics_service
+                        .borrow_mut()
+                        .update_peer_tracks(&sink_peer);
+
+                    self.0.peers.add_peer(src_peer);
+                    self.0.peers.add_peer(sink_peer);
+
+                    future::try_join_all(futs)
+                        .await
+                        .map_err(RoomError::PeerTrafficWatcherMailbox)?;
+
+                    Ok(Updated(src_peer_id, sink_peer_id))
                 }
-                .into_actor(room)
-            }),
-        )
+            }
+        }
     }
 
     /// Removes all [`Peer`]s related to given [`Member`].
@@ -466,39 +664,30 @@ impl PeersService {
     /// key - [`Peer`]'s owner [`MemberId`],
     /// value - removed [`Peer`]'s [`PeerId`].
     // TODO: remove in #91.
+    #[inline]
     pub fn remove_peers_related_to_member(
-        &mut self,
+        &self,
         member_id: &MemberId,
     ) -> HashMap<MemberId, Vec<PeerId>> {
-        let mut peers_to_remove: HashMap<MemberId, Vec<PeerId>> =
-            HashMap::new();
+        self.0.peers.remove_peers_related_to_member(member_id)
+    }
 
-        self.get_peers_by_member_id(member_id).for_each(|peer| {
-            self.get_peers_by_member_id(&peer.partner_member_id())
-                .filter(|partner_peer| {
-                    &partner_peer.partner_member_id() == member_id
-                })
-                .for_each(|partner_peer| {
-                    peers_to_remove
-                        .entry(partner_peer.member_id())
-                        .or_insert_with(Vec::new)
-                        .push(partner_peer.id());
-                });
+    /// Adds new [`WebRtcPlayEndpoint`] to the [`Peer`] with a provided
+    /// [`PeerId`].
+    pub fn add_sink(&self, peer_id: PeerId, sink: WebRtcPlayEndpoint) {
+        let mut peer: Peer<Stable> = self.take_inner_peer(peer_id).unwrap();
+        let mut partner_peer: Peer<Stable> =
+            self.take_inner_peer(peer.partner_peer_id()).unwrap();
 
-            peers_to_remove
-                .entry(peer.member_id())
-                .or_insert_with(Vec::new)
-                .push(peer.id());
-        });
+        peer.add_publisher(
+            &sink.src(),
+            &mut partner_peer,
+            &self.0.tracks_count,
+        );
+        peer.add_endpoint(&Endpoint::from(sink));
 
-        peers_to_remove
-            .values()
-            .flat_map(|peer_ids| peer_ids.iter())
-            .for_each(|id| {
-                self.peers.remove(id);
-            });
-
-        peers_to_remove
+        self.0.peers.add_peer(peer);
+        self.0.peers.add_peer(partner_peer);
     }
 
     /// Updates [`PeerTracks`] of the [`Peer`] with provided [`PeerId`] in the
@@ -509,8 +698,229 @@ impl PeersService {
     /// Errors with [`RoomError::PeerNotFound`] if requested [`PeerId`] doesn't
     /// exist in [`PeerRepository`].
     pub fn sync_peer_spec(&mut self, peer_id: PeerId) -> Result<(), RoomError> {
-        let peer = self.get_peer_by_id(peer_id)?;
-        self.peer_metrics_service.update_peer_tracks(&peer);
+        self.0.peers.map_peer_by_id(peer_id, |peer| {
+            self.0
+                .peer_metrics_service
+                .borrow_mut()
+                .update_peer_tracks(&peer);
+        })?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::{channel::mpsc, future, StreamExt as _};
+    use tokio::time::timeout;
+
+    use crate::{
+        api::control::{
+            endpoints::webrtc_publish_endpoint::P2pMode, refs::SrcUri,
+        },
+        signalling::{
+            elements::Member, peers::traffic_watcher::MockPeerTrafficWatcher,
+        },
+        turn::service::test::new_turn_auth_service_mock,
+    };
+
+    use super::*;
+    use crate::api::control::endpoints::webrtc_publish_endpoint::{
+        AudioSettings, VideoSettings,
+    };
+
+    /// Checks that newly created [`Peer`] will be created in the
+    /// [`PeerMetricsService`] and [`PeerTrafficWatcher`].
+    #[actix_rt::test]
+    async fn peer_is_registered_in_metrics_service() {
+        let mut mock = MockPeerTrafficWatcher::new();
+        mock.expect_register_room()
+            .returning(|_, _| Box::pin(future::ok(())));
+        mock.expect_unregister_room().returning(|_| {});
+        let (register_peer_tx, mut register_peer_rx) = mpsc::unbounded();
+        let register_peer_done =
+            timeout(Duration::from_secs(1), register_peer_rx.next());
+        mock.expect_register_peer().returning(move |_, _, _| {
+            register_peer_tx.unbounded_send(()).unwrap();
+            Box::pin(future::ok(()))
+        });
+        mock.expect_traffic_flows().returning(|_, _, _| {});
+        mock.expect_traffic_stopped().returning(|_, _, _| {});
+
+        let peers_service = PeersService::new(
+            "test".into(),
+            new_turn_auth_service_mock(),
+            Arc::new(mock),
+            &conf::Media::default(),
+        );
+
+        let publisher = Member::new(
+            "publisher".into(),
+            "test".to_string(),
+            "test".into(),
+            Duration::from_secs(10),
+            Duration::from_secs(10),
+            Duration::from_secs(5),
+        );
+        let receiver = Member::new(
+            "receiver".into(),
+            "test".to_string(),
+            "test".into(),
+            Duration::from_secs(10),
+            Duration::from_secs(10),
+            Duration::from_secs(5),
+        );
+        let publish = WebRtcPublishEndpoint::new(
+            "publish".to_string().into(),
+            P2pMode::Always,
+            publisher.downgrade(),
+            false,
+            AudioSettings::default(),
+            VideoSettings::default(),
+        );
+        let play = WebRtcPlayEndpoint::new(
+            "play-publisher".to_string().into(),
+            SrcUri::try_from("local://test/publisher/publish".to_string())
+                .unwrap(),
+            publish.downgrade(),
+            receiver.downgrade(),
+            false,
+        );
+
+        peers_service
+            .clone()
+            .connect_endpoints(publish, play)
+            .await
+            .unwrap();
+
+        register_peer_done.await.unwrap().unwrap();
+
+        assert!(peers_service
+            .0
+            .peer_metrics_service
+            .borrow()
+            .is_peer_registered(PeerId(0)));
+        assert!(peers_service
+            .0
+            .peer_metrics_service
+            .borrow()
+            .is_peer_registered(PeerId(1)));
+    }
+
+    /// Check that when new `Endpoint`s added to the [`PeerService`], tracks
+    /// count will be updated in the [`PeerMetricsService`].
+    #[actix_rt::test]
+    async fn adding_new_endpoint_updates_peer_metrics() {
+        let mut mock = MockPeerTrafficWatcher::new();
+        mock.expect_register_room()
+            .returning(|_, _| Box::pin(future::ok(())));
+        mock.expect_unregister_room().returning(|_| {});
+        let (register_peer_tx, register_peer_rx) = mpsc::unbounded();
+        let register_peer_done = timeout(
+            Duration::from_secs(1),
+            register_peer_rx.take(4).collect::<Vec<_>>(),
+        );
+        mock.expect_register_peer().returning(move |_, _, _| {
+            register_peer_tx.unbounded_send(()).unwrap();
+            Box::pin(future::ok(()))
+        });
+        mock.expect_traffic_flows().returning(|_, _, _| {});
+        mock.expect_traffic_stopped().returning(|_, _, _| {});
+
+        let peers_service = PeersService::new(
+            "test".into(),
+            new_turn_auth_service_mock(),
+            Arc::new(mock),
+            &conf::Media::default(),
+        );
+
+        let publisher = Member::new(
+            "publisher".into(),
+            "test".to_string(),
+            "test".into(),
+            Duration::from_secs(10),
+            Duration::from_secs(10),
+            Duration::from_secs(5),
+        );
+        let receiver = Member::new(
+            "receiver".into(),
+            "test".to_string(),
+            "test".into(),
+            Duration::from_secs(10),
+            Duration::from_secs(10),
+            Duration::from_secs(5),
+        );
+        let publish = WebRtcPublishEndpoint::new(
+            "publish".to_string().into(),
+            P2pMode::Always,
+            publisher.downgrade(),
+            false,
+            AudioSettings::default(),
+            VideoSettings::default(),
+        );
+        let play = WebRtcPlayEndpoint::new(
+            "play-publisher".to_string().into(),
+            SrcUri::try_from("local://test/publisher/publish".to_string())
+                .unwrap(),
+            publish.downgrade(),
+            receiver.downgrade(),
+            false,
+        );
+
+        peers_service
+            .clone()
+            .connect_endpoints(publish, play)
+            .await
+            .unwrap();
+
+        let first_peer_tracks_count = peers_service
+            .0
+            .peer_metrics_service
+            .borrow()
+            .peer_tracks_count(PeerId(0));
+        assert_eq!(first_peer_tracks_count, 2);
+        let second_peer_tracks_count = peers_service
+            .0
+            .peer_metrics_service
+            .borrow()
+            .peer_tracks_count(PeerId(1));
+        assert_eq!(second_peer_tracks_count, 2);
+
+        let publish = WebRtcPublishEndpoint::new(
+            "publish".to_string().into(),
+            P2pMode::Always,
+            receiver.downgrade(),
+            false,
+            AudioSettings::default(),
+            VideoSettings::default(),
+        );
+        let play = WebRtcPlayEndpoint::new(
+            "play-publisher".to_string().into(),
+            SrcUri::try_from("local://test/publisher/publish".to_string())
+                .unwrap(),
+            publish.downgrade(),
+            publisher.downgrade(),
+            false,
+        );
+
+        peers_service
+            .clone()
+            .connect_endpoints(publish, play)
+            .await
+            .unwrap();
+
+        let first_peer_tracks_count = peers_service
+            .0
+            .peer_metrics_service
+            .borrow()
+            .peer_tracks_count(PeerId(0));
+        assert_eq!(first_peer_tracks_count, 4);
+        let second_peer_tracks_count = peers_service
+            .0
+            .peer_metrics_service
+            .borrow()
+            .peer_tracks_count(PeerId(1));
+        assert_eq!(second_peer_tracks_count, 4);
+
+        register_peer_done.await.unwrap();
     }
 }

--- a/src/signalling/peers/mod.rs
+++ b/src/signalling/peers/mod.rs
@@ -560,7 +560,7 @@ impl PeerRepository {
         self.take(peer_id)?.try_into().map_err(Into::into)
     }
 
-    /// Store [`Peer`] in [`Room`].
+    /// Stores [`Peer`] in [`Room`].
     ///
     /// [`Room`]: crate::signalling::Room
     pub fn add_peer<S: Into<PeerStateMachine>>(&self, peer: S) {

--- a/src/signalling/room/command_handler.rs
+++ b/src/signalling/room/command_handler.rs
@@ -12,7 +12,7 @@ use medea_client_api_proto::{
 use crate::{
     log::prelude::*,
     media::{
-        Peer, PeerStateMachine, Stable, WaitLocalHaveRemote, WaitLocalSdp,
+        New, Peer, PeerStateMachine, WaitLocalHaveRemote, WaitLocalSdp,
         WaitRemoteSdp,
     },
 };
@@ -39,7 +39,7 @@ impl CommandHandler for Room {
         from_peer.update_senders_statuses(senders_statuses);
 
         let to_peer_id = from_peer.partner_peer_id();
-        let to_peer: Peer<Stable> = self.peers.take_inner_peer(to_peer_id)?;
+        let to_peer: Peer<New> = self.peers.take_inner_peer(to_peer_id)?;
 
         let from_peer = from_peer.set_local_sdp(sdp_offer.clone());
         let to_peer = to_peer.set_remote_sdp(sdp_offer.clone());
@@ -52,7 +52,7 @@ impl CommandHandler for Room {
         let event = Event::PeerCreated {
             peer_id: to_peer.id(),
             sdp_offer: Some(sdp_offer),
-            tracks: to_peer.new_tracks(),
+            tracks: to_peer.tracks(),
             ice_servers,
             force_relay: to_peer.is_force_relayed(),
         };

--- a/src/signalling/room/command_handler.rs
+++ b/src/signalling/room/command_handler.rs
@@ -12,8 +12,8 @@ use medea_client_api_proto::{
 use crate::{
     log::prelude::*,
     media::{
-        New, Peer, PeerError, PeerStateMachine, WaitLocalHaveRemote,
-        WaitLocalSdp, WaitRemoteSdp,
+        Peer, PeerStateMachine, Stable, WaitLocalHaveRemote, WaitLocalSdp,
+        WaitRemoteSdp,
     },
 };
 
@@ -39,7 +39,7 @@ impl CommandHandler for Room {
         from_peer.update_senders_statuses(senders_statuses);
 
         let to_peer_id = from_peer.partner_peer_id();
-        let to_peer: Peer<New> = self.peers.take_inner_peer(to_peer_id)?;
+        let to_peer: Peer<Stable> = self.peers.take_inner_peer(to_peer_id)?;
 
         let from_peer = from_peer.set_local_sdp(sdp_offer.clone());
         let to_peer = to_peer.set_remote_sdp(sdp_offer.clone());
@@ -52,7 +52,7 @@ impl CommandHandler for Room {
         let event = Event::PeerCreated {
             peer_id: to_peer.id(),
             sdp_offer: Some(sdp_offer),
-            tracks: to_peer.tracks(),
+            tracks: to_peer.new_tracks(),
             ice_servers,
             force_relay: to_peer.is_force_relayed(),
         };
@@ -123,28 +123,12 @@ impl CommandHandler for Room {
             return Ok(Box::new(actix::fut::ok(())));
         }
 
-        let from_peer = self.peers.get_peer_by_id(from_peer_id)?;
-        if let PeerStateMachine::New(_) = from_peer {
-            return Err(PeerError::WrongState(
-                from_peer_id,
-                "Not New",
-                format!("{}", from_peer),
-            )
-            .into());
-        }
-
-        let to_peer_id = from_peer.partner_peer_id();
-        let to_peer = self.peers.get_peer_by_id(to_peer_id)?;
-        if let PeerStateMachine::New(_) = to_peer {
-            return Err(PeerError::WrongState(
-                to_peer_id,
-                "Not New",
-                format!("{}", to_peer),
-            )
-            .into());
-        }
-
-        let to_member_id = to_peer.member_id();
+        let to_peer_id = self
+            .peers
+            .map_peer_by_id(from_peer_id, PeerStateMachine::partner_peer_id)?;
+        let to_member_id = self
+            .peers
+            .map_peer_by_id(to_peer_id, PeerStateMachine::member_id)?;
         let event = Event::IceCandidateDiscovered {
             peer_id: to_peer_id,
             candidate,
@@ -175,8 +159,10 @@ impl CommandHandler for Room {
         peer_id: PeerId,
         tracks_patches: Vec<TrackPatch>,
     ) -> Self::Output {
-        if let Ok(p) = self.peers.get_peer_by_id(peer_id) {
-            let member_id = p.member_id();
+        if let Ok(member_id) = self
+            .peers
+            .map_peer_by_id(peer_id, PeerStateMachine::member_id)
+        {
             Ok(Box::new(
                 self.members
                     .send_event_to_member(

--- a/src/signalling/room/mod.rs
+++ b/src/signalling/room/mod.rs
@@ -294,7 +294,9 @@ impl Room {
                             }
                         }
                         _ => {
-                            // TODO
+                            // Temporary change, because renegotiation
+                            // functional will be
+                            // implemented in the #105 PR.
                             Box::new(actix::fut::ok(()))
                         }
                     },

--- a/src/signalling/room/rpc_server.rs
+++ b/src/signalling/room/rpc_server.rs
@@ -20,6 +20,7 @@ use crate::{
         RpcServer,
     },
     log::prelude::*,
+    media::PeerStateMachine,
     utils::ResponseActAnyFuture,
 };
 
@@ -65,13 +66,15 @@ impl Room {
             | C::UpdateTracks { peer_id, .. } => peer_id,
         };
 
-        let peer = self
+        let peer_member_id = self
             .peers
-            .get_peer_by_id(peer_id)
+            .map_peer_by_id(peer_id, PeerStateMachine::member_id)
             .map_err(|_| PeerNotFound(peer_id))?;
-        if peer.member_id() != command.member_id {
-            return Err(PeerBelongsToAnotherMember(peer_id, peer.member_id()));
+
+        if peer_member_id != command.member_id {
+            return Err(PeerBelongsToAnotherMember(peer_id, peer_member_id));
         }
+
         Ok(())
     }
 }

--- a/src/signalling/room/rpc_server.rs
+++ b/src/signalling/room/rpc_server.rs
@@ -70,11 +70,9 @@ impl Room {
             .peers
             .map_peer_by_id(peer_id, PeerStateMachine::member_id)
             .map_err(|_| PeerNotFound(peer_id))?;
-
         if peer_member_id != command.member_id {
             return Err(PeerBelongsToAnotherMember(peer_id, peer_member_id));
         }
-
         Ok(())
     }
 }


### PR DESCRIPTION
Part of #27

Required for #105




## Synopsis

`PeersService` currently returns `ActorFuture`s (for the `Room` actor) from the functions and does changes before `ActorFuture` is actually polled. Also, because of it `Room` structure has public field `peer`. After this PR all this problems will be resolved.




## Solution

Get rid of the `ActorFuture` and make this functions `async`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `WIP: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `WIP: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
