### PR TITLE
Apply changes to remote Peer regardless of Peer state (#27)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
  "pin-project",
  "rand 0.7.3",
  "regex",
- "serde 1.0.114",
+ "serde 1.0.115",
  "serde_json",
  "serde_urlencoded",
  "sha1",
@@ -148,7 +148,7 @@ dependencies = [
  "http",
  "log",
  "regex",
- "serde 1.0.114",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "actix-service"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e4fc95dfa7e24171b2d0bb46b85f8ab0e8499e4e3caec691fc4ea65c287564"
+checksum = "0052435d581b5be835d11f4eb3bce417c8af18d87ddf8ace99f8e67e595882bb"
 dependencies = [
  "futures-util",
  "pin-project",
@@ -288,7 +288,7 @@ dependencies = [
  "net2",
  "pin-project",
  "regex",
- "serde 1.0.114",
+ "serde 1.0.115",
  "serde_json",
  "serde_urlencoded",
  "time",
@@ -452,9 +452,9 @@ checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-trait"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
+checksum = "caae68055714ff28740f310927e04f2eba76ff580b16fb18ed90073ee71646f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -502,7 +502,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "rand 0.7.3",
- "serde 1.0.114",
+ "serde 1.0.115",
  "serde_json",
  "serde_urlencoded",
 ]
@@ -560,7 +560,7 @@ dependencies = [
  "atomic-waker",
  "futures-lite",
  "once_cell",
- "parking",
+ "parking 1.0.6",
  "waker-fn",
 ]
 
@@ -704,7 +704,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.114",
+ "serde 1.0.115",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -859,7 +859,7 @@ dependencies = [
  "config",
  "crossbeam-queue",
  "num_cpus",
- "serde 1.0.114",
+ "serde 1.0.115",
  "tokio",
 ]
 
@@ -875,7 +875,7 @@ dependencies = [
  "futures 0.3.5",
  "log",
  "redis",
- "serde 1.0.114",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -961,9 +961,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "either"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "encoding_rs"
@@ -976,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4bfcfacb61d231109d1d55202c1f33263319668b168843e02ad4652725ec9c"
+checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -988,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68082183f458867ce7cddea16d4df4443c1537112c0c09c450dedc09daf5c719"
+checksum = "7f14646a9e0430150a87951622ba9675472b68e384b7701b8423b30560805c7a"
 
 [[package]]
 name = "failure"
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a9cb09840f81cd211e435d00a4e487edd263dc3c8ff815c32dd76ad668ebed"
+checksum = "4bd3bdaaf0a72155260a1c098989b60db1cbb22d6a628e64f16237aa4da93cc7"
 
 [[package]]
 name = "fixedbitset"
@@ -1137,15 +1137,15 @@ checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-lite"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe71459749b2e8e66fb95df721b22fa08661ad384a0c5b519e11d3893b4692a"
+checksum = "97999970129b808f0ccba93211201d431fcc12d7e1ffae03a61b5cedd1a7ced2"
 dependencies = [
  "fastrand",
  "futures-core",
  "futures-io",
  "memchr",
- "parking",
+ "parking 2.0.0",
  "pin-project-lite",
  "waker-fn",
 ]
@@ -1251,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
 dependencies = [
  "autocfg",
 ]
@@ -1327,7 +1327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c57351e2c81b7a03e82a6c8f4198b309c158f6d67c4adb707af6af7d91465a"
 dependencies = [
  "humantime",
- "serde 1.0.114",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -1373,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
+checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1584,7 +1584,7 @@ dependencies = [
  "rand 0.7.3",
  "redis",
  "rust-crypto",
- "serde 1.0.114",
+ "serde 1.0.115",
  "serde_json",
  "serde_yaml",
  "serial_test",
@@ -1610,7 +1610,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "medea-macro",
- "serde 1.0.114",
+ "serde 1.0.115",
  "serde_json",
  "serde_with",
 ]
@@ -1630,7 +1630,7 @@ dependencies = [
  "humantime-serde",
  "medea-control-api-proto",
  "protobuf",
- "serde 1.0.114",
+ "serde 1.0.115",
  "serde_json",
  "slog",
  "slog-async",
@@ -1683,7 +1683,7 @@ dependencies = [
  "medea-reactive",
  "mockall",
  "predicates-tree",
- "serde 1.0.114",
+ "serde 1.0.115",
  "serde_json",
  "tracerr",
  "wasm-bindgen",
@@ -1910,6 +1910,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb300f271742d4a2a66c01b6b2fa0c83dfebd2e0bf11addb879a3547b4ed87c"
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.16.2"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d883f78645c21b7281d21305181aa1f4dd9e9363e7cf2566c93121552cff003e"
+checksum = "cb14183cc7f213ee2410067e1ceeadba2a7478a59432ff0747a335202798b1e2"
 
 [[package]]
 name = "quick-error"
@@ -2377,9 +2383,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
 dependencies = [
  "serde_derive",
 ]
@@ -2399,9 +2405,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2416,7 +2422,7 @@ checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.114",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -2436,7 +2442,7 @@ checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
  "dtoa",
  "itoa",
- "serde 1.0.114",
+ "serde 1.0.115",
  "url",
 ]
 
@@ -2446,7 +2452,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d3d595d64120bbbc70b7f6d5ae63298b62a3d9f373ec2f56acf5365ca8a444"
 dependencies = [
- "serde 1.0.114",
+ "serde 1.0.115",
  "serde_with_macros",
 ]
 
@@ -2469,7 +2475,7 @@ checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
 dependencies = [
  "dtoa",
  "linked-hash-map 0.5.3",
- "serde 1.0.114",
+ "serde 1.0.115",
  "yaml-rust",
 ]
 
@@ -2557,7 +2563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
 dependencies = [
  "chrono",
- "serde 1.0.114",
+ "serde 1.0.115",
  "serde_json",
  "slog",
 ]
@@ -2600,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "smart-default"
@@ -2829,7 +2835,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
- "serde 1.0.114",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -3063,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0aae59226cf195d8e74d4b34beae1859257efb4e5fed3f147d2dc2c7d372178"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
  "cfg-if",
  "log",
@@ -3075,9 +3081,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
+checksum = "1fe233f4227389ab7df5b32649239da7ebe0b281824b4e84b342d04d3fd8c25e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3086,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d593f98af59ebc017c0648f0117525db358745a8894a8d684e185ba3f45954f9"
+checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
 dependencies = [
  "lazy_static",
 ]
@@ -3242,7 +3248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
 dependencies = [
  "cfg-if",
- "serde 1.0.114",
+ "serde 1.0.115",
  "serde_json",
  "wasm-bindgen-macro",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,16 +401,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-std"
-version = "1.6.2"
+name = "async-executor"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d68a33ebc8b57800847d00787307f84a562224a14db069b0acefe4c2abbf5d"
+checksum = "90f47c78ea98277cb1f5e6f60ba4fc762f5eafe9f6511bc2f7dfd8b75c225650"
 dependencies = [
+ "async-io",
+ "futures-lite",
+ "multitask",
+ "parking 1.0.6",
+ "scoped-tls",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae22a338d28c75b53702b66f77979062cb29675db376d99e451af4fa79dedb3"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "once_cell",
+ "parking 2.0.0",
+ "polling",
+ "socket2",
+ "vec-arena",
+ "wepoll-sys-stjepang",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20e85981fc34e84cdff3fc2c9219189752633fdc538a06df8b5ac45b68a4f3a9"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-std"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c8da367da62b8ff2313c406c9ac091c1b31d67a165becdd2de380d846260f7"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "async-mutex",
  "async-task",
+ "blocking",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-lite",
  "kv-log-macro",
  "log",
  "memchr",
@@ -419,7 +466,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
- "smol",
  "wasm-bindgen-futures",
 ]
 
@@ -552,15 +598,14 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2468ff7bf85066b4a3678fede6fe66db31846d753ff0adfbfab2c6a6e81612b"
+checksum = "76e94bf99b692f54c9d05f97454d3faf11134523fe5b180564a3fb6ed63bcc0a"
 dependencies = [
  "async-channel",
  "atomic-waker",
  "futures-lite",
  "once_cell",
- "parking 1.0.6",
  "waker-fn",
 ]
 
@@ -642,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.2"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",
@@ -1826,6 +1871,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 
 [[package]]
+name = "multitask"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c09c35271e7dcdb5f709779111f2c8e8ab8e06c1b587c1c6a9e179d865aaa5b4"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2068,18 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "polling"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d83023eb990619815bb41b45625b02da62b00d0f24b0a08aae37697b3f6c94"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wepoll-sys-stjepang",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2622,27 +2690,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smol"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620cbb3c6e34da57d3a248cda0cd01cd5848164dc062e764e65d06fe3ea7aed5"
-dependencies = [
- "async-task",
- "blocking",
- "concurrent-queue",
- "fastrand",
- "futures-io",
- "futures-util",
- "libc",
- "once_cell",
- "scoped-tls",
- "slab",
- "socket2",
- "wepoll-sys-stjepang",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "socket2"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3206,6 +3253,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "vec-arena"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17dfb54bf57c9043f4616cb03dab30eff012cc26631b797d8354b916708db919"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.1"
+version = "2.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
 dependencies = [
  "ansi_term",
  "atty",
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ff9c66992ebea984b9446b2a45b300947216c17544ec9d7f045afe24333cd0"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
 ]
@@ -988,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.3.0"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298f00c3b04c1d9b4cb86aefaaa35348af0957d98b30a5306fc635f8e718923d"
+checksum = "68082183f458867ce7cddea16d4df4443c1537112c0c09c450dedc09daf5c719"
 
 [[package]]
 name = "failure"
@@ -2503,9 +2503,9 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
 dependencies = [
  "arc-swap",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,9 +391,9 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "async-channel"
-version = "1.1.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee81ba99bee79f3c8ae114ae4baa7eaa326f63447cf2ec65e4393618b63f8770"
+checksum = "e164690d07eca7d0cb5921ee86b3276cd7d561ae7d613abd2ac1ce54fb2fc0a8"
 dependencies = [
  "concurrent-queue",
  "event-listener",

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -376,6 +376,7 @@ pub struct TrackPatch {
 
 impl TrackPatch {
     /// Returns new empty [`TrackPatch`] with a provided [`TrackId`].
+    #[inline]
     #[must_use]
     pub fn new(id: TrackId) -> Self {
         Self { id, is_muted: None }

--- a/src/api/client/rpc_connection.rs
+++ b/src/api/client/rpc_connection.rs
@@ -56,8 +56,7 @@ pub trait RpcConnection: fmt::Debug + Send {
     /// Sends [`Event`] to remote [`Member`].
     ///
     /// [`Member`]: crate::signalling::elements::member::Member
-    fn send_event(&self, msg: Event)
-        -> LocalBoxFuture<'static, Result<(), ()>>;
+    fn send_event(&self, msg: Event);
 }
 
 /// Settings of [`WsSession`].

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -35,13 +35,7 @@ pub trait RpcServer: Debug + Send {
     ) -> LocalBoxFuture<'static, ()>;
 
     /// Sends [`Command`].
-    ///
-    /// [`Command`]:
-    fn send_command(
-        &self,
-        member_id: MemberId,
-        msg: Command,
-    ) -> LocalBoxFuture<'static, ()>;
+    fn send_command(&self, member_id: MemberId, msg: Command);
 }
 
 #[cfg(test)]

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -8,8 +8,7 @@ pub mod track;
 pub use self::{
     ice_user::{IceUser, IceUsername},
     peer::{
-        Peer, PeerError, PeerStateMachine, Stable, WaitLocalHaveRemote,
-        WaitLocalSdp, WaitRemoteSdp,
+        Peer, PeerError, PeerStateMachine, Stable, WaitLocalSdp, WaitRemoteSdp,
     },
     track::MediaTrack,
 };

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -42,7 +42,7 @@
 //! # Applying changes regardless of [`Peer`] state
 //!
 //! Sometimes you may want to apply changes immediately, and perform
-//! renegotiation later. In this case you would call
+//! renegotiation later. In this case you should call
 //! [`PeerStateMachine::force_commit_scheduled_changes`]`.
 //!
 //! [1]: https://www.w3.org/TR/webrtc/#rtcpeerconnection-interface
@@ -138,7 +138,7 @@ impl PeerError {
 
 /// Implementation of [`Peer`] state machine.
 ///
-/// State transitions scheme:
+/// # State transitions scheme
 ///
 /// ```text
 /// +---------------+                   +-----------------+

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -107,7 +107,7 @@ pub trait PeerUpdatesSubscriber: fmt::Debug {
     /// state, otherwise only forced [`TrackChange`]s will be sent.
     fn negotiation_needed(&self, peer_id: PeerId);
 
-    /// Forcebly updates [`Peer`] without renegotiation.
+    /// Forcibly updates [`Peer`] without renegotiation.
     fn force_update(&self, peer_id: PeerId, changes: Vec<TrackUpdate>);
 }
 

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -682,7 +682,9 @@ impl Peer<Stable> {
     }
 
     /// Transition new [`Peer`] into state of waiting for local description.
-    pub fn start(self) -> Peer<WaitLocalSdp> {
+    pub fn start(mut self) -> Peer<WaitLocalSdp> {
+        self.negotiation_started();
+
         Peer {
             context: self.context,
             state: WaitLocalSdp {},
@@ -691,15 +693,23 @@ impl Peer<Stable> {
 
     /// Transition new [`Peer`] into state of waiting for remote description.
     pub fn set_remote_sdp(
-        self,
+        mut self,
         sdp_offer: String,
     ) -> Peer<WaitLocalHaveRemote> {
+        self.negotiation_started();
+
         let mut context = self.context;
         context.sdp_offer = Some(sdp_offer);
         Peer {
             context,
             state: WaitLocalHaveRemote {},
         }
+    }
+
+    /// This method will be called everytime when [`Peer`] goes from [`Stable`]
+    /// state into any other state.
+    fn negotiation_started(&mut self) {
+        self.context.is_forcebly_updated = false;
     }
 
     /// Returns [mid]s of this [`Peer`].
@@ -732,11 +742,12 @@ impl Peer<Stable> {
     /// Resets [`Context::sdp_offer`] and [`Context::sdp_answer`].
     ///
     /// [SDP]: https://tools.ietf.org/html/rfc4317
-    pub fn start_negotiation(self) -> Peer<WaitLocalSdp> {
+    pub fn start_negotiation(mut self) -> Peer<WaitLocalSdp> {
+        self.negotiation_started();
+
         let mut context = self.context;
         context.sdp_answer = None;
         context.sdp_offer = None;
-        context.is_forcebly_updated = false;
 
         Peer {
             context,

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -454,9 +454,25 @@ impl<T> TrackChangeHandler for Peer<T> {
         self.context.receivers.insert(track.id, track);
     }
 
-    /// Does nothing.
+    /// Removes all opposite to the provided [`TrackPatch`]es from the
+    /// [`Context::pending_track_updates`].
     #[inline]
-    fn on_track_patch(&mut self, _: TrackPatch) {}
+    fn on_track_patch(&mut self, patch: TrackPatch) {
+        self.context.pending_track_updates =
+            std::mem::take(&mut self.context.pending_track_updates)
+                .into_iter()
+                .filter(|t| {
+                    if let TrackChange::TrackPatch(p) = t {
+                        patch.is_opposite(&p) || p != &patch
+                    } else {
+                        true
+                    }
+                })
+                .collect();
+        self.context
+            .pending_track_updates
+            .push(TrackChange::TrackPatch(patch));
+    }
 }
 
 /// [RTCPeerConnection] representation.
@@ -880,29 +896,11 @@ pub struct PeerChangesScheduler<'a> {
 impl<'a> PeerChangesScheduler<'a> {
     /// Schedules provided [`TrackPatch`]s.
     ///
-    /// Removes all opposite to the provided [`TrackPatch`]es from the
-    /// [`Context::pending_track_updates`].
-    ///
     /// Provided [`TrackPatch`]s will be sent to the client on (re)negotiation.
     pub fn patch_tracks(&mut self, patches: Vec<TrackPatch>) {
-        let mut pending_track_updates =
-            std::mem::take(&mut self.context.pending_track_updates);
-
         for patch in patches {
-            pending_track_updates = pending_track_updates
-                .into_iter()
-                .filter(|t| {
-                    if let TrackChange::TrackPatch(p) = t {
-                        patch.is_opposite(&p) && p != &patch
-                    } else {
-                        true
-                    }
-                })
-                .collect();
             self.schedule_change(TrackChange::TrackPatch(patch));
         }
-
-        self.context.pending_track_updates = pending_track_updates;
     }
 
     /// Schedules `send` tracks adding to `self` and `recv` tracks for this

--- a/src/signalling/peers/mod.rs
+++ b/src/signalling/peers/mod.rs
@@ -756,8 +756,7 @@ mod tests {
         }
 
         /// Returns [`Stream`] into which will be sent all [`PeerId`]s and
-        /// [`TrackUpdate`]s of [`Peer`] which are should be forcibly
-        /// updated.
+        /// [`TrackUpdate`]s of [`Peer`] which are should be forcibly updated.
         #[allow(dead_code)]
         pub fn on_force_update(
             &self,

--- a/src/signalling/peers/mod.rs
+++ b/src/signalling/peers/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     api::control::{MemberId, RoomId},
     conf,
     log::prelude::*,
-    media::{peer::NegotiationSubscriber, Peer, PeerError, PeerStateMachine},
+    media::{peer::PeerUpdatesSubscriber, Peer, PeerError, PeerStateMachine},
     signalling::{
         elements::endpoints::{
             webrtc::{WebRtcPlayEndpoint, WebRtcPublishEndpoint},
@@ -80,7 +80,7 @@ pub struct PeersService {
 
     /// Subscriber to the events which indicates that negotiation process
     /// should be started for a some [`Peer`].
-    negotiation_sub: Rc<dyn NegotiationSubscriber>,
+    negotiation_sub: Rc<dyn PeerUpdatesSubscriber>,
 }
 
 /// Simple ID counter.
@@ -126,7 +126,7 @@ impl PeersService {
         turn_service: Arc<dyn TurnAuthService>,
         peers_traffic_watcher: Arc<dyn PeerTrafficWatcher>,
         media_conf: &conf::Media,
-        negotiation_sub: Rc<dyn NegotiationSubscriber>,
+        negotiation_sub: Rc<dyn PeerUpdatesSubscriber>,
     ) -> Rc<Self> {
         Rc::new(Self {
             room_id: room_id.clone(),
@@ -729,7 +729,7 @@ mod tests {
 
     use super::*;
 
-    /// Mock for the [`NegotiationSubscriber`] trait.
+    /// Mock for the [`PeerUpdatesSubscriber`] trait.
     ///
     /// You can subscribe to the [`Stream`] into which will be sent all
     /// [`PeerId`]s of [`Peer`] which are should be renegotiated.
@@ -756,7 +756,7 @@ mod tests {
         }
 
         /// Returns [`Stream`] into which will be sent all [`PeerId`]s and
-        /// [`TrackUpdate`]s of [`Peer`] which are should be forcebly
+        /// [`TrackUpdate`]s of [`Peer`] which are should be forcibly
         /// updated.
         pub fn on_force_update(
             &self,
@@ -769,7 +769,7 @@ mod tests {
         }
     }
 
-    impl NegotiationSubscriber for NegotiationSubMock {
+    impl PeerUpdatesSubscriber for NegotiationSubMock {
         /// Sends [`PeerId`] to the
         /// [`NegotiationSubMock::on_negotiation_needed`] [`Stream`].
         fn negotiation_needed(&self, peer_id: PeerId) {

--- a/src/signalling/room/command_handler.rs
+++ b/src/signalling/room/command_handler.rs
@@ -3,7 +3,6 @@
 
 use std::collections::HashMap;
 
-use actix::WrapFuture as _;
 use medea_client_api_proto::{
     CommandHandler, Event, IceCandidate, NegotiationRole, PeerId, PeerMetrics,
     TrackId, TrackPatch,
@@ -11,16 +10,13 @@ use medea_client_api_proto::{
 
 use crate::{
     log::prelude::*,
-    media::{
-        Peer, PeerStateMachine, Stable, WaitLocalHaveRemote, WaitLocalSdp,
-        WaitRemoteSdp,
-    },
+    media::{Peer, PeerStateMachine, WaitLocalSdp, WaitRemoteSdp},
 };
 
-use super::{ActFuture, Room, RoomError};
+use super::{Room, RoomError};
 
 impl CommandHandler for Room {
-    type Output = Result<ActFuture<Result<(), RoomError>>, RoomError>;
+    type Output = Result<(), RoomError>;
 
     /// Sends [`Event::PeerCreated`] to provided [`Peer`] partner. Provided
     /// [`Peer`] state must be [`WaitLocalSdp`] and will be changed to
@@ -35,14 +31,14 @@ impl CommandHandler for Room {
     ) -> Self::Output {
         let mut from_peer: Peer<WaitLocalSdp> =
             self.peers.take_inner_peer(from_peer_id)?;
+        let to_peer: Peer<WaitRemoteSdp> =
+            self.peers.take_inner_peer(from_peer.partner_peer_id())?;
+
         from_peer.set_mids(mids)?;
         from_peer.update_senders_statuses(senders_statuses);
 
-        let to_peer_id = from_peer.partner_peer_id();
-        let to_peer: Peer<Stable> = self.peers.take_inner_peer(to_peer_id)?;
-
-        let from_peer = from_peer.set_local_sdp(sdp_offer.clone());
-        let to_peer = to_peer.set_remote_sdp(sdp_offer.clone());
+        let from_peer = from_peer.set_local_offer(sdp_offer.clone());
+        let to_peer = to_peer.set_remote_offer(sdp_offer.clone());
 
         let to_member_id = to_peer.member_id();
         let ice_servers = to_peer.ice_servers_list().ok_or_else(|| {
@@ -51,7 +47,7 @@ impl CommandHandler for Room {
 
         let event = if from_peer.is_known_to_remote() {
             Event::TracksApplied {
-                peer_id: to_peer_id,
+                peer_id: to_peer.id(),
                 negotiation_role: Some(NegotiationRole::Answerer(sdp_offer)),
                 updates: to_peer.get_updates(),
             }
@@ -70,11 +66,7 @@ impl CommandHandler for Room {
 
         self.peers.sync_peer_spec(from_peer_id)?;
 
-        Ok(Box::new(
-            self.members
-                .send_event_to_member(to_member_id, event)
-                .into_actor(self),
-        ))
+        self.members.send_event_to_member(to_member_id, event)
     }
 
     /// Sends [`Event::SdpAnswerMade`] to provided [`Peer`] partner. Provided
@@ -87,20 +79,19 @@ impl CommandHandler for Room {
         sdp_answer: String,
         senders_statuses: HashMap<TrackId, bool>,
     ) -> Self::Output {
-        let from_peer: Peer<WaitLocalHaveRemote> =
+        let from_peer: Peer<WaitLocalSdp> =
             self.peers.take_inner_peer(from_peer_id)?;
+        let to_peer: Peer<WaitRemoteSdp> =
+            self.peers.take_inner_peer(from_peer.partner_peer_id())?;
+
         from_peer.update_senders_statuses(senders_statuses);
 
-        let to_peer_id = from_peer.partner_peer_id();
-        let to_peer: Peer<WaitRemoteSdp> =
-            self.peers.take_inner_peer(to_peer_id)?;
-
-        let from_peer = from_peer.set_local_sdp(sdp_answer.clone());
-        let to_peer = to_peer.set_remote_sdp(&sdp_answer);
+        let from_peer = from_peer.set_local_answer(sdp_answer.clone());
+        let to_peer = to_peer.set_remote_answer(sdp_answer.clone());
 
         let to_member_id = to_peer.member_id();
         let event = Event::SdpAnswerMade {
-            peer_id: to_peer_id,
+            peer_id: to_peer.id(),
             sdp_answer,
         };
 
@@ -109,11 +100,7 @@ impl CommandHandler for Room {
 
         self.peers.sync_peer_spec(from_peer_id)?;
 
-        Ok(Box::new(
-            self.members
-                .send_event_to_member(to_member_id, event)
-                .into_actor(self),
-        ))
+        self.members.send_event_to_member(to_member_id, event)
     }
 
     /// Sends [`Event::IceCandidateDiscovered`] to provided [`Peer`] partner.
@@ -126,7 +113,7 @@ impl CommandHandler for Room {
         // TODO: add E2E test
         if candidate.candidate.is_empty() {
             warn!("Empty candidate from Peer: {}, ignoring", from_peer_id);
-            return Ok(Box::new(actix::fut::ok(())));
+            return Ok(());
         }
 
         let to_peer_id = self
@@ -140,11 +127,7 @@ impl CommandHandler for Room {
             candidate,
         };
 
-        Ok(Box::new(
-            self.members
-                .send_event_to_member(to_member_id, event)
-                .into_actor(self),
-        ))
+        self.members.send_event_to_member(to_member_id, event)
     }
 
     /// Does nothing atm.
@@ -153,7 +136,7 @@ impl CommandHandler for Room {
         _: PeerId,
         _: PeerMetrics,
     ) -> Self::Output {
-        Ok(Box::new(actix::fut::ok(())))
+        Ok(())
     }
 
     /// Sends [`Event::TracksApplied`] with data from the received
@@ -171,14 +154,14 @@ impl CommandHandler for Room {
             self.peers.map_peer_by_id_mut(peer_id, |peer| {
                 peer.as_changes_scheduler()
                     .patch_tracks(tracks_patches.clone());
+                peer.force_commit_scheduled_changes();
                 peer.partner_peer_id()
             })?;
         self.peers.map_peer_by_id_mut(partner_peer_id, |peer| {
             peer.as_changes_scheduler().patch_tracks(tracks_patches);
+            peer.commit_scheduled_changes();
         })?;
 
-        self.peers.commit_scheduled_changes(peer_id)?;
-
-        Ok(Box::new(actix::fut::ok(())))
+        Ok(())
     }
 }

--- a/src/signalling/room/command_handler.rs
+++ b/src/signalling/room/command_handler.rs
@@ -150,10 +150,10 @@ impl CommandHandler for Room {
         peer_id: PeerId,
         tracks_patches: Vec<TrackPatch>,
     ) -> Self::Output {
-        // note that we force committing changes to Member that send
-        // UpdateTracks request so, response will be sent immediately,
-        // regardless of that Peer state, but non-foricbly commiting
-        // changes to partner Peer, so it will be notified of changes only
+        // Note, that we force committing changes to `Member` that send
+        // `UpdateTracks` request, so response will be sent immediately,
+        // regardless of that `Peer` state, but non-forcibly committing
+        // changes to partner `Peer`, so it will be notified of changes only
         // during next negotiation.
         let partner_peer_id =
             self.peers.map_peer_by_id_mut(peer_id, |peer| {

--- a/src/signalling/room/command_handler.rs
+++ b/src/signalling/room/command_handler.rs
@@ -150,6 +150,11 @@ impl CommandHandler for Room {
         peer_id: PeerId,
         tracks_patches: Vec<TrackPatch>,
     ) -> Self::Output {
+        // note that we force committing changes to Member that send
+        // UpdateTracks request so, response will be sent immediately,
+        // regardless of that Peer state, but non-foricbly commiting
+        // changes to partner Peer, so it will be notified of changes only
+        // during next negotiation.
         let partner_peer_id =
             self.peers.map_peer_by_id_mut(peer_id, |peer| {
                 peer.as_changes_scheduler()

--- a/src/signalling/room/mod.rs
+++ b/src/signalling/room/mod.rs
@@ -28,7 +28,7 @@ use crate::{
         MemberId, RoomId,
     },
     log::prelude::*,
-    media::{peer::NegotiationSubscriber, Peer, PeerError, Stable},
+    media::{peer::PeerUpdatesSubscriber, Peer, PeerError, Stable},
     shutdown::ShutdownGracefully,
     signalling::{
         elements::{member::MemberError, Member, MembersLoadError},
@@ -168,7 +168,7 @@ impl Room {
                 peers_traffic_watcher,
                 &context.config.media,
                 Rc::new(ctx.address().downgrade())
-                    as Rc<dyn NegotiationSubscriber>,
+                    as Rc<dyn PeerUpdatesSubscriber>,
             ),
             members: ParticipantService::new(room_spec, context)?,
             state: State::Started,

--- a/src/signalling/room/peer_events_handler.rs
+++ b/src/signalling/room/peer_events_handler.rs
@@ -223,6 +223,11 @@ impl Handler<NegotiationNeeded> for Room {
                 self.send_peer_created(peer_id)
             }
         } else {
+            actix_try!(self.peers.map_peer_by_id_mut(
+                msg.0,
+                PeerStateMachine::commit_force_changes
+            ));
+
             Box::new(fut::ok(()))
         }
     }

--- a/src/signalling/room/rpc_server.rs
+++ b/src/signalling/room/rpc_server.rs
@@ -119,18 +119,8 @@ impl RpcServer for Addr<Room> {
     }
 
     /// Sends [`CommandMessage`] message to [`Room`] actor ignoring any errors.
-    fn send_command(
-        &self,
-        member_id: MemberId,
-        msg: Command,
-    ) -> LocalBoxFuture<'static, ()> {
-        self.send(CommandMessage::new(member_id, msg))
-            .map(|res| {
-                if let Err(e) = res {
-                    error!("Failed to send CommandMessage cause {:?}", e);
-                }
-            })
-            .boxed_local()
+    fn send_command(&self, member_id: MemberId, msg: Command) {
+        self.do_send(CommandMessage::new(member_id, msg));
     }
 }
 

--- a/tests/e2e/signalling/add_endpoints_synchronization.rs
+++ b/tests/e2e/signalling/add_endpoints_synchronization.rs
@@ -1,7 +1,7 @@
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 use futures::{channel::mpsc, StreamExt};
-use medea_client_api_proto::{Command, Direction, Event, TrackUpdate};
+use medea_client_api_proto::{Direction, Event, TrackUpdate};
 use medea_control_api_proto::grpc::api::{self as proto};
 use tokio::time::delay_for;
 
@@ -10,7 +10,7 @@ use crate::{
         ControlClient, MemberBuilder, RoomBuilder, WebRtcPlayEndpointBuilder,
         WebRtcPublishEndpointBuilder,
     },
-    signalling::{SendCommand, TestMember},
+    signalling::{handle_peer_created, TestMember},
 };
 
 /// Creates Room with two Member's with `WebRtcPublishEndpoint`'s.
@@ -101,7 +101,7 @@ async fn add_endpoints_synchronization() {
     loop {
         if let Event::PeerCreated {
             peer_id,
-            negotiation_role: _,
+            negotiation_role,
             tracks,
             ..
         } = second_rx.select_next_some().await
@@ -127,18 +127,10 @@ async fn add_endpoints_synchronization() {
             assert_eq!(count_send_tracks, 2);
             assert_eq!(tracks.len(), 2);
 
-            let make_offer = Command::MakeSdpOffer {
-                peer_id,
-                sdp_offer: "caller_offer".into(),
-                mids: tracks
-                    .iter()
-                    .map(|t| t.id)
-                    .enumerate()
-                    .map(|(mid, id)| (id, mid.to_string()))
-                    .collect(),
-                senders_statuses: HashMap::new(),
-            };
-            second.send(SendCommand(make_offer)).await.unwrap();
+            second
+                .send(handle_peer_created(peer_id, &negotiation_role, &tracks))
+                .await
+                .unwrap();
             break;
         }
     }

--- a/tests/e2e/signalling/add_endpoints_synchronization.rs
+++ b/tests/e2e/signalling/add_endpoints_synchronization.rs
@@ -13,7 +13,7 @@ use crate::{
     signalling::{SendCommand, TestMember},
 };
 
-/// Creates Room with two Member's with WebRtcPublishEndpoint's.
+/// Creates Room with two Member's with `WebRtcPublishEndpoint`'s.
 pub fn create_room_req(room_id: &str) -> proto::CreateRequest {
     RoomBuilder::default()
         .id(room_id.to_string())

--- a/tests/e2e/signalling/mod.rs
+++ b/tests/e2e/signalling/mod.rs
@@ -26,7 +26,7 @@ use awc::{
 use futures::{executor, stream::SplitSink, SinkExt as _, StreamExt as _};
 use medea_client_api_proto::{
     ClientMsg, Command, Event, IceCandidate, NegotiationRole, PeerId,
-    RpcSettings, ServerMsg, TrackId, TrackUpdate,
+    RpcSettings, ServerMsg, Track, TrackId, TrackUpdate,
 };
 
 pub type MessageHandler =
@@ -407,4 +407,31 @@ impl StreamHandler<Result<Frame, WsProtocolError>> for TestMember {
 
         ctx.stop()
     }
+}
+
+/// Helper function that handles `Event::PeerCreated` returning
+/// `Command::MakeSdpOffer` or `Command::MakeSdpAnswer`.
+pub fn handle_peer_created(
+    peer_id: PeerId,
+    negotiation_role: &NegotiationRole,
+    tracks: &[Track],
+) -> SendCommand {
+    SendCommand(match negotiation_role {
+        NegotiationRole::Offerer => Command::MakeSdpOffer {
+            peer_id,
+            sdp_offer: "caller_offer".into(),
+            mids: tracks
+                .iter()
+                .map(|t| t.id)
+                .enumerate()
+                .map(|(mid, id)| (id, mid.to_string()))
+                .collect(),
+            senders_statuses: HashMap::new(),
+        },
+        NegotiationRole::Answerer(_) => Command::MakeSdpAnswer {
+            peer_id,
+            sdp_answer: "responder_answer".into(),
+            senders_statuses: HashMap::new(),
+        },
+    })
 }

--- a/tests/e2e/signalling/mod.rs
+++ b/tests/e2e/signalling/mod.rs
@@ -238,6 +238,119 @@ impl Handler<SendCommand> for TestMember {
     }
 }
 
+#[derive(actix::Message)]
+#[rtype(result = "()")]
+pub struct NegotiationStep(pub Event);
+
+impl Handler<NegotiationStep> for TestMember {
+    type Result = ();
+
+    fn handle(
+        &mut self,
+        msg: NegotiationStep,
+        _: &mut Self::Context,
+    ) -> Self::Result {
+        let event = msg.0;
+        match &event {
+            Event::PeerCreated {
+                peer_id,
+                negotiation_role,
+                tracks,
+                ..
+            } => {
+                self.known_peers.insert(*peer_id);
+                tracks.iter().for_each(|t| {
+                    use medea_client_api_proto::Direction;
+                    let mid = match &t.direction {
+                        Direction::Send { mid, .. }
+                        | Direction::Recv { mid, .. } => mid.clone(),
+                    };
+                    if let Some(mid) = mid {
+                        self.add_mid(t.id, mid);
+                    } else {
+                        self.generate_mid(t.id);
+                    }
+                });
+
+                match negotiation_role {
+                    NegotiationRole::Offerer => {
+                        self.send_command(Command::MakeSdpOffer {
+                            peer_id: *peer_id,
+                            sdp_offer: "caller_offer".into(),
+                            mids: self.known_tracks_mids.clone(),
+                            senders_statuses: HashMap::new(),
+                        })
+                    }
+                    NegotiationRole::Answerer(sdp_offer) => {
+                        assert_eq!(sdp_offer, "caller_offer");
+                        self.send_command(Command::MakeSdpAnswer {
+                            peer_id: *peer_id,
+                            sdp_answer: "responder_answer".into(),
+                            senders_statuses: HashMap::new(),
+                        })
+                    }
+                }
+
+                self.send_command(Command::SetIceCandidate {
+                    peer_id: *peer_id,
+                    candidate: IceCandidate {
+                        candidate: "ice_candidate".to_string(),
+                        sdp_m_line_index: None,
+                        sdp_mid: None,
+                    },
+                });
+            }
+            Event::TracksApplied {
+                peer_id,
+                negotiation_role,
+                updates,
+            } => {
+                assert!(self.known_peers.contains(peer_id));
+                updates.iter().for_each(|t| {
+                    use medea_client_api_proto::Direction;
+                    if let TrackUpdate::Added(track) = t {
+                        let mid = match &track.direction {
+                            Direction::Send { mid, .. }
+                            | Direction::Recv { mid, .. } => mid.clone(),
+                        };
+                        if let Some(mid) = mid {
+                            self.add_mid(track.id, mid);
+                        } else {
+                            self.generate_mid(track.id);
+                        }
+                    }
+                });
+
+                if let Some(negotiation_role) = negotiation_role {
+                    match negotiation_role {
+                        NegotiationRole::Answerer(sdp_offer) => {
+                            assert_eq!(sdp_offer, "caller_offer");
+                            self.send_command(Command::MakeSdpAnswer {
+                                peer_id: *peer_id,
+                                sdp_answer: "responder_answer".into(),
+                                senders_statuses: HashMap::new(),
+                            })
+                        }
+                        NegotiationRole::Offerer => {
+                            self.send_command(Command::MakeSdpOffer {
+                                peer_id: *peer_id,
+                                sdp_offer: "caller_offer".into(),
+                                mids: self.known_tracks_mids.clone(),
+                                senders_statuses: HashMap::new(),
+                            })
+                        }
+                    }
+                }
+            }
+            Event::SdpAnswerMade { peer_id, .. }
+            | Event::IceCandidateDiscovered { peer_id, .. } => {
+                assert!(self.known_peers.contains(peer_id))
+            }
+            Event::PeersRemoved { .. } => {}
+        }
+    }
+}
+
 /// Basic signalling implementation.
 /// [`TestMember::on_message`] function will be called for each [`Event`]
 /// received from test server.
@@ -255,128 +368,7 @@ impl StreamHandler<Result<Frame, WsProtocolError>> for TestMember {
                 ServerMsg::Ping(id) => self.send_pong(id),
                 ServerMsg::Event(event) => {
                     if self.auto_negotiation {
-                        match &event {
-                            Event::PeerCreated {
-                                peer_id,
-                                negotiation_role,
-                                tracks,
-                                ..
-                            } => {
-                                self.known_peers.insert(*peer_id);
-                                tracks.iter().for_each(|t| {
-                                    use medea_client_api_proto::Direction;
-                                    let mid = match &t.direction {
-                                        Direction::Send { mid, .. }
-                                        | Direction::Recv { mid, .. } => {
-                                            mid.clone()
-                                        }
-                                    };
-                                    if let Some(mid) = mid {
-                                        self.add_mid(t.id, mid);
-                                    } else {
-                                        self.generate_mid(t.id);
-                                    }
-                                });
-
-                                match negotiation_role {
-                                    NegotiationRole::Offerer => self
-                                        .send_command(Command::MakeSdpOffer {
-                                            peer_id: *peer_id,
-                                            sdp_offer: "caller_offer".into(),
-                                            mids: self
-                                                .known_tracks_mids
-                                                .clone(),
-                                            senders_statuses: HashMap::new(),
-                                        }),
-                                    NegotiationRole::Answerer(sdp_offer) => {
-                                        assert_eq!(sdp_offer, "caller_offer");
-                                        self.send_command(
-                                            Command::MakeSdpAnswer {
-                                                peer_id: *peer_id,
-                                                sdp_answer: "responder_answer"
-                                                    .into(),
-                                                senders_statuses: HashMap::new(
-                                                ),
-                                            },
-                                        )
-                                    }
-                                }
-
-                                self.send_command(Command::SetIceCandidate {
-                                    peer_id: *peer_id,
-                                    candidate: IceCandidate {
-                                        candidate: "ice_candidate".to_string(),
-                                        sdp_m_line_index: None,
-                                        sdp_mid: None,
-                                    },
-                                });
-                            }
-                            Event::TracksApplied {
-                                peer_id,
-                                negotiation_role,
-                                updates,
-                            } => {
-                                assert!(self.known_peers.contains(peer_id));
-                                updates.iter().for_each(|t| {
-                                    use medea_client_api_proto::Direction;
-                                    if let TrackUpdate::Added(track) = t {
-                                        let mid = match &track.direction {
-                                            Direction::Send { mid, .. }
-                                            | Direction::Recv { mid, .. } => {
-                                                mid.clone()
-                                            }
-                                        };
-                                        if let Some(mid) = mid {
-                                            self.add_mid(track.id, mid);
-                                        } else {
-                                            self.generate_mid(track.id);
-                                        }
-                                    }
-                                });
-
-                                if let Some(negotiation_role) = negotiation_role
-                                {
-                                    match negotiation_role {
-                                        NegotiationRole::Answerer(
-                                            sdp_offer,
-                                        ) => {
-                                            assert_eq!(
-                                                sdp_offer,
-                                                "caller_offer"
-                                            );
-                                            self.send_command(
-                                                Command::MakeSdpAnswer {
-                                                    peer_id: *peer_id,
-                                                    sdp_answer:
-                                                        "responder_answer"
-                                                            .into(),
-                                                    senders_statuses:
-                                                        HashMap::new(),
-                                                },
-                                            )
-                                        }
-                                        NegotiationRole::Offerer => self
-                                            .send_command(
-                                                Command::MakeSdpOffer {
-                                                    peer_id: *peer_id,
-                                                    sdp_offer: "caller_offer"
-                                                        .into(),
-                                                    mids: self
-                                                        .known_tracks_mids
-                                                        .clone(),
-                                                    senders_statuses:
-                                                        HashMap::new(),
-                                                },
-                                            ),
-                                    }
-                                }
-                            }
-                            Event::SdpAnswerMade { peer_id, .. }
-                            | Event::IceCandidateDiscovered {
-                                peer_id, ..
-                            } => assert!(self.known_peers.contains(peer_id)),
-                            Event::PeersRemoved { .. } => {}
-                        }
+                        ctx.notify(NegotiationStep(event.clone()));
                     }
                     let mut events: Vec<&Event> = self.events.iter().collect();
                     events.push(&event);

--- a/tests/e2e/signalling/track_disable.rs
+++ b/tests/e2e/signalling/track_disable.rs
@@ -204,7 +204,7 @@ async fn track_disables_and_enables_are_instant() {
         };
     }
 
-    for i in 0..20 {
+    for i in 0..25 {
         let mut tracks_patches = Vec::new();
         tracks_patches.push(TrackPatch {
             id: TrackId(2),
@@ -221,7 +221,7 @@ async fn track_disables_and_enables_are_instant() {
 
     let (force_update_received, all_renegotiations_performed) =
         tokio::time::timeout(
-            Duration::from_secs(5),
+            Duration::from_secs(30),
             future::join(
                 force_update_received_rx,
                 all_renegotiations_performed_rx,

--- a/tests/e2e/signalling/track_disable.rs
+++ b/tests/e2e/signalling/track_disable.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{cell::Cell, rc::Rc, time::Duration};
 
 use actix::{Addr, AsyncContext};
 use futures::{
@@ -16,7 +16,6 @@ use crate::{
     grpc_control_api::{create_room_req, ControlClient},
     signalling::{ConnectionEvent, SendCommand, TestMember},
 };
-use std::{cell::Cell, rc::Rc};
 
 // Sends 2 UpdateTracks with is_muted = `disabled`.
 // Waits for single/multiple TracksApplied with expected track changes on on
@@ -248,6 +247,8 @@ async fn track_disables_and_enables_are_instant() {
         .unwrap();
 }
 
+/// Checks that force update mechanism works for muting and renegotiation after
+/// force update will be performed.
 #[actix_rt::test]
 async fn force_update_works() {
     const TEST_NAME: &str = "force_update_works";

--- a/tests/e2e/signalling/track_disable.rs
+++ b/tests/e2e/signalling/track_disable.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, rc::Rc, time::Duration};
+use std::{cell::Cell, collections::HashMap, rc::Rc, time::Duration};
 
 use actix::{Addr, AsyncContext};
 use futures::{
@@ -9,11 +9,15 @@ use futures::{
     future, StreamExt,
 };
 use medea_client_api_proto::{
-    Command, Event, PeerId, TrackId, TrackPatch, TrackUpdate,
+    Command, Event, NegotiationRole, PeerId, TrackId, TrackPatch, TrackUpdate,
 };
+use medea_control_api_proto::grpc::api as proto;
 
 use crate::{
-    grpc_control_api::{create_room_req, ControlClient},
+    grpc_control_api::{
+        create_room_req, ControlClient, WebRtcPlayEndpointBuilder,
+        WebRtcPublishEndpointBuilder,
+    },
     signalling::{ConnectionEvent, SendCommand, TestMember},
 };
 
@@ -240,6 +244,164 @@ async fn track_disables_and_enables_are_instant() {
     all_renegotiations_performed
         .expect("all_renegotiations_performed")
         .unwrap();
+}
+
+#[actix_rt::test]
+async fn track_disables_and_enables_are_instant2() {
+    const TEST_NAME: &str = "track_disables_and_enables_are_instant2";
+
+    let mut client = ControlClient::new().await;
+    let credentials = client.create(create_room_req(TEST_NAME)).await;
+    client
+        .create(
+            WebRtcPublishEndpointBuilder::default()
+                .id("publish")
+                .p2p_mode(proto::web_rtc_publish_endpoint::P2p::Always)
+                .build()
+                .unwrap()
+                .build_request(format!("{}/responder", TEST_NAME)),
+        )
+        .await;
+    client
+        .create(
+            WebRtcPlayEndpointBuilder::default()
+                .id("play")
+                .src(format!("local://{}/responder/publish", TEST_NAME))
+                .build()
+                .unwrap()
+                .build_request(format!("{}/publisher", TEST_NAME)),
+        )
+        .await;
+
+    let (first_tx, mut first_rx) = mpsc::unbounded();
+    let first = TestMember::connect(
+        credentials.get("publisher").unwrap(),
+        Some(Box::new(move |event, _, _| {
+            first_tx.unbounded_send(event.clone()).unwrap();
+        })),
+        None,
+        Some(Duration::from_secs(500)),
+        false,
+    )
+    .await;
+
+    let (second_tx, mut second_rx) = mpsc::unbounded();
+    let second = TestMember::connect(
+        credentials.get("responder").unwrap(),
+        Some(Box::new(move |event, _, _| {
+            second_tx.unbounded_send(event.clone()).unwrap();
+        })),
+        None,
+        Some(Duration::from_secs(500)),
+        false,
+    )
+    .await;
+
+    loop {
+        if let Event::PeerCreated {
+            peer_id,
+            negotiation_role,
+            tracks,
+            ..
+        } = first_rx.select_next_some().await
+        {
+            let answer = match negotiation_role {
+                NegotiationRole::Offerer => Command::MakeSdpOffer {
+                    peer_id,
+                    sdp_offer: "offer".into(),
+                    mids: tracks
+                        .iter()
+                        .map(|t| t.id)
+                        .enumerate()
+                        .map(|(mid, id)| (id, mid.to_string()))
+                        .collect(),
+                    senders_statuses: HashMap::new(),
+                },
+                NegotiationRole::Answerer(_) => Command::MakeSdpAnswer {
+                    peer_id,
+                    sdp_answer: "answer".into(),
+                    senders_statuses: HashMap::new(),
+                },
+            };
+            first.send(SendCommand(answer)).await.unwrap();
+            break;
+        }
+    }
+
+    loop {
+        if let Event::PeerCreated {
+            peer_id,
+            negotiation_role,
+            tracks,
+            ..
+        } = second_rx.select_next_some().await
+        {
+            let answer = match negotiation_role {
+                NegotiationRole::Offerer => Command::MakeSdpOffer {
+                    peer_id,
+                    sdp_offer: "offer".into(),
+                    mids: tracks
+                        .iter()
+                        .map(|t| t.id)
+                        .enumerate()
+                        .map(|(mid, id)| (id, mid.to_string()))
+                        .collect(),
+                    senders_statuses: HashMap::new(),
+                },
+                NegotiationRole::Answerer(_) => Command::MakeSdpAnswer {
+                    peer_id,
+                    sdp_answer: "answer".into(),
+                    senders_statuses: HashMap::new(),
+                },
+            };
+            second.send(SendCommand(answer)).await.unwrap();
+            break;
+        }
+    }
+    first
+        .send(SendCommand(Command::UpdateTracks {
+            peer_id: PeerId(0),
+            tracks_patches: vec![TrackPatch {
+                id: TrackId(0),
+                is_muted: Some(true),
+            }],
+        }))
+        .await
+        .unwrap();
+    loop {
+        if let Event::TracksApplied {
+            peer_id,
+            updates: _,
+            negotiation_role,
+        } = first_rx.select_next_some().await
+        {
+            assert_eq!(peer_id.0, 0);
+            assert_eq!(negotiation_role, Some(NegotiationRole::Offerer));
+            break;
+        }
+    }
+    second
+        .send(SendCommand(Command::UpdateTracks {
+            peer_id: PeerId(1),
+            tracks_patches: vec![TrackPatch {
+                id: TrackId(2),
+                is_muted: Some(true),
+            }],
+        }))
+        .await
+        .unwrap();
+    loop {
+        if let Event::TracksApplied {
+            peer_id,
+            updates: _,
+            negotiation_role,
+        } = second_rx.select_next_some().await
+        {
+            assert_eq!(peer_id.0, 1);
+            assert_eq!(negotiation_role, None);
+            break;
+        }
+    }
 }
 
 /// Checks that force update mechanism works for muting and renegotiation after

--- a/tests/e2e/signalling/track_disable.rs
+++ b/tests/e2e/signalling/track_disable.rs
@@ -230,7 +230,7 @@ async fn track_disables_and_enables_are_instant() {
         .await
         .unwrap();
     force_update_received.expect("force_update_received");
-    all_renegotiations_performed.unwrap("all_renegotiations_performed");
+    all_renegotiations_performed.expect("all_renegotiations_performed");
 }
 
 #[actix_rt::test]

--- a/tests/e2e/signalling/track_disable.rs
+++ b/tests/e2e/signalling/track_disable.rs
@@ -1,24 +1,24 @@
-use std::{cell::Cell, collections::HashMap, rc::Rc, time::Duration};
+use std::{cell::Cell, rc::Rc, time::Duration};
 
 use actix::{Addr, AsyncContext};
 use futures::{
-    channel::{
-        mpsc::{self, UnboundedReceiver},
-        oneshot,
-    },
-    future, StreamExt,
+    channel::mpsc::{self, UnboundedReceiver},
+    future, Stream, StreamExt,
 };
 use medea_client_api_proto::{
     Command, Event, NegotiationRole, PeerId, TrackId, TrackPatch, TrackUpdate,
 };
 use medea_control_api_proto::grpc::api as proto;
+use tokio::time::timeout;
 
 use crate::{
     grpc_control_api::{
         create_room_req, ControlClient, WebRtcPlayEndpointBuilder,
         WebRtcPublishEndpointBuilder,
     },
-    signalling::{ConnectionEvent, SendCommand, TestMember},
+    signalling::{
+        handle_peer_created, ConnectionEvent, SendCommand, TestMember,
+    },
 };
 
 // Sends 2 UpdateTracks with is_muted = `disabled`.
@@ -145,67 +145,53 @@ async fn track_disables_and_enables() {
 #[actix_rt::test]
 async fn track_disables_and_enables_are_instant() {
     const TEST_NAME: &str = "track_disables_and_enables_are_instant";
+    const EVENTS_COUNT: usize = 100;
+
+    fn filter_events(
+        rx: UnboundedReceiver<Event>,
+    ) -> impl Stream<Item = (bool, Option<NegotiationRole>)> {
+        rx.filter_map(|val| async {
+            match val {
+                Event::TracksApplied {
+                    mut updates,
+                    negotiation_role,
+                    ..
+                } => {
+                    match updates.len() {
+                        0 => {
+                            // 0 updates means that TracksApplied must proc
+                            // negotiation
+                            negotiation_role.unwrap();
+                            None
+                        }
+                        1 => {
+                            if let TrackUpdate::Updated(patch) =
+                                updates.pop().unwrap()
+                            {
+                                Some((
+                                    patch.is_muted.unwrap(),
+                                    negotiation_role,
+                                ))
+                            } else {
+                                unreachable!();
+                            }
+                        }
+                        _ => unreachable!("patches dedup failed"),
+                    }
+                }
+                _ => None,
+            }
+        })
+    }
 
     let mut client = ControlClient::new().await;
     let credentials = client.create(create_room_req(TEST_NAME)).await;
 
     let (publisher_tx, mut publisher_rx) = mpsc::unbounded();
-    let _publisher = TestMember::connect(
+    let publisher = TestMember::connect(
         credentials.get("publisher").unwrap(),
-        Some(Box::new(move |event, ctx, _| {
-            if let Event::SdpAnswerMade { peer_id, .. } = event {
-                for i in 0..20 {
-                    let mut tracks_patches = Vec::new();
-                    tracks_patches.push(TrackPatch {
-                        id: TrackId(0),
-                        is_muted: Some(i % 2 == 0),
-                    });
-                    ctx.notify(SendCommand(Command::UpdateTracks {
-                        peer_id: *peer_id,
-                        tracks_patches,
-                    }));
-                }
-            }
-            publisher_tx.unbounded_send(event.clone()).unwrap();
-        })),
-        None,
-        Some(Duration::from_secs(500)),
-        true,
-    )
-    .await;
-    let (force_update_received_tx, force_update_received_rx) =
-        oneshot::channel();
-    let mut force_update_received_tx = Some(force_update_received_tx);
-    let (all_renegotiations_performed_tx, all_renegotiations_performed_rx) =
-        oneshot::channel();
-    let mut all_renegotiations_performed_tx =
-        Some(all_renegotiations_performed_tx);
-    let pub_peer_id = Rc::new(Cell::new(None));
-    let _subscriber = TestMember::connect(
-        credentials.get("responder").unwrap(),
-        Some(Box::new({
-            let pub_peer_id = Rc::clone(&pub_peer_id);
-            move |event, _, _| match event {
-                Event::PeerCreated { peer_id, .. } => {
-                    pub_peer_id.set(Some(*peer_id));
-                }
-                Event::TracksApplied {
-                    negotiation_role, ..
-                } => {
-                    if negotiation_role.is_none() {
-                        if let Some(force_update_received_tx) =
-                            force_update_received_tx.take()
-                        {
-                            let _ = force_update_received_tx.send(());
-                        }
-                    } else if let Some(all_renegotiations_performed_tx) =
-                        all_renegotiations_performed_tx.take()
-                    {
-                        all_renegotiations_performed_tx.send(()).unwrap();
-                    }
-                }
-                _ => {}
-            }
+        Some(Box::new(move |event, _, _| {
+            let _ = publisher_tx.unbounded_send(event.clone());
         })),
         None,
         Some(Duration::from_secs(500)),
@@ -213,37 +199,70 @@ async fn track_disables_and_enables_are_instant() {
     )
     .await;
 
-    // wait until initial negotiation finishes
+    let (subscriber_tx, subscriber_rx) = mpsc::unbounded();
+    let _subscriber = TestMember::connect(
+        credentials.get("responder").unwrap(),
+        Some(Box::new(move |event, _, _| {
+            let _ = subscriber_tx.unbounded_send(event.clone());
+        })),
+        None,
+        Some(Duration::from_secs(500)),
+        true,
+    )
+    .await;
+
+    // wait until initial negotiation finishes, and send a bunch of UpdateTracks
+    let mut mutes_sent = Vec::with_capacity(EVENTS_COUNT);
     loop {
         if let Event::SdpAnswerMade { .. } =
             publisher_rx.select_next_some().await
         {
+            for i in 0..EVENTS_COUNT {
+                let is_muted = i % 2 == 1;
+                mutes_sent.push(is_muted);
+                publisher.do_send(SendCommand(Command::UpdateTracks {
+                    peer_id: PeerId(0),
+                    tracks_patches: vec![TrackPatch {
+                        id: TrackId(0),
+                        is_muted: Some(is_muted),
+                    }],
+                }));
+            }
             break;
         };
     }
 
-    let (force_update_received, all_renegotiations_performed) =
-        tokio::time::timeout(
-            Duration::from_secs(30),
-            future::join(
-                tokio::time::timeout(
-                    Duration::from_secs(10),
-                    force_update_received_rx,
-                ),
-                tokio::time::timeout(
-                    Duration::from_secs(10),
-                    all_renegotiations_performed_rx,
-                ),
-            ),
+    let mutes_received_by_publisher: Vec<_> = timeout(
+        Duration::from_secs(10),
+        filter_events(publisher_rx)
+            .take(EVENTS_COUNT)
+            .map(|val| val.0)
+            .collect(),
+    )
+    .await
+    .unwrap();
+
+    // gather events sent to subscriber until they stop going
+    let mut mutes_received_by_receiver: Vec<_> =
+        tokio::stream::StreamExt::timeout(
+            filter_events(subscriber_rx),
+            Duration::from_secs(5),
         )
-        .await
-        .unwrap();
-    force_update_received
-        .expect("force_update_received")
-        .unwrap();
-    all_renegotiations_performed
-        .expect("all_renegotiations_performed")
-        .unwrap();
+        .take_while(|val| future::ready(val.is_ok()))
+        .map(Result::unwrap)
+        .collect()
+        .await;
+
+    assert_eq!(mutes_sent, mutes_received_by_publisher);
+    assert!(mutes_received_by_receiver.iter().all(|val| val.1.is_some()));
+    assert_eq!(
+        *mutes_sent.get(0).unwrap(),
+        mutes_received_by_receiver.get(0).unwrap().0
+    );
+    assert_eq!(
+        mutes_sent.pop().unwrap(),
+        mutes_received_by_receiver.pop().unwrap().0
+    );
 }
 
 #[actix_rt::test]
@@ -305,25 +324,10 @@ async fn track_disables_and_enables_are_instant2() {
             ..
         } = first_rx.select_next_some().await
         {
-            let answer = match negotiation_role {
-                NegotiationRole::Offerer => Command::MakeSdpOffer {
-                    peer_id,
-                    sdp_offer: "offer".into(),
-                    mids: tracks
-                        .iter()
-                        .map(|t| t.id)
-                        .enumerate()
-                        .map(|(mid, id)| (id, mid.to_string()))
-                        .collect(),
-                    senders_statuses: HashMap::new(),
-                },
-                NegotiationRole::Answerer(_) => Command::MakeSdpAnswer {
-                    peer_id,
-                    sdp_answer: "answer".into(),
-                    senders_statuses: HashMap::new(),
-                },
-            };
-            first.send(SendCommand(answer)).await.unwrap();
+            first
+                .send(handle_peer_created(peer_id, &negotiation_role, &tracks))
+                .await
+                .unwrap();
             break;
         }
     }
@@ -336,28 +340,20 @@ async fn track_disables_and_enables_are_instant2() {
             ..
         } = second_rx.select_next_some().await
         {
-            let answer = match negotiation_role {
-                NegotiationRole::Offerer => Command::MakeSdpOffer {
-                    peer_id,
-                    sdp_offer: "offer".into(),
-                    mids: tracks
-                        .iter()
-                        .map(|t| t.id)
-                        .enumerate()
-                        .map(|(mid, id)| (id, mid.to_string()))
-                        .collect(),
-                    senders_statuses: HashMap::new(),
-                },
-                NegotiationRole::Answerer(_) => Command::MakeSdpAnswer {
-                    peer_id,
-                    sdp_answer: "answer".into(),
-                    senders_statuses: HashMap::new(),
-                },
-            };
-            second.send(SendCommand(answer)).await.unwrap();
+            second
+                .send(handle_peer_created(peer_id, &negotiation_role, &tracks))
+                .await
+                .unwrap();
             break;
         }
     }
+    // wait until initial negotiation finishes
+    loop {
+        if let Event::SdpAnswerMade { .. } = first_rx.select_next_some().await {
+            break;
+        };
+    }
+
     first
         .send(SendCommand(Command::UpdateTracks {
             peer_id: PeerId(0),
@@ -413,19 +409,16 @@ async fn force_update_works() {
     let mut client = ControlClient::new().await;
     let credentials = client.create(create_room_req(TEST_NAME)).await;
 
-    let (
-        publisher_connection_established_tx,
-        mut publisher_connection_established_rx,
-    ) = mpsc::unbounded();
+    let (pub_con_established_tx, mut pub_con_established_rx) =
+        mpsc::unbounded();
     let (force_update_tx, mut force_update_rx) = mpsc::unbounded();
     let (renegotiation_update_tx, mut renegotiation_update_rx) =
         mpsc::unbounded();
-    let is_renegotiation_happened = Rc::new(Cell::new(false));
+    let renegotiation_done = Rc::new(Cell::new(false));
     let _publisher = TestMember::connect(
         credentials.get("publisher").unwrap(),
         Some(Box::new({
-            let is_renegotiation_happened =
-                Rc::clone(&is_renegotiation_happened);
+            let renegotiation_done = Rc::clone(&renegotiation_done);
             let renegotiation_update_tx = renegotiation_update_tx.clone();
             let force_update_tx = force_update_tx.clone();
             move |event, ctx, _| match &event {
@@ -445,7 +438,7 @@ async fn force_update_works() {
                 } => {
                     if negotiation_role.is_none() {
                         force_update_tx.unbounded_send(()).unwrap();
-                    } else if is_renegotiation_happened.get() {
+                    } else if renegotiation_done.get() {
                         renegotiation_update_tx.unbounded_send(()).unwrap();
                     } else {
                         ctx.notify(SendCommand(Command::UpdateTracks {
@@ -455,7 +448,7 @@ async fn force_update_works() {
                                 id: TrackId(0),
                             }],
                         }));
-                        is_renegotiation_happened.set(true);
+                        renegotiation_done.set(true);
                     }
                 }
                 _ => {}
@@ -463,9 +456,7 @@ async fn force_update_works() {
         })),
         Some(Box::new(move |event| {
             if let ConnectionEvent::Started = event {
-                publisher_connection_established_tx
-                    .unbounded_send(())
-                    .unwrap()
+                pub_con_established_tx.unbounded_send(()).unwrap()
             }
         })),
         Some(Duration::from_secs(500)),
@@ -473,7 +464,7 @@ async fn force_update_works() {
     )
     .await;
 
-    publisher_connection_established_rx.next().await.unwrap();
+    pub_con_established_rx.next().await.unwrap();
 
     let mut pub_peer_id = None;
     let mut track_id = None;
@@ -500,7 +491,7 @@ async fn force_update_works() {
             } => {
                 if negotiation_role.is_none() {
                     force_update_tx.unbounded_send(()).unwrap();
-                } else if is_renegotiation_happened.get() {
+                } else if renegotiation_done.get() {
                     renegotiation_update_tx.unbounded_send(()).unwrap();
                 } else {
                     ctx.notify(SendCommand(Command::UpdateTracks {
@@ -510,7 +501,7 @@ async fn force_update_works() {
                             id: track_id.unwrap(),
                         }],
                     }));
-                    is_renegotiation_happened.set(true);
+                    renegotiation_done.set(true);
                 }
             }
             _ => {}
@@ -522,11 +513,8 @@ async fn force_update_works() {
     .await;
 
     let (force_update, renegotiation_update) = future::join(
-        tokio::time::timeout(Duration::from_secs(10), force_update_rx.next()),
-        tokio::time::timeout(
-            Duration::from_secs(10),
-            renegotiation_update_rx.next(),
-        ),
+        timeout(Duration::from_secs(10), force_update_rx.next()),
+        timeout(Duration::from_secs(10), renegotiation_update_rx.next()),
     )
     .await;
     force_update.unwrap().unwrap();

--- a/tests/e2e/signalling/track_disable.rs
+++ b/tests/e2e/signalling/track_disable.rs
@@ -204,7 +204,7 @@ async fn track_disables_and_enables_are_instant() {
         };
     }
 
-    for i in 0..25 {
+    for i in 0..20 {
         let mut tracks_patches = Vec::new();
         tracks_patches.push(TrackPatch {
             id: TrackId(2),
@@ -223,14 +223,14 @@ async fn track_disables_and_enables_are_instant() {
         tokio::time::timeout(
             Duration::from_secs(30),
             future::join(
-                force_update_received_rx,
-                all_renegotiations_performed_rx,
+                tokio::time::timeout(Duration::from_secs(10), force_update_received_rx),
+                tokio::time::timeout(Duration::from_secs(10), all_renegotiations_performed_rx),
             ),
         )
         .await
         .unwrap();
-    force_update_received.unwrap();
-    all_renegotiations_performed.unwrap();
+    force_update_received.expect("force_update_received");
+    all_renegotiations_performed.unwrap("all_renegotiations_performed");
 }
 
 #[actix_rt::test]


### PR DESCRIPTION
Part of #27




## Synopsis

В комнате есть пользователь `Alice` у которого проблемное соединение с сервером, пользователь `Bob` отправляет больше одного `UpdateTracks` подряд для своего пира, соединенного с `Alice`. Пока renegotiation для первого `UpdateTracks` не завершится, пользователь `Bob` не получит `TracksApplied` для второго `UpdateTracks`. Это приводит к полному зависанию мьюта у `Bob`'а, пока `Alice` не восстановит подключение с сервером, поскольку `Alice` не может завершить renegotiation.




## Solution

Отправлять `TracksApplied` без renegotiation, если пир на данный момент не Stable, и проводить новый renegotiation для этих изменений, когда пир перейдет в Stable стейт.

`TracksApplied` без renegotiation'а будут отправляться только на ивентов, которые требуют как можно более быстрого отрабатывания и могут терпеть некоторый рассинхрон description'ов, для остальных ивентов будет использоваться renegotiation queue стратегия.

Также, нужно учитывать, что медиа траффик не будет моментально начинать идти при анмьюте, поскольку траффик не сможет идти без renegotiation'а.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `WIP: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `WIP: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
