### PR TITLE
Upgrade stable Rust to 1.45 version 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ MEDEA_IMAGE_NAME := $(strip \
 DEMO_IMAGE_NAME := instrumentisto/medea-demo
 CONTROL_MOCK_IMAGE_NAME := instrumentisto/medea-control-api-mock
 
-RUST_VER := 1.44
+RUST_VER := 1.45
 CHROME_VERSION := 83.0
 FIREFOX_VERSION := 78.0.2
 
@@ -274,9 +274,7 @@ endif
 #	make cargo.lint
 
 cargo.lint:
-	cargo clippy --all -- -D clippy::pedantic -D warnings \
-		-A clippy::used_underscore_binding
-# TODO: Enable ignored lints when Rust 1.45 is released.
+	cargo clippy --all -- -D clippy::pedantic -D warnings
 
 
 

--- a/jason/src/peer/mod.rs
+++ b/jason/src/peer/mod.rs
@@ -476,7 +476,7 @@ impl PeerConnection {
             S::Failed => IceConnectionState::Failed,
             S::Disconnected => IceConnectionState::Disconnected,
             S::Closed => IceConnectionState::Closed,
-            _ => {
+            S::__Nonexhaustive => {
                 console_error("Unknown ICE connection state");
                 return;
             }

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -332,7 +332,7 @@ impl TrackChange {
     fn as_new_track(&self, partner_peer_id: Id) -> Option<Track> {
         match self.as_track_update(partner_peer_id) {
             TrackUpdate::Added(track) => Some(track),
-            _ => None,
+            TrackUpdate::Updated(_) => None,
         }
     }
 


### PR DESCRIPTION
## Synopsis

Rust 1.45 is stable.




## Solution

Upgrade to Rust 1.45.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `WIP: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [x] `WIP: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
