### PR TITLE
Add facingMode constraint configuration to Jason (#27)

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -9,6 +9,7 @@ doc-valid-idents = [
     "OAuth", "OpenGL", "OpenSSH", "OpenSSL", "OpenStreetMap", "TrueType",
     "iOS", "macOS", "TeX", "LaTeX", "BibTeX", "BibLaTeX", "MinGW",
     "BigInt64Array", "BigUint64Array",
+    "ConstrainDOMString",
     "DOMHighResTimeStamp",
     "getDisplayMedia", "getUserMedia", "gRPC",
     "MediaDeviceKind", "MediaDeviceInfo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a71bf475cbe07281d0b3696abb48212db118e7e23219f13596ce865235ff5766"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -327,7 +327,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95aceadaf327f18f0df5962fedc1bde2f870566a0b9f65c89508a3b1f79334c"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -485,7 +485,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -502,7 +502,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -877,7 +877,7 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "strsim 0.9.3",
  "syn 1.0.40",
@@ -931,7 +931,7 @@ checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling",
  "derive_builder_core",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -943,7 +943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -954,7 +954,7 @@ version = "0.99.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -1026,7 +1026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
 dependencies = [
  "heck",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -1053,7 +1053,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
  "synstructure",
@@ -1222,7 +1222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "linked-hash-map"
@@ -1764,7 +1764,7 @@ dependencies = [
  "Inflector",
  "async-trait",
  "medea-jason",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
  "synstructure",
@@ -1878,7 +1878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b873f753808fe0c3827ce76edb3ace27804966dfde3043adfac1c24d0a2559df"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -2071,7 +2071,7 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -2168,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -2211,7 +2211,7 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -2253,7 +2253,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
 ]
 
 [[package]]
@@ -2524,7 +2524,7 @@ version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -2577,7 +2577,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4070d2c9b9d258465ad1d82aabb985b84cd9a3afa94da25ece5a9938ba5f1606"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -2611,7 +2611,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65f59259be9fc1bf677d06cc1456e97756004a1a5a577480f71430bd7c17ba33"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -2731,16 +2731,16 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2783,7 +2783,7 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
 ]
@@ -2794,7 +2794,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
  "unicode-xid 0.2.1",
@@ -2902,7 +2902,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -2980,7 +2980,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19970cf58f3acc820962be74c4021b8bbc8e8a1c4e3a02095d0aa60cde5f3633"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "prost-build",
  "quote 1.0.7",
  "syn 1.0.40",
@@ -3191,7 +3191,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -3386,7 +3386,7 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
  "wasm-bindgen-shared",
@@ -3420,7 +3420,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
  "wasm-bindgen-backend",
@@ -3453,7 +3453,7 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fb9c67be7439ee8ab1b7db502a49c05e51e2835b66796c705134d9b8e1a585"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
 ]
 

--- a/jason/CHANGELOG.md
+++ b/jason/CHANGELOG.md
@@ -37,7 +37,9 @@ All user visible changes to this project will be documented in this file. This p
             - `MediaManager.init_local_stream()`.
         - Local media stream constraints:
             - `MediaStreamSettings`, `AudioTrackConstraints` classes ([#46], [#97]);
-            - `DeviceVideoTrackConstraints`, `DisplayVideoTrackConstraints` classes ([#78]).
+            - `DeviceVideoTrackConstraints`, `DisplayVideoTrackConstraints` classes ([#78]);
+            - `DeviceVideoTrackConstraints.ideal_facing_mode` and `DeviceVideoTrackConstraints.exact_facing_mode`;
+            - `FacingMode` enum.
         - Room initialization ([#46]):
             - `Jason.init_room()`;
             - `Room.join()`;

--- a/jason/CHANGELOG.md
+++ b/jason/CHANGELOG.md
@@ -38,7 +38,7 @@ All user visible changes to this project will be documented in this file. This p
         - Local media stream constraints:
             - `MediaStreamSettings`, `AudioTrackConstraints` classes ([#46], [#97]);
             - `DeviceVideoTrackConstraints`, `DisplayVideoTrackConstraints` classes ([#78]);
-            - `DeviceVideoTrackConstraints.ideal_facing_mode` and `DeviceVideoTrackConstraints.exact_facing_mode` ([#137]);
+            - `DeviceVideoTrackConstraints.ideal_facing_mode` and `DeviceVideoTrackConstraints.exact_facing_mode` functions ([#137]);
             - `FacingMode` enum ([#137]).
         - Room initialization ([#46]):
             - `Jason.init_room()`;

--- a/jason/CHANGELOG.md
+++ b/jason/CHANGELOG.md
@@ -38,8 +38,8 @@ All user visible changes to this project will be documented in this file. This p
         - Local media stream constraints:
             - `MediaStreamSettings`, `AudioTrackConstraints` classes ([#46], [#97]);
             - `DeviceVideoTrackConstraints`, `DisplayVideoTrackConstraints` classes ([#78]);
-            - `DeviceVideoTrackConstraints.ideal_facing_mode` and `DeviceVideoTrackConstraints.exact_facing_mode`;
-            - `FacingMode` enum.
+            - `DeviceVideoTrackConstraints.ideal_facing_mode` and `DeviceVideoTrackConstraints.exact_facing_mode` ([#137]);
+            - `FacingMode` enum ([#137]).
         - Room initialization ([#46]):
             - `Jason.init_room()`;
             - `Room.join()`;
@@ -97,6 +97,7 @@ All user visible changes to this project will be documented in this file. This p
 [#123]: /../../pull/123
 [#124]: /../../pull/124
 [#132]: /../../pull/132
+[#137]: /../../pull/137
 
 
 

--- a/jason/demo/index.html
+++ b/jason/demo/index.html
@@ -258,9 +258,9 @@
           } else {
             let video = new DeviceVideoTrackConstraints();
             if (videoSource.value === 'facingModeUser') {
-              video.exact_facing_mode(FacingMode.User);
+              video.ideal_facing_mode(FacingMode.User);
             } else if (videoSource.value === 'facingModeEnvironment') {
-              video.exact_facing_mode(FacingMode.Environment);
+              video.ideal_facing_mode(FacingMode.Environment);
             } else {
               video.device_id(videoSource.value);
             }

--- a/jason/demo/index.html
+++ b/jason/demo/index.html
@@ -13,6 +13,7 @@
       AudioTrackConstraints,
       DeviceVideoTrackConstraints,
       DisplayVideoTrackConstraints,
+      FacingMode,
     } from './js/medea_jason.js';
 
     const controlUrl = document.location.protocol + "//" +
@@ -221,10 +222,20 @@
         }
       }
 
-      const option = document.createElement('option');
-      option.value = "screen";
-      option.text = "screen";
-      video_select.append(option);
+      const screen = document.createElement('option');
+      screen.value = "screen";
+      screen.text = "screen";
+      video_select.append(screen);
+
+      const facingModeUser = document.createElement('option');
+      facingModeUser.value = "facingModeUser";
+      facingModeUser.text = "Facing user";
+      video_select.append(facingModeUser);
+
+      const facingModeEnvironment = document.createElement('option');
+      facingModeEnvironment.value = 'facingModeEnvironment';
+      facingModeEnvironment.text = "Facing environment";
+      video_select.append(facingModeEnvironment);
     }
 
     async function build_constraints(audio_select, video_select) {
@@ -246,7 +257,13 @@
             constraints.display_video(video);
           } else {
             let video = new DeviceVideoTrackConstraints();
-            video.device_id(videoSource.value);
+            if (videoSource.value === 'facingModeUser') {
+              video.exact_facing_mode(FacingMode.User);
+            } else if (videoSource.value === 'facingModeEnvironment') {
+              video.exact_facing_mode(FacingMode.Environment);
+            } else {
+              video.device_id(videoSource.value);
+            }
             constraints.device_video(video);
           }
         } else {

--- a/jason/demo/index.html
+++ b/jason/demo/index.html
@@ -258,9 +258,9 @@
           } else {
             let video = new DeviceVideoTrackConstraints();
             if (videoSource.value === 'facingModeUser') {
-              video.ideal_facing_mode(FacingMode.User);
+              video.exact_facing_mode(FacingMode.User);
             } else if (videoSource.value === 'facingModeEnvironment') {
-              video.ideal_facing_mode(FacingMode.Environment);
+              video.exact_facing_mode(FacingMode.Environment);
             } else {
               video.device_id(videoSource.value);
             }

--- a/jason/e2e-demo/js/index.js
+++ b/jason/e2e-demo/js/index.js
@@ -475,6 +475,7 @@ window.onload = async function() {
         video_select.append(option);
       }
     }
+
     const screen = document.createElement('option');
     screen.value = "screen";
     screen.text = "screen";

--- a/jason/e2e-demo/js/index.js
+++ b/jason/e2e-demo/js/index.js
@@ -512,9 +512,9 @@ window.onload = async function() {
         } else {
           let video = new rust.DeviceVideoTrackConstraints();
           if (videoSource.value === 'facingModeUser') {
-            video.ideal_facing_mode(rust.FacingMode.User);
+            video.exact_facing_mode(rust.FacingMode.User);
           } else if (videoSource.value === 'facingModeEnvironment') {
-            video.ideal_facing_mode(rust.FacingMode.Environment);
+            video.exact_facing_mode(rust.FacingMode.Environment);
           } else {
             video.device_id(videoSource.value);
           }

--- a/jason/e2e-demo/js/index.js
+++ b/jason/e2e-demo/js/index.js
@@ -512,9 +512,9 @@ window.onload = async function() {
         } else {
           let video = new rust.DeviceVideoTrackConstraints();
           if (videoSource.value === 'facingModeUser') {
-            video.exact_facing_mode(rust.FacingMode.User);
+            video.ideal_facing_mode(rust.FacingMode.User);
           } else if (videoSource.value === 'facingModeEnvironment') {
-            video.exact_facing_mode(rust.FacingMode.Environment);
+            video.ideal_facing_mode(rust.FacingMode.Environment);
           } else {
             video.device_id(videoSource.value);
           }

--- a/jason/e2e-demo/js/index.js
+++ b/jason/e2e-demo/js/index.js
@@ -475,10 +475,20 @@ window.onload = async function() {
         video_select.append(option);
       }
     }
-    const option = document.createElement('option');
-    option.value = "screen";
-    option.text = "screen";
-    video_select.append(option);
+    const screen = document.createElement('option');
+    screen.value = "screen";
+    screen.text = "screen";
+    video_select.append(screen);
+
+    const facingModeUser = document.createElement('option');
+    facingModeUser.value = "facingModeUser";
+    facingModeUser.text = "Facing user";
+    video_select.append(facingModeUser);
+
+    const facingModeEnvironment = document.createElement('option');
+    facingModeEnvironment.value = 'facingModeEnvironment';
+    facingModeEnvironment.text = "Facing environment";
+    video_select.append(facingModeEnvironment);
   }
 
   async function build_constraints(audio_select, video_select) {
@@ -500,7 +510,13 @@ window.onload = async function() {
           constraints.display_video(video);
         } else {
           let video = new rust.DeviceVideoTrackConstraints();
-          video.device_id(videoSource.value);
+          if (videoSource.value === 'facingModeUser') {
+            video.exact_facing_mode(rust.FacingMode.User);
+          } else if (videoSource.value === 'facingModeEnvironment') {
+            video.exact_facing_mode(rust.FacingMode.Environment);
+          } else {
+            video.device_id(videoSource.value);
+          }
           constraints.device_video(video);
         }
       } else {

--- a/jason/src/lib.rs
+++ b/jason/src/lib.rs
@@ -30,7 +30,7 @@ pub use self::{
     api::{ConnectionHandle, Jason, RoomHandle},
     media::{
         AudioTrackConstraints, DeviceVideoTrackConstraints,
-        DisplayVideoTrackConstraints, MediaStreamSettings,
+        DisplayVideoTrackConstraints, FacingMode, MediaStreamSettings,
     },
 };
 

--- a/jason/src/media/constraints.rs
+++ b/jason/src/media/constraints.rs
@@ -630,6 +630,8 @@ pub struct DeviceVideoTrackConstraints {
     /// If `true` then without this [`DeviceVideoTrackConstraints`] call
     /// session can't be started.
     is_required: bool,
+
+    facing_mode: FacingMode,
 }
 
 impl DeviceVideoTrackConstraints {
@@ -670,6 +672,34 @@ impl DeviceVideoTrackConstraints {
     pub fn device_id(&mut self, device_id: String) {
         self.device_id = Some(device_id);
     }
+
+    /// Sets [facingMode][1] constraint.
+    ///
+    /// [1]: https://tinyurl.com/y2ks2mjj
+    pub fn facing_mode(&mut self, facing_mode: FacingMode) {}
+}
+
+struct Range<T> {
+    min: T,
+    max: T,
+    ideal: T,
+    exact: T,
+}
+
+/// Describes the directions that the camera can face, as seen from the user's
+/// perspective. Representation of [VideoFacingModeEnum][1].
+///
+/// [1]: https://www.w3.org/TR/mediacapture-streams/#dom-videofacingmodeenum
+#[wasm_bindgen]
+enum FacingMode {
+    /// The source is facing toward the user (a self-view camera).
+    User,
+    ///  The source is facing away from the user (viewing the environment).
+    Environment,
+    /// The source is facing to the left of the user.
+    Left,
+    /// The source is facing to the right of the user.
+    Right,
 }
 
 /// Constraints applicable to video tracks sourced from screen capture.

--- a/jason/src/media/constraints.rs
+++ b/jason/src/media/constraints.rs
@@ -688,7 +688,7 @@ where
 ///
 /// [1]: https://www.w3.org/TR/mediacapture-streams/#dom-videofacingmodeenum
 #[wasm_bindgen]
-#[derive(Clone, Copy, PartialEq, Display, Debug)]
+#[derive(Clone, Copy, Debug, Display, PartialEq)]
 pub enum FacingMode {
     /// The source is facing toward the user (a self-view camera).
     #[display(fmt = "user")]

--- a/jason/src/media/constraints.rs
+++ b/jason/src/media/constraints.rs
@@ -627,20 +627,20 @@ impl Constraint for DeviceId {
 /// Describes the directions that the camera can face, as seen from the user's
 /// perspective. Representation of [VideoFacingModeEnum][1].
 ///
-/// [1]: https://www.w3.org/TR/mediacapture-streams/#dom-videofacingmodeenum
+/// [1]: https://w3.org/TR/mediacapture-streams/#dom-videofacingmodeenum
 #[wasm_bindgen]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FacingMode {
-    /// The source is facing toward the user (a self-view camera).
+    /// Facing toward the user (a self-view camera).
     User,
 
-    /// The source is facing away from the user (viewing the environment).
+    /// Facing away from the user (viewing the environment).
     Environment,
 
-    /// The source is facing to the left of the user.
+    /// Facing to the left of the user.
     Left,
 
-    /// The source is facing to the right of the user.
+    /// Facing to the right of the user.
     Right,
 }
 
@@ -661,12 +661,12 @@ impl Constraint for FacingMode {
     }
 }
 
-/// Representation of the [ConstrainDOMString].
+/// Representation of the [ConstrainDOMString][1].
 ///
-/// Can set exact(must be the parameter's value) and ideal(should be used if
+/// Can set exact (must be the parameter's value) and ideal (should be used if
 /// possible) constrain.
 ///
-/// [ConstrainDOMString]: https://tinyurl.com/y6qkebfk
+/// [1]: https://w3.org/TR/mediacapture-streams/#dom-constraindomstring
 #[derive(Clone, Copy, Debug)]
 enum ConstrainString<T> {
     Exact(T),
@@ -767,14 +767,14 @@ impl DeviceVideoTrackConstraints {
 
     /// Sets exact [facingMode][1] constraint.
     ///
-    /// [1]: https://tinyurl.com/y2ks2mjj
+    /// [1]: https://w3.org/TR/mediacapture-streams/#dom-constraindomstring
     pub fn exact_facing_mode(&mut self, facing_mode: FacingMode) {
         self.facing_mode = Some(ConstrainString::Exact(facing_mode));
     }
 
     /// Sets ideal [facingMode][1] constraint.
     ///
-    /// [1]: https://tinyurl.com/y2ks2mjj
+    /// [1]: https://w3.org/TR/mediacapture-streams/#dom-constraindomstring
     pub fn ideal_facing_mode(&mut self, facing_mode: FacingMode) {
         self.facing_mode = Some(ConstrainString::Ideal(facing_mode));
     }

--- a/jason/src/media/constraints.rs
+++ b/jason/src/media/constraints.rs
@@ -633,6 +633,9 @@ pub struct DeviceVideoTrackConstraints {
     /// session can't be started.
     is_required: bool,
 
+    /// [facingMode][1] constraint.
+    ///
+    /// [1]: https://tinyurl.com/y2ks2mjj
     facing_mode: StringConstrain<FacingMode>,
 }
 
@@ -675,21 +678,34 @@ impl DeviceVideoTrackConstraints {
         self.device_id = Some(device_id);
     }
 
-    /// Sets [facingMode][1] constraint.
+    /// Sets exact [facingMode][1] constraint.
     ///
     /// [1]: https://tinyurl.com/y2ks2mjj
     pub fn exact_facing_mode(&mut self, facing_mode: FacingMode) {
         self.facing_mode.set_exact(facing_mode);
     }
 
+    /// Sets ideal [facingMode][1] constraint.
+    ///
+    /// [1]: https://tinyurl.com/y2ks2mjj
     pub fn ideal_facing_mode(&mut self, facing_mode: FacingMode) {
         self.facing_mode.set_ideal(facing_mode);
     }
 }
 
+/// Representation of the [`ConstrainDOMString`].
+///
+/// Can set exact and ideal constrain value.
+///
+/// [`ConstrainDOMString`]: https://tinyurl.com/y6qkebfk
 #[derive(Clone, Copy, Debug)]
 struct StringConstrain<T> {
+    /// If the property can't be set to one of the listed values, matching will
+    /// fail.
     exact: Option<T>,
+
+    /// If possible, one of the listed values will be used, but if it's not
+    /// possible, the user agent will use the closest possible match.
     ideal: Option<T>,
 }
 

--- a/jason/src/media/mod.rs
+++ b/jason/src/media/mod.rs
@@ -11,7 +11,7 @@ mod stream;
 pub use self::{
     constraints::{
         AudioTrackConstraints, DeviceVideoTrackConstraints,
-        DisplayVideoTrackConstraints, LocalStreamConstraints,
+        DisplayVideoTrackConstraints, FacingMode, LocalStreamConstraints,
         MediaStreamSettings, MultiSourceMediaStreamConstraints,
         RecvConstraints, TrackConstraints, VideoTrackConstraints,
     },


### PR DESCRIPTION
Part of #27




## Synopsis

We need to configure exact or ideal [`MediaTrackConstraints.facingMode`] constrain.




## Solution

Add [`MediaTrackConstraints.facingMode`] configuring to the `DeviceVideoTrackConstraints`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
[`MediaTrackConstraints.facingMode`]: https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/facingMode
