### PR TITLE
Omit using 64-bit integer types in Jason and Client API

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -8,6 +8,7 @@ doc-valid-idents = [
     "IPv4", "IPv6", "JavaScript", "NaN", "NaNs",
     "OAuth", "OpenGL", "OpenSSH", "OpenSSL", "OpenStreetMap", "TrueType",
     "iOS", "macOS", "TeX", "LaTeX", "BibTeX", "BibLaTeX", "MinGW",
+    "BigInt64Array",
     "DOMHighResTimeStamp",
     "getDisplayMedia", "getUserMedia", "gRPC",
     "MediaDeviceKind", "MediaDeviceInfo",

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -8,7 +8,7 @@ doc-valid-idents = [
     "IPv4", "IPv6", "JavaScript", "NaN", "NaNs",
     "OAuth", "OpenGL", "OpenSSH", "OpenSSL", "OpenStreetMap", "TrueType",
     "iOS", "macOS", "TeX", "LaTeX", "BibTeX", "BibLaTeX", "MinGW",
-    "BigInt64Array",
+    "BigInt64Array", "BigUint64Array",
     "DOMHighResTimeStamp",
     "getDisplayMedia", "getUserMedia", "gRPC",
     "MediaDeviceKind", "MediaDeviceInfo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc9a9dd069569f212bc4330af9f17c4afb5e8ce185e83dbb14f1349dda18b10"
+
+[[package]]
 name = "adler32"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,7 +482,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.3.7",
  "object",
  "rustc-demangle",
 ]
@@ -556,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1be3409f94d7bdceeb5f5fac551039d9b3f00e25da7a74fc4d33400a0d96368"
+checksum = "77c1f1d60091c1b73e2b1f4560ab419204b178e625fa945ded7b660becd2bd46"
 
 [[package]]
 name = "cfg-if"
@@ -948,14 +954,14 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
+checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
 dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.0",
 ]
 
 [[package]]
