### PR TITLE
Add ConnectionHandle.on_close callback (#27)

### DIFF
--- a/jason/CHANGELOG.md
+++ b/jason/CHANGELOG.md
@@ -50,6 +50,7 @@ All user visible changes to this project will be documented in this file. This p
     - Library API:
         - `Room.on_connection_loss` callback that JS side can start Jason reconnection on connection loss with ([#75]);
         - `Room.on_close` callback for WebSocket close initiated by server ([#55]);
+        - `ConnectionHandle.get_remote_id` method ([#120]);
         - `ConnectionHandle.on_close` callback ([#120]).
 - RPC messaging:
     - Cleanup Jason state on normal (`code = 1000`) WebSocket close ([#55]);

--- a/jason/CHANGELOG.md
+++ b/jason/CHANGELOG.md
@@ -49,7 +49,8 @@ All user visible changes to this project will be documented in this file. This p
 - Room management:
     - Library API:
         - `Room.on_connection_loss` callback that JS side can start Jason reconnection on connection loss with ([#75]);
-        - `Room.on_close` callback for WebSocket close initiated by server ([#55]).
+        - `Room.on_close` callback for WebSocket close initiated by server ([#55]);
+        - `ConnectionHandle.on_close` callback ([#120]).
 - RPC messaging:
     - Cleanup Jason state on normal (`code = 1000`) WebSocket close ([#55]);
     - `RpcClient` and `RpcTransport` reconnection ([#75]).
@@ -84,6 +85,7 @@ All user visible changes to this project will be documented in this file. This p
 [#97]: /../../pull/97
 [#105]: /../../pull/105
 [#106]: /../../pull/106
+[#120]: /../../pull/120
 
 
 

--- a/jason/demo/index.html
+++ b/jason/demo/index.html
@@ -52,6 +52,7 @@
     let isAudioMuted = false;
     let isVideoMuted = false;
     let isPublishingEnabled = true;
+    let remote_videos = {};
 
     async function createRoom(roomId) {
       try {
@@ -493,11 +494,17 @@
           let innerVideoDiv = document.createElement("div");
           innerVideoDiv.className = "col-md-3";
           innerVideoDiv.appendChild(video);
+          remote_videos[connection.get_remote_id()] = innerVideoDiv;
           videoDiv.appendChild(innerVideoDiv);
 
           video.oncanplay = async () => {
             await video.play();
           };
+        });
+
+        connection.on_close(() => {
+          remote_videos[connection.get_remote_id()].remove();
+          delete remote_videos[connection.get_remote_id()];
         });
       });
 

--- a/jason/e2e-demo/js/index.js
+++ b/jason/e2e-demo/js/index.js
@@ -3,6 +3,7 @@ const controlUrl = controlDomain + '/control-api/';
 const baseUrl = 'ws://127.0.0.1:8080/ws/';
 
 let roomId = window.location.hash.replace("#", "");
+let remote_videos = {};
 
 let usernameInput = document.getElementsByClassName('connection-settings__username')[0];
 let usernameMenuButton = document.getElementById('username-menu-button');
@@ -123,25 +124,27 @@ async function createMember(roomId, memberId) {
     }
   });
 
-  try {
-    for (let i = 0; i < memberIds.length; i++) {
-      let id = memberIds[i];
-      await axios({
-        method: 'post',
-        url: controlUrl + roomId + "/" + id + '/' + 'play-' + memberId,
-        data: {
-          kind: 'WebRtcPlayEndpoint',
-          src: 'local://' + roomId + '/' + memberId + '/publish',
-          force_relay: false
-        }
-      })
-    }
+  if (isPublish) {
+    try {
+      for (let i = 0; i < memberIds.length; i++) {
+        let id = memberIds[i];
+        await axios({
+          method: 'post',
+          url: controlUrl + roomId + "/" + id + '/' + 'play-' + memberId,
+          data: {
+            kind: 'WebRtcPlayEndpoint',
+            src: 'local://' + roomId + '/' + memberId + '/publish',
+            force_relay: false
+          }
+        })
+      }
 
-  } catch (e) {
-    console.log(e.response);
+    } catch (e) {
+      console.log(e.response);
+    }
   }
 
-  return resp.data.sids[memberId]
+  return resp.data.sids[memberId];
 }
 
 const colorizedJson = {
@@ -524,11 +527,17 @@ window.onload = async function() {
         let innerVideoDiv = document.createElement("div");
         innerVideoDiv.className = "video";
         innerVideoDiv.appendChild(video);
+        remote_videos[connection.get_remote_id()] = innerVideoDiv;
         videoDiv.appendChild(innerVideoDiv);
 
         video.oncanplay = async () => {
           await video.play();
         };
+      });
+
+      connection.on_close(() => {
+        remote_videos[connection.get_remote_id()].remove();
+        delete remote_videos[connection.get_remote_id()];
       });
     });
 

--- a/jason/src/api/connection.rs
+++ b/jason/src/api/connection.rs
@@ -2,25 +2,101 @@
 
 use std::{
     cell::RefCell,
+    collections::HashMap,
     rc::{Rc, Weak},
 };
 
-use medea_client_api_proto::TrackId;
+use medea_client_api_proto::{Direction, PeerId, Track, TrackId};
 use wasm_bindgen::prelude::*;
 
 use crate::{
     media::MediaStreamTrack,
     peer::{PeerMediaStream, RemoteMediaStream},
-    utils::{Callback, HandlerDetachedError},
+    utils::{Callback0, Callback1, HandlerDetachedError},
 };
 
-/// Actual data of a connection with a specific remote [`Member`].
-///
-/// Shared between JS side ([`ConnectionHandle`]) and
-/// Rust side ([`Connection`]).
-struct InnerConnection {
-    remote_stream: RefCell<Option<PeerMediaStream>>,
-    on_remote_stream: Callback<RemoteMediaStream>,
+/// Connections service.
+// TODO: Store MemberId's or some other metadata, that will make it possible
+//       to identify remote Member.
+#[derive(Default)]
+pub struct Connections {
+    /// Local [`PeerId`] to remote [`PeerId`].
+    local_to_remote: RefCell<HashMap<PeerId, PeerId>>,
+
+    /// Remote [`PeerId`] to [`Connection`] with that `Peer`.
+    connections: RefCell<HashMap<PeerId, Connection>>,
+
+    /// Callback from JS side which will be invoked on remote `Member` media
+    /// stream arrival.
+    on_new_connection: Callback1<ConnectionHandle>,
+}
+
+impl Connections {
+    /// Sets callback, which will be invoked when new [`Connection`] is
+    /// established.
+    pub fn on_new_connection(&self, f: js_sys::Function) {
+        self.on_new_connection.set_func(f);
+    }
+
+    /// Creates new [`Connection`]s based on senders and receivers of provided
+    /// [`Track`]s.
+    // TODO: creates connections based on remote peer_ids atm, should create
+    //       connections based on remote member_ids
+    pub fn create_connections_from_tracks(
+        &self,
+        local_peer: PeerId,
+        tracks: &[Track],
+    ) {
+        let create_connection = |connections: &Self, remote_id: &PeerId| {
+            let is_new =
+                !connections.connections.borrow().contains_key(remote_id);
+            if is_new {
+                let con = Connection::new(*remote_id);
+                connections.on_new_connection.call(con.new_handle());
+                connections.connections.borrow_mut().insert(*remote_id, con);
+                connections
+                    .local_to_remote
+                    .borrow_mut()
+                    .insert(local_peer, *remote_id);
+            }
+        };
+
+        for track in tracks {
+            match &track.direction {
+                Direction::Send { ref receivers, .. } => {
+                    for receiver in receivers {
+                        create_connection(self, receiver);
+                    }
+                }
+                Direction::Recv { ref sender, .. } => {
+                    create_connection(self, sender);
+                }
+            }
+        }
+    }
+
+    /// Lookup [`Connection`] by remote [`PeerId`].
+    pub fn get(&self, remote_peer_id: PeerId) -> Option<Connection> {
+        self.connections.borrow().get(&remote_peer_id).cloned()
+    }
+
+    /// Closes [`Connection`] associated with provided local [`PeerId`].
+    ///
+    /// Invokes `on_close` callback.
+    pub fn close_connection(&self, local_peer: PeerId) {
+        if let Some(remote_id) =
+            self.local_to_remote.borrow_mut().remove(&local_peer)
+        {
+            if let Some(connection) =
+                self.connections.borrow_mut().remove(&remote_id)
+            {
+                // `on_close` callback is invoked here and not in `Drop`
+                // implementation so `ConnectionHandle` is
+                // available during callback invocation
+                connection.0.on_close.call();
+            }
+        }
+    }
 }
 
 /// Connection with a specific remote `Member`, that is used on JS side.
@@ -28,6 +104,25 @@ struct InnerConnection {
 /// Actually, represents a [`Weak`]-based handle to `InnerConnection`.
 #[wasm_bindgen]
 pub struct ConnectionHandle(Weak<InnerConnection>);
+
+/// Actual data of a connection with a specific remote [`Member`].
+///
+/// Shared between JS side ([`ConnectionHandle`]) and
+/// Rust side ([`Connection`]).
+struct InnerConnection {
+    /// Remote [`PeerId`].
+    sender_id: PeerId,
+
+    /// [`PeerMediaStream`] received from remote member.
+    remote_stream: RefCell<Option<PeerMediaStream>>,
+
+    /// JS callback, that will be invoked when remote [`PeerMediaStream`] is
+    /// received.
+    on_remote_stream: Callback1<RemoteMediaStream>,
+
+    /// JS callback, that will be invoked when this connection is closed.
+    on_close: Callback0,
+}
 
 #[wasm_bindgen]
 impl ConnectionHandle {
@@ -37,20 +132,33 @@ impl ConnectionHandle {
         upgrade_or_detached!(self.0)
             .map(|inner| inner.on_remote_stream.set_func(f))
     }
+
+    /// Sets callback, which will be invoked when this `Connection` will close.
+    pub fn on_close(&self, f: js_sys::Function) -> Result<(), JsValue> {
+        upgrade_or_detached!(self.0).map(|inner| inner.on_close.set_func(f))
+    }
+
+    /// Returns remote `PeerId`.
+    pub fn get_remote_id(&self) -> Result<u32, JsValue> {
+        upgrade_or_detached!(self.0).map(|inner| inner.sender_id.0)
+    }
 }
 
 /// Connection with a specific remote [`Member`], that is used on Rust side.
 ///
 /// Actually, represents a handle to [`InnerConnection`].
-pub(crate) struct Connection(Rc<InnerConnection>);
+#[derive(Clone)]
+pub struct Connection(Rc<InnerConnection>);
 
 impl Connection {
     /// Instantiates new [`Connection`] for a given [`Member`].
     #[inline]
-    pub(crate) fn new() -> Self {
+    pub fn new(sender_id: PeerId) -> Self {
         Self(Rc::new(InnerConnection {
+            sender_id,
             remote_stream: RefCell::new(None),
-            on_remote_stream: Callback::default(),
+            on_remote_stream: Callback1::default(),
+            on_close: Callback0::default(),
         }))
     }
 
@@ -59,11 +167,7 @@ impl Connection {
     ///
     /// If this is the first track added to this [`Connection`], then a new
     /// [`PeerMediaStream`] is built and sent to `on_remote_stream` callback.
-    pub(crate) fn add_remote_track(
-        &self,
-        track_id: TrackId,
-        track: MediaStreamTrack,
-    ) {
+    pub fn add_remote_track(&self, track_id: TrackId, track: MediaStreamTrack) {
         let is_new_stream = self.0.remote_stream.borrow().is_none();
         let mut remote_stream_ref = self.0.remote_stream.borrow_mut();
         let stream = remote_stream_ref.get_or_insert_with(PeerMediaStream::new);
@@ -76,7 +180,7 @@ impl Connection {
 
     /// Creates new [`ConnectionHandle`] for using [`Connection`] on JS side.
     #[inline]
-    pub(crate) fn new_handle(&self) -> ConnectionHandle {
+    pub fn new_handle(&self) -> ConnectionHandle {
         ConnectionHandle(Rc::downgrade(&self.0))
     }
 }

--- a/jason/src/api/connection.rs
+++ b/jason/src/api/connection.rs
@@ -111,7 +111,7 @@ pub struct ConnectionHandle(Weak<InnerConnection>);
 /// Rust side ([`Connection`]).
 struct InnerConnection {
     /// Remote [`PeerId`].
-    sender_id: PeerId,
+    remote_id: PeerId,
 
     /// [`PeerMediaStream`] received from remote member.
     remote_stream: RefCell<Option<PeerMediaStream>>,
@@ -140,7 +140,7 @@ impl ConnectionHandle {
 
     /// Returns remote `PeerId`.
     pub fn get_remote_id(&self) -> Result<u32, JsValue> {
-        upgrade_or_detached!(self.0).map(|inner| inner.sender_id.0)
+        upgrade_or_detached!(self.0).map(|inner| inner.remote_id.0)
     }
 }
 
@@ -153,9 +153,9 @@ pub struct Connection(Rc<InnerConnection>);
 impl Connection {
     /// Instantiates new [`Connection`] for a given [`Member`].
     #[inline]
-    pub fn new(sender_id: PeerId) -> Self {
+    pub fn new(remote_id: PeerId) -> Self {
         Self(Rc::new(InnerConnection {
-            sender_id,
+            remote_id,
             remote_stream: RefCell::new(None),
             on_remote_stream: Callback1::default(),
             on_close: Callback0::default(),

--- a/jason/src/api/connection.rs
+++ b/jason/src/api/connection.rs
@@ -75,7 +75,7 @@ impl Connections {
         }
     }
 
-    /// Lookup [`Connection`] by remote [`PeerId`].
+    /// Lookups [`Connection`] by the given remote [`PeerId`].
     pub fn get(&self, remote_peer_id: PeerId) -> Option<Connection> {
         self.connections.borrow().get(&remote_peer_id).cloned()
     }

--- a/jason/src/api/mod.rs
+++ b/jason/src/api/mod.rs
@@ -20,7 +20,11 @@ use crate::{
 };
 
 #[doc(inline)]
-pub use self::{connection::ConnectionHandle, room::Room, room::RoomHandle};
+pub use self::{
+    connection::{ConnectionHandle, Connections},
+    room::Room,
+    room::RoomHandle,
+};
 
 /// General library interface.
 ///

--- a/jason/src/utils/callback.rs
+++ b/jason/src/utils/callback.rs
@@ -26,7 +26,7 @@ impl Callback0 {
         self.f.borrow().as_ref().map(|f| f.call0(&JsValue::NULL))
     }
 
-    /// Indicates if callback is set.
+    /// Indicates whether callback is set.
     #[inline]
     pub fn is_set(&self) -> bool {
         self.f.borrow().as_ref().is_some()

--- a/jason/src/utils/callback.rs
+++ b/jason/src/utils/callback.rs
@@ -5,13 +5,41 @@ use std::{cell::RefCell, marker::PhantomData};
 use js_sys::Function as JsFunction;
 use wasm_bindgen::JsValue;
 
+/// Wrapper for JS function with no arguments.
+#[derive(Default)]
+pub struct Callback0 {
+    f: RefCell<Option<JsFunction>>,
+}
+
+impl Callback0 {
+    /// Sets inner JS function.
+    #[inline]
+    pub fn set_func(&self, f: JsFunction) {
+        self.f.borrow_mut().replace(f);
+    }
+
+    /// Invokes JS function if any.
+    ///
+    /// Returns `None` if no callback is set, otherwise returns its invocation
+    /// result.
+    pub fn call(&self) -> Option<Result<JsValue, JsValue>> {
+        self.f.borrow().as_ref().map(|f| f.call0(&JsValue::NULL))
+    }
+
+    /// Indicates if callback is set.
+    #[inline]
+    pub fn is_set(&self) -> bool {
+        self.f.borrow().as_ref().is_some()
+    }
+}
+
 /// Wrapper for a single argument JS function.
-pub struct Callback<A> {
+pub struct Callback1<A> {
     f: RefCell<Option<JsFunction>>,
     _arg: PhantomData<A>,
 }
 
-impl<A> Default for Callback<A> {
+impl<A> Default for Callback1<A> {
     #[inline]
     fn default() -> Self {
         Self {
@@ -21,7 +49,7 @@ impl<A> Default for Callback<A> {
     }
 }
 
-impl<A: Into<JsValue>> Callback<A> {
+impl<A: Into<JsValue>> Callback1<A> {
     /// Sets inner JS function.
     #[inline]
     pub fn set_func(&self, f: JsFunction) {
@@ -46,7 +74,7 @@ impl<A: Into<JsValue>> Callback<A> {
     }
 }
 
-impl<A> From<JsFunction> for Callback<A> {
+impl<A> From<JsFunction> for Callback1<A> {
     #[inline]
     fn from(f: JsFunction) -> Self {
         Self {

--- a/jason/src/utils/mod.rs
+++ b/jason/src/utils/mod.rs
@@ -18,7 +18,7 @@ use web_sys::Window;
 
 #[doc(inline)]
 pub use self::{
-    callback::{Callback, Callback2},
+    callback::{Callback0, Callback1, Callback2},
     errors::{
         console_error, HandlerDetachedError, JasonError, JsCaused, JsError,
         JsonParseError,

--- a/jason/tests/api/connection.rs
+++ b/jason/tests/api/connection.rs
@@ -1,0 +1,127 @@
+#![cfg(target_arch = "wasm32")]
+
+use futures::channel::oneshot;
+use medea_client_api_proto::{
+    Direction, MediaType, PeerId, Track, TrackId, VideoSettings,
+};
+use medea_jason::{
+    api::{ConnectionHandle, Connections},
+    media::{MediaManager, MediaStreamTrack},
+    peer::RemoteMediaStream,
+    AudioTrackConstraints, DeviceVideoTrackConstraints, MediaStreamSettings,
+};
+use wasm_bindgen::{closure::Closure, JsValue};
+use wasm_bindgen_test::*;
+
+use crate::{timeout, wait_and_check_test_result};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn proto_recv_video_track() -> Track {
+    Track {
+        id: TrackId(1),
+        direction: Direction::Recv {
+            sender: PeerId(234),
+            mid: None,
+        },
+        media_type: MediaType::Video(VideoSettings { is_required: false }),
+    }
+}
+
+async fn get_video_track() -> MediaStreamTrack {
+    let manager = MediaManager::default();
+    let mut settings = MediaStreamSettings::new();
+    settings.device_video(DeviceVideoTrackConstraints::new());
+    let (stream, _) = manager.get_stream(settings).await.unwrap();
+    stream.into_tracks().into_iter().next().unwrap()
+}
+
+async fn get_audio_track() -> MediaStreamTrack {
+    let manager = MediaManager::default();
+    let mut settings = MediaStreamSettings::new();
+    settings.audio(AudioTrackConstraints::new());
+    let (stream, _) = manager.get_stream(settings).await.unwrap();
+    stream.into_tracks().into_iter().next().unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn on_new_connection_fires() {
+    let cons = Connections::default();
+
+    let (cb, test_result) = js_callback!(|handle: ConnectionHandle| {
+        cb_assert_eq!(handle.get_remote_id().unwrap(), 234);
+    });
+    cons.on_new_connection(cb.into());
+
+    cons.create_connections_from_tracks(PeerId(1), &[proto_recv_video_track()]);
+
+    wait_and_check_test_result(test_result, || {}).await;
+}
+
+#[wasm_bindgen_test]
+async fn on_remote_stream_fires() {
+    let cons = Connections::default();
+
+    cons.create_connections_from_tracks(PeerId(1), &[proto_recv_video_track()]);
+
+    let con = cons.get(PeerId(234)).unwrap();
+    let con_handle = con.new_handle();
+
+    let (cb, test_result) = js_callback!(|stream: RemoteMediaStream| {
+        cb_assert_eq!(
+            stream
+                .get_media_stream()
+                .unwrap()
+                .get_video_tracks()
+                .length(),
+            1
+        );
+    });
+    con_handle.on_remote_stream(cb.into()).unwrap();
+
+    con.add_remote_track(TrackId(1), get_video_track().await);
+
+    wait_and_check_test_result(test_result, || {}).await;
+}
+
+#[wasm_bindgen_test]
+async fn tracks_are_added_to_remote_stream() {
+    let cons = Connections::default();
+
+    cons.create_connections_from_tracks(PeerId(1), &[proto_recv_video_track()]);
+
+    let con = cons.get(PeerId(234)).unwrap();
+    let con_handle = con.new_handle();
+
+    let (tx, rx) = oneshot::channel();
+    let closure = Closure::once_into_js(move |stream: RemoteMediaStream| {
+        assert!(tx.send(stream).is_ok());
+    });
+    con_handle.on_remote_stream(closure.into()).unwrap();
+
+    con.add_remote_track(TrackId(1), get_video_track().await);
+
+    let stream = timeout(100, rx).await.unwrap().unwrap();
+    let stream = stream.get_media_stream().unwrap();
+    assert_eq!(stream.get_tracks().length(), 1);
+
+    con.add_remote_track(TrackId(2), get_audio_track().await);
+    assert_eq!(stream.get_tracks().length(), 2);
+}
+
+#[wasm_bindgen_test]
+async fn on_closed_fires() {
+    let cons = Connections::default();
+    cons.create_connections_from_tracks(PeerId(1), &[proto_recv_video_track()]);
+    let con = cons.get(PeerId(234)).unwrap();
+    let con_handle = con.new_handle();
+
+    let (on_close, test_result) = js_callback!(|nothing: JsValue| {
+        cb_assert_eq!(nothing.is_undefined(), true);
+    });
+    con_handle.on_close(on_close.into()).unwrap();
+
+    cons.close_connection(PeerId(1));
+
+    wait_and_check_test_result(test_result, || {}).await;
+}

--- a/jason/tests/api/mod.rs
+++ b/jason/tests/api/mod.rs
@@ -1,1 +1,2 @@
+mod connection;
 mod room;


### PR DESCRIPTION
Related to #27

## Synopsis

В данный момент клиент не знает когда отваливается его Connection с удаленным Member'ом. Например:
1. Сценарий 1к1
2. Один из пользователей отключается
3. Второму пользователю мы отправляем `PeersRemoved` event, но клиентское приложение никак не узанет что коннекшен закрыт.

## Solution

Add `ConnectionHandle.on_close` callback.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `WIP: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [x] `WIP: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
