### PR TITLE
Implement WebSocket broadcast in medea-control-api-mock

### DIFF
--- a/mock/control-api/README.md
+++ b/mock/control-api/README.md
@@ -90,13 +90,13 @@ Currently, it supports two kinds of events (`Created` and `Deleted`) with the fo
 }
 ```
 
-Additionally, [WebSocket] clients can send arbitrary messages, and those will be broadcasted to other [WebSocket] clients that subscribed to same `room_id`. The only validation that app makes is that message is a valid JSON.
+#### 3. `Broadcast` event
 
-Broadcast messages has `method` field set to `Broadcast`, and original message goes to `payload`, i.e.: 
+Additionally, [WebSocket] clients can send arbitrary messages, and those will be broadcast to other [WebSocket] clients that subscribed to the same `room_id`. The only validation that app performs is that message is a valid JSON.
 
 ```json
 {
-    "method":"Broadcast",
+    "method": "Broadcast",
     "payload": {
         "anything": "that other user sent",
         "asd": 123 

--- a/mock/control-api/README.md
+++ b/mock/control-api/README.md
@@ -90,6 +90,20 @@ Currently, it supports two kinds of events (`Created` and `Deleted`) with the fo
 }
 ```
 
+Additionally, [WebSocket] clients can send arbitrary messages, and those will be broadcasted to other [WebSocket] clients that subscribed to same `room_id`. The only validation that app makes is that message is a valid JSON.
+
+Broadcast messages has `method` field set to `Broadcast`, and original message goes to `payload`, i.e.: 
+
+```json
+{
+    "method":"Broadcast",
+    "payload": {
+        "anything": "that other user sent",
+        "asd": 123 
+    }
+}
+```
+
 
 
 

--- a/mock/control-api/src/api/ws.rs
+++ b/mock/control-api/src/api/ws.rs
@@ -171,7 +171,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsSession {
                                 .subscribers
                                 .lock()
                                 .unwrap()
-                                .get_mut(&self.room_id)
+                                .get(&self.room_id)
                             {
                                 subs.iter()
                                     .filter(|sub| **sub != this)

--- a/mock/control-api/src/api/ws.rs
+++ b/mock/control-api/src/api/ws.rs
@@ -56,6 +56,7 @@ pub struct Notification(Value);
 #[derive(Serialize)]
 #[serde(tag = "method")]
 enum NotificationVariants<'a> {
+    Broadcast { payload: Value },
     Created { fid: &'a str, element: &'a Element },
     Deleted { fid: &'a str },
 }
@@ -79,6 +80,14 @@ impl Notification {
                 fid: fid.as_ref(),
             })
             .unwrap(),
+        )
+    }
+
+    /// Builds `method: Broadcast` [`Notification`].
+    pub fn broadcast(payload: Value) -> Notification {
+        Self(
+            serde_json::to_value(NotificationVariants::Broadcast { payload })
+                .unwrap(),
         )
     }
 }
@@ -121,11 +130,11 @@ impl Actor for WsSession {
 
     /// Removes [`WsSession`] from [`WsSession`]s map.
     fn stopped(&mut self, ctx: &mut Self::Context) {
-        let recipient = ctx.address().recipient();
+        let this = ctx.address().recipient();
         if let Some(subs) =
             self.subscribers.lock().unwrap().get_mut(&self.room_id)
         {
-            subs.retain(|sub| *sub != recipient)
+            subs.retain(|sub| *sub != this)
         }
     }
 }
@@ -154,6 +163,34 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsSession {
                     ctx.stop();
                 }
                 ws::Message::Pong(_) => {}
+                ws::Message::Text(text) => {
+                    match serde_json::from_str::<Value>(&text) {
+                        Ok(msg) => {
+                            let this = ctx.address().recipient();
+                            if let Some(subs) = self
+                                .subscribers
+                                .lock()
+                                .unwrap()
+                                .get_mut(&self.room_id)
+                            {
+                                subs.iter()
+                                    .filter(|sub| **sub != this)
+                                    .for_each(|sub| {
+                                        let _ = sub.do_send(
+                                            Notification::broadcast(
+                                                msg.clone(),
+                                            ),
+                                        );
+                                    })
+                            }
+                        }
+                        Err(err) => error!(
+                            "Received broadcast message but it is not a valid \
+                             JSON: {:?}",
+                            err
+                        ),
+                    }
+                }
                 _ => error!("Unsupported client message: {:?}", msg),
             },
             Err(err) => {

--- a/mock/control-api/src/api/ws.rs
+++ b/mock/control-api/src/api/ws.rs
@@ -187,7 +187,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsSession {
                         Err(err) => error!(
                             "Received broadcast message but it is not a valid \
                              JSON: {:?}",
-                            err
+                            err,
                         ),
                     }
                 }


### PR DESCRIPTION
## Solution

Implement WebSocket broadcast in medea-control-api-mock




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