@@ -1327,9 +1333,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce10c23ad2ea25ceca0093bd3192229da4c5b3c0f2de499c1ecac0d98d452177"
+checksum = "c4b9172132a62451e56142bff9afc91c8e4a4500aa5b847da36815b63bfda916"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1639,6 +1645,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
 dependencies = [
  "adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -2316,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
+checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
  "itoa",
  "ryu",
@@ -3065,9 +3080,9 @@ checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
@@ -3131,9 +3146,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
+checksum = "6a634620115e4a229108b71bde263bb4220c483b3f07f5ba514ee8d15064c4c2"
 dependencies = [
  "cfg-if",
  "serde 1.0.114",
@@ -3143,9 +3158,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded84f06e0ed21499f6184df0e0cb3494727b0c5da89534e0fcc55c51d812101"
+checksum = "3e53963b583d18a5aa3aaae4b4c1cb535218246131ba22a71f05b518098571df"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3158,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64487204d863f109eb77e8462189d111f27cb5712cc9fdb3461297a76963a2f6"
+checksum = "dba48d66049d2a6cc8488702e7259ab7afc9043ad0dc5448444f46f2a453b362"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3170,9 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838e423688dac18d73e31edce74ddfac468e37b1506ad163ffaf0a46f703ffe3"
+checksum = "3fcfd5ef6eec85623b4c6e844293d4516470d8f19cd72d0d12246017eb9060b8"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3180,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
+checksum = "9adff9ee0e94b926ca81b57f57f86d5545cdcb1d259e21ec9bdd95b901754c75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3193,15 +3208,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd"
+checksum = "7f7b90ea6c632dd06fd765d44542e234d5e63d9bb917ecd64d79778a13bd79ae"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0dfda4d3b3f8acbc3c291b09208081c203af457fb14a229783b06e2f128aa7"
+checksum = "8edfbb0918bc0e8207c38200c9462ba8d03d8276dd99bdca14c08281af61883f"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -3213,9 +3228,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2e18093f11c19ca4e188c177fecc7c372304c311189f12c2f9bea5b7324ac7"
+checksum = "343d02640a91e4cd89d81dba8b9047991b4bf103657c1a2d18884808c83642fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3223,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b72fe77fd39e4bd3eaa4412fd299a0be6b3dfe9d2597e2f1c20beb968f41d17"
+checksum = "863539788676619aac1a23e2df3655e96b32b0e05eb72ca34ba045ad573c625d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/jason/src/rpc/heartbeat.rs
+++ b/jason/src/rpc/heartbeat.rs
@@ -50,7 +50,7 @@ struct Inner {
     idle_watchdog_task: Option<TaskHandle>,
 
     /// Number of last received [`ServerMsg::Ping`].
-    last_ping_num: u64,
+    last_ping_num: u32,
 
     /// [`mpsc::UnboundedSender`]s for a [`Heartbeat::on_idle`].
     on_idle_subs: Vec<mpsc::UnboundedSender<()>>,
@@ -60,7 +60,7 @@ impl Inner {
     /// Sends [`ClientMsg::Pong`] to a server.
     ///
     /// If some error happen then it will be printed with [`console_error`].
-    fn send_pong(&self, n: u64) {
+    fn send_pong(&self, n: u32) {
         self.transport
             .send(&ClientMsg::Pong(n))
             .map_err(tracerr::wrap!(=> TransportError))

--- a/jason/src/rpc/mod.rs
+++ b/jason/src/rpc/mod.rs
@@ -429,16 +429,12 @@ impl WebSocketRpcClient {
             ServerMsg::RpcSettings(settings) => {
                 self.update_settings(
                     IdleTimeout(
-                        Duration::from_millis(u64::from(
-                            settings.idle_timeout_ms,
-                        ))
-                        .into(),
+                        Duration::from_millis(settings.idle_timeout_ms.into())
+                            .into(),
                     ),
                     PingInterval(
-                        Duration::from_millis(u64::from(
-                            settings.ping_interval_ms,
-                        ))
-                        .into(),
+                        Duration::from_millis(settings.ping_interval_ms.into())
+                            .into(),
                     ),
                 )
                 .map_err(tracerr::wrap!(=> RpcClientError))
@@ -458,12 +454,10 @@ impl WebSocketRpcClient {
         rpc_settings: RpcSettings,
     ) -> Result<(), Traced<RpcClientError>> {
         let idle_timeout = IdleTimeout(
-            Duration::from_millis(u64::from(rpc_settings.idle_timeout_ms))
-                .into(),
+            Duration::from_millis(rpc_settings.idle_timeout_ms.into()).into(),
         );
         let ping_interval = PingInterval(
-            Duration::from_millis(u64::from(rpc_settings.ping_interval_ms))
-                .into(),
+            Duration::from_millis(rpc_settings.ping_interval_ms.into()).into(),
         );
 
         let heartbeat =

--- a/jason/src/rpc/mod.rs
+++ b/jason/src/rpc/mod.rs
@@ -429,10 +429,16 @@ impl WebSocketRpcClient {
             ServerMsg::RpcSettings(settings) => {
                 self.update_settings(
                     IdleTimeout(
-                        Duration::from_millis(settings.idle_timeout_ms).into(),
+                        Duration::from_millis(u64::from(
+                            settings.idle_timeout_ms,
+                        ))
+                        .into(),
                     ),
                     PingInterval(
-                        Duration::from_millis(settings.ping_interval_ms).into(),
+                        Duration::from_millis(u64::from(
+                            settings.ping_interval_ms,
+                        ))
+                        .into(),
                     ),
                 )
                 .map_err(tracerr::wrap!(=> RpcClientError))
@@ -452,10 +458,12 @@ impl WebSocketRpcClient {
         rpc_settings: RpcSettings,
     ) -> Result<(), Traced<RpcClientError>> {
         let idle_timeout = IdleTimeout(
-            Duration::from_millis(rpc_settings.idle_timeout_ms).into(),
+            Duration::from_millis(u64::from(rpc_settings.idle_timeout_ms))
+                .into(),
         );
         let ping_interval = PingInterval(
-            Duration::from_millis(rpc_settings.ping_interval_ms).into(),
+            Duration::from_millis(u64::from(rpc_settings.ping_interval_ms))
+                .into(),
         );
 
         let heartbeat =

--- a/jason/tests/api/room.rs
+++ b/jason/tests/api/room.rs
@@ -826,8 +826,8 @@ mod patches_generation {
     /// `audio_track_muted_state_fn`'s output will be used as `is_muted` value
     /// for all audio [`Track`]s.
     async fn get_room_and_commands_receiver(
-        peers_count: u64,
-        audio_track_muted_state_fn: impl Fn(u64) -> bool,
+        peers_count: u32,
+        audio_track_muted_state_fn: impl Fn(u32) -> bool,
     ) -> (Room, mpsc::UnboundedReceiver<Command>) {
         let mut repo = Box::new(MockPeerRepository::new());
 

--- a/jason/tests/peer/mod.rs
+++ b/jason/tests/peer/mod.rs
@@ -31,7 +31,7 @@ use crate::{delay_for, get_test_unrequired_tracks, timeout};
 wasm_bindgen_test_configure!(run_in_browser);
 
 fn toggle_mute_tracks_updates(
-    tracks_ids: &[u64],
+    tracks_ids: &[u32],
     is_muted: bool,
 ) -> Vec<TrackPatch> {
     tracks_ids
@@ -43,8 +43,8 @@ fn toggle_mute_tracks_updates(
         .collect()
 }
 
-const AUDIO_TRACK_ID: u64 = 1;
-const VIDEO_TRACK_ID: u64 = 2;
+const AUDIO_TRACK_ID: u32 = 1;
+const VIDEO_TRACK_ID: u32 = 2;
 
 #[wasm_bindgen_test]
 async fn mute_unmute_audio() {

--- a/jason/tests/rpc/mod.rs
+++ b/jason/tests/rpc/mod.rs
@@ -555,8 +555,8 @@ mod on_connection_loss {
     use super::*;
 
     async fn helper(
-        idle_timeout_ms: Option<u64>,
-        ping_interval_ms: Option<u64>,
+        idle_timeout_ms: Option<u32>,
+        ping_interval_ms: Option<u32>,
         transport_changes: Option<TransportState>,
     ) -> WebSocketRpcClient {
         let ws = WebSocketRpcClient::new(Box::new(move |_| {
@@ -565,9 +565,9 @@ mod on_connection_loss {
                 transport.expect_on_message().times(3).returning(move || {
                     on_message_mock(RpcSettings {
                         idle_timeout_ms: idle_timeout_ms
-                            .unwrap_or(u64::max_value()),
+                            .unwrap_or(u32::max_value()),
                         ping_interval_ms: ping_interval_ms
-                            .unwrap_or(u64::max_value()),
+                            .unwrap_or(u32::max_value()),
                     })
                 });
                 transport.expect_set_close_reason().return_once(|_| ());

--- a/proto/client-api/CHANGELOG.md
+++ b/proto/client-api/CHANGELOG.md
@@ -16,7 +16,7 @@ All user visible changes to this project will be documented in this file. This p
         - `Pong` is now `Ping`.
     - Client messages:
         - `Ping` is now `Pong`.
-    - Use 32-bit types instead of 64-bit types ([#115]).
+    - Use 32-bit integer types instead of 64-bit ([#115]).
 
 ### Added
 

--- a/proto/client-api/CHANGELOG.md
+++ b/proto/client-api/CHANGELOG.md
@@ -16,6 +16,7 @@ All user visible changes to this project will be documented in this file. This p
         - `Pong` is now `Ping`.
     - Client messages:
         - `Ping` is now `Pong`.
+    - Use 32-bit types instead of 64-bit types ([#115]).
 
 ### Added
 
@@ -63,6 +64,7 @@ All user visible changes to this project will be documented in this file. This p
 [#102]: /../../pull/102
 [#105]: /../../pull/105
 [#106]: /../../pull/106
+[#115]: /../../pull/115
 
 
 

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -12,14 +12,15 @@
 //!
 //! Avoid using 64 bit types. Jason uses [wasm-bindgen] to interop with JS,
 //! and exposing 64 bit types to JS will make [wasm-bindgen] to use
-//! [BigInt64Array][2] in its JS glue, which is not implemented or was
-//! implemented too recently in some UA's.
+//! [BigInt64Array][2] / [BigUint64Array][3] in its JS glue, which are not
+//! implemented or were implemented too recently in some UA's.
 //!
 //! So its better to keep protocol 64-bit-types-clean to avoid breaking things
 //! by accident.
 //!
 //! [wasm-bindgen]: https://github.com/rustwasm/wasm-bindgen
 //! [2]: https://tinyurl.com/y8bacb93
+//! [3]: https://tinyurl.com/y4j3b4cs
 
 pub mod stats;
 

--- a/proto/client-api/src/stats.rs
+++ b/proto/client-api/src/stats.rs
@@ -237,9 +237,9 @@ pub enum RtcStatsType {
     /// ICE remote candidate statistics related to the [RTCIceTransport]
     /// objects.
     ///
-    /// A remote candidate is [deleted] when the [RTCIceTransport] does an ICE
-    /// restart, and the candidate is no longer a member of any non-deleted
-    /// candidate pair.
+    /// A remote candidate is [deleted][1] when the [RTCIceTransport] does an
+    /// ICE restart, and the candidate is no longer a member of any
+    /// non-deleted candidate pair.
     ///
     /// [RTCIceTransport]: https://w3.org/TR/webrtc/#dom-rtcicetransport
     /// [1]: https://w3.org/TR/webrtc-stats/#dfn-deleted
@@ -1385,7 +1385,7 @@ pub enum MediaSourceKind {
 #[derive(Clone, Debug, Deserialize, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaSourceStat {
-    /// Value of the [MediaStreamTrack]'s ID attribute.
+    /// Value of the [MediaStreamTrack][1]'s ID attribute.
     ///
     /// [1]: https://w3.org/TR/mediacapture-streams/#mediastreamtrack
     pub track_identifier: Option<String>,

--- a/proto/client-api/src/stats.rs
+++ b/proto/client-api/src/stats.rs
@@ -238,8 +238,8 @@ pub enum RtcStatsType {
     /// objects.
     ///
     /// A remote candidate is [deleted][1] when the [RTCIceTransport] does an
-    /// ICE restart, and the candidate is no longer a member of any
-    /// non-deleted candidate pair.
+    /// ICE restart, and the candidate is no longer a member of any non-deleted
+    /// candidate pair.
     ///
     /// [RTCIceTransport]: https://w3.org/TR/webrtc/#dom-rtcicetransport
     /// [1]: https://w3.org/TR/webrtc-stats/#dfn-deleted

--- a/src/api/client/session.rs
+++ b/src/api/client/session.rs
@@ -66,7 +66,7 @@ pub struct WsSession {
     last_activity: Instant,
 
     /// Last number of [`ServerMsg::Ping`].
-    last_ping_num: u64,
+    last_ping_num: u32,
 
     /// Interval to send [`ServerMsg::Ping`]s to a client with.
     ping_interval: Duration,

--- a/tests/e2e/signalling/mod.rs
+++ b/tests/e2e/signalling/mod.rs
@@ -89,7 +89,7 @@ impl TestMember {
     }
 
     /// Sends pong to the server.
-    fn send_pong(&mut self, id: u64) {
+    fn send_pong(&mut self, id: u32) {
         executor::block_on(async move {
             let json = serde_json::to_string(&ClientMsg::Pong(id)).unwrap();
             self.sink.send(ws::Message::Text(json)).await.unwrap();

--- a/tests/e2e/signalling/rpc_settings.rs
+++ b/tests/e2e/signalling/rpc_settings.rs
@@ -24,12 +24,12 @@ async fn rpc_settings_server_msg() {
             MemberBuilder::default()
                 .id("member")
                 .credentials("test")
-                .ping_interval(Some(Duration::from_secs(u64::from(
-                    PING_INTERVAL_SECS,
-                ))))
-                .idle_timeout(Some(Duration::from_secs(u64::from(
-                    IDLE_TIMEOUT_SECS,
-                ))))
+                .ping_interval(Some(Duration::from_secs(
+                    PING_INTERVAL_SECS.into(),
+                )))
+                .idle_timeout(Some(Duration::from_secs(
+                    IDLE_TIMEOUT_SECS.into(),
+                )))
                 .reconnect_timeout(Some(Duration::from_secs(0)))
                 .build()
                 .unwrap(),

--- a/tests/e2e/signalling/rpc_settings.rs
+++ b/tests/e2e/signalling/rpc_settings.rs
@@ -14,8 +14,8 @@ use crate::{
 #[actix_rt::test]
 async fn rpc_settings_server_msg() {
     const ROOM_ID: &str = "rpc_settings_server_msg";
-    const PING_INTERVAL_SECS: u64 = 111;
-    const IDLE_TIMEOUT_SECS: u64 = 222;
+    const PING_INTERVAL_SECS: u32 = 111;
+    const IDLE_TIMEOUT_SECS: u32 = 222;
 
     let mut control_client = ControlClient::new().await;
     let create_room = RoomBuilder::default()
@@ -24,8 +24,12 @@ async fn rpc_settings_server_msg() {
             MemberBuilder::default()
                 .id("member")
                 .credentials("test")
-                .ping_interval(Some(Duration::from_secs(PING_INTERVAL_SECS)))
-                .idle_timeout(Some(Duration::from_secs(IDLE_TIMEOUT_SECS)))
+                .ping_interval(Some(Duration::from_secs(u64::from(
+                    PING_INTERVAL_SECS,
+                ))))
+                .idle_timeout(Some(Duration::from_secs(u64::from(
+                    IDLE_TIMEOUT_SECS,
+                ))))
                 .reconnect_timeout(Some(Duration::from_secs(0)))
                 .build()
                 .unwrap(),


### PR DESCRIPTION
## Synopsis

Jason uses [wasm-bindgen] to interop with JS, and exposing 64 bit types to JS will make [wasm-bindgen] to use [BigInt64Array] / [BigUint64Array] in its JS glue, which is not implemented or was implemented too recently in some UA's.

E.g. it just breaks Safari, since WebKit doesnt have [BigInt64Array] / [BigUint64Array] support. https://bugs.webkit.org/show_bug.cgi?id=190800

[wasm-bindgen]: https://github.com/rustwasm/wasm-bindgen
[BigInt64Array]: https://tinyurl.com/y8bacb93
[BigUint64Array]: https://tinyurl.com/y4j3b4cs

## Solution

Avoid using 64 bit types in Jason and `medea-client-api-proto`.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `WIP: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `WIP: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
