### PR TITLE
Rename Event::TracksUpdated to Event::PeerUpdated (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ All user visible changes to this project will be documented in this file. This p
     - `PeerConnection` renegotiation functionality ([#105]);
     - Calculate and send call quality score based on RTC stats ([#132]);
     - Enabling/disabling `MediaTrack`s by receiver ([#127], [#155]);
-    - Send `PeerUpdate::IceRestart` based on RTC stats analysis ([#138]);
+    - Send `PeerUpdate::IceRestart` based on RTC stats analysis ([#138], [#139]);
     - Multiple `Room`s served by one RPC connection support ([#147]);
     - Muting/unmuting `MediaTrack`s ([#156]);
     - State synchronization on a RPC reconnection ([#167]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,11 @@ All user visible changes to this project will be documented in this file. This p
     - Send reason of closing WebSocket connection as [Close](https://tools.ietf.org/html/rfc4566#section-5.14) frame's description ([#58]);
     - Send `Event::RpcSettingsUpdated` when `Member` connects ([#75]);
     - Send relay mode in `Event::PeerCreated` which is used for configuring client's `RtcIceTransportPolicy` ([#79]);
-    - Emit `TracksApplied` event to create new and update existing tracks ([#105]);
+    - Emit `PeerUpdated` event to create new and update existing tracks ([#105], [#139]);
     - `PeerConnection` renegotiation functionality ([#105]);
     - Calculate and send call quality score based on RTC stats ([#132]);
     - Enabling/disabling `MediaTrack`s by receiver ([#127], [#155]);
-    - Send `TrackUpdate::IceRestart` based on RTC stats analysis ([#138]);
+    - Send `PeerUpdate::IceRestart` based on RTC stats analysis ([#138]);
     - Multiple `Room`s served by one RPC connection support ([#147]);
     - Muting/unmuting `MediaTrack`s ([#156]);
     - State synchronization on a RPC reconnection ([#167]).
@@ -85,6 +85,7 @@ All user visible changes to this project will be documented in this file. This p
 [#132]: /../../pull/132
 [#135]: /../../pull/135
 [#138]: /../../pull/138
+[#139]: /../../pull/139
 [#147]: /../../pull/147
 [#153]: /../../pull/153
 [#155]: /../../pull/155

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,7 +2169,7 @@ dependencies = [
  "humantime-serde",
  "hyper 0.14.4",
  "lazy_static",
- "medea-client-api-proto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "medea-client-api-proto",
  "medea-control-api-mock",
  "medea-control-api-proto 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "medea-coturn-telnet-client 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2207,20 +2207,6 @@ dependencies = [
 [[package]]
 name = "medea-client-api-proto"
 version = "0.2.0"
-dependencies = [
- "async-trait",
- "derive_more",
- "medea-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.124",
- "serde_json",
- "serde_with",
-]
-
-[[package]]
-name = "medea-client-api-proto"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1303db14dcbd46378f8e76ad08c48cb36f7c2b619c6fd003740956e7f22fcdcb"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2325,7 +2311,7 @@ dependencies = [
  "futures 0.3.13",
  "js-sys",
  "log",
- "medea-client-api-proto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "medea-client-api-proto",
  "medea-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "medea-reactive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ dotenv = "0.15"
 failure = "0.1"
 futures = { version = "0.3", features = ["compat"] }
 humantime-serde = "1.0"
-medea-client-api-proto = { version = "0.2", features = ["medea"] }
+medea-client-api-proto = { path = "proto/client-api", features = ["medea"] }
 medea-control-api-proto = "0.1"
 medea-macro = { path = "crates/medea-macro" }
 rand = "0.8"

--- a/docs/rfc/0002-webrtc-client-api.md
+++ b/docs/rfc/0002-webrtc-client-api.md
@@ -194,7 +194,7 @@ struct VideoSettings {}
 
 [WebSocket] messages from `Media Server` to `Web Client`.
 
-The naming for `Event` follows the convention `<entity><passive-verb>`, for example: `PeerCreated`, `TracksApplied`, `PeersRemoved`.
+The naming for `Event` follows the convention `<entity><passive-verb>`, for example: `PeerCreated`, `PeerUpdated`, `PeersRemoved`.
 
 The format of `Event` [WebSocket] message may be implemented as the following:
 ```rust
@@ -386,21 +386,34 @@ struct PeersRemoved {
 ```
 </details>
 
-#### 3. TracksApplied
+#### 3. PeerUpdated
 
 ```rust
-struct TracksApplied {
+pub enum NegotiationRole {
+    Offerer,
+    Answerer(String),
+}
+
+enum PeerUpdate {
+    Added(Track),
+    Updated(TrackPatch),
+    IceRestart,
+}
+
+struct PeerUpdated {
     peer_id: u64,
-    tracks: Vec<Track>,
+    updates: Vec<PeerUpdate>,
+    negotiation_role: Option<NegotiationRole>,
 }
 ```
 
-`Media Server` notifies about necessity to update `Track`s in specified `Peer`.
+`Media Server` notifies about necessity to update specified `Peer`.
 
 It can be used to:
 1. Add new `Track`.
 2. Update existing `Track` settings (e.g. change to lower video resolution, mute audio).
 3. Update `send` `Track` receivers list (add/remove).
+4. Perform ICE restart.
 
 ##### Examples 
 
@@ -774,7 +787,7 @@ struct ApplyTracks {
 }
 ```
 
-`Web Client` asks permission to update `Track`s in specified `Peer`. `Media Server` gives permission by sending `TracksApplied` event.
+`Web Client` asks permission to update `Track`s in specified `Peer`. `Media Server` gives permission by sending `PeerUpdated` event.
 
 It can be used to express `Web Client`'s intentions to:
 1. Update existing `Track` settings.
@@ -884,7 +897,7 @@ struct MakeSdpOffer {
 
 `Web Client` can send it:
 1. As reaction to `PeerCreated {sdp_offer: None}` event.
-2. As reaction to `TracksApplied` event if update requires SDP re-negotiation.
+2. As reaction to `PeerUpdated` event if update requires SDP re-negotiation.
 
 ##### Examples
 
@@ -987,7 +1000,7 @@ enum RemotePeerTrackType {
 }
 ```
 
-`Web Client` asks permission to send or receive media to/from specified remote `Peer`. `Media Server` may gives permission by sending `TracksApplied` event.
+`Web Client` asks permission to send or receive media to/from specified remote `Peer`. `Media Server` may gives permission by sending `PeerUpdated` event.
 
 Params:
 1. `peer_id`: if `Some`, then `Web Client` wants to connect specified local `Peer` to remote one; if `None`, then `Media Server`
@@ -1107,7 +1120,7 @@ Metrics list will be extended as needed.
 
 #### 10. UpdateTracks
 
-`Web Client` asks permission to update `Track`s in specified `Peer`. `Media Server` gives permission by sending `Event::TracksApplied`.
+`Web Client` asks permission to update `Track`s in specified `Peer`. `Media Server` gives permission by sending `Event::PeerUpdated`.
 
 ```rust
 struct UpdateTracks {
@@ -1487,7 +1500,7 @@ struct TrackPatch {
 
     ```json
     {
-      "event": "TracksApplied",
+      "event": "PeerUpdated",
       "data": {
         "peer_id": 2,
         "tracks": [{
@@ -1519,7 +1532,7 @@ struct TrackPatch {
 
     ```json
     {
-      "event": "TracksApplied",
+      "event": "PeerUpdated",
       "data": {
         "peer_id": 1,
         "tracks": [{
@@ -1784,7 +1797,7 @@ struct TrackPatch {
 
     ```json
     {
-      "event": "TracksApplied",
+      "event": "PeerUpdated",
       "data": {
         "peer_id": 1,
         "tracks": [{
@@ -1930,7 +1943,7 @@ struct TrackPatch {
 
     ```json
     {
-      "event": "TracksApplied",
+      "event": "PeerUpdated",
       "data": {
         "peer_id": 1,
         "tracks": [{

--- a/jason/CHANGELOG.md
+++ b/jason/CHANGELOG.md
@@ -94,7 +94,7 @@ All user visible changes to this project will be documented in this file. This p
         - Enabling/disabling audio/video send/receive via `UpdateTracks` command ([#81], [#155]);
         - Muting/unmuting audio/video send via `UpdateTracks` ([#156]).
     - Handling of RPC events:
-        - `PeerUpdated` with `PeerUpdate::Added`, `PeerUpdate::Updated` and `PeerUpdate::IceRestart` ([#105], [#138]);
+        - `PeerUpdated` with `PeerUpdate::Added`, `PeerUpdate::Updated` and `PeerUpdate::IceRestart` ([#105], [#138], [#139]);
         - `ConnectionQualityUpdated` ([#132]).
 - Error handling:
     - Library API:
@@ -127,6 +127,7 @@ All user visible changes to this project will be documented in this file. This p
 [#132]: /../../pull/132
 [#137]: /../../pull/137
 [#138]: /../../pull/138
+[#139]: /../../pull/139
 [#143]: /../../pull/143
 [#144]: /../../pull/144
 [#145]: /../../pull/145

--- a/jason/CHANGELOG.md
+++ b/jason/CHANGELOG.md
@@ -94,7 +94,7 @@ All user visible changes to this project will be documented in this file. This p
         - Enabling/disabling audio/video send/receive via `UpdateTracks` command ([#81], [#155]);
         - Muting/unmuting audio/video send via `UpdateTracks` ([#156]).
     - Handling of RPC events:
-        - `TracksApplied` with `TrackUpdate::Added`, `TrackUpdate::Updated` and `TrackUpdate::IceRestart` ([#105], [#138]);
+        - `PeerUpdated` with `PeerUpdate::Added`, `PeerUpdate::Updated` and `PeerUpdate::IceRestart` ([#105], [#138]);
         - `ConnectionQualityUpdated` ([#132]).
 - Error handling:
     - Library API:

--- a/jason/Cargo.toml
+++ b/jason/Cargo.toml
@@ -32,7 +32,7 @@ fragile = { version = "1.0", optional = true }
 futures = "0.3"
 js-sys = "0.3"
 log = "0.4"
-medea-client-api-proto = { version = "0.2", features = ["jason"] }
+medea-client-api-proto = { path = "../proto/client-api", features = ["jason"] }
 medea-macro = "0.2"
 medea-reactive = "0.1"
 mockall = { version = "0.9", optional = true }

--- a/jason/tests/api/room.rs
+++ b/jason/tests/api/room.rs
@@ -16,7 +16,7 @@ use futures::{
 use medea_client_api_proto::{
     state, AudioSettings, Command, Direction, Event, IceConnectionState,
     MediaSourceKind, MediaType, MemberId, NegotiationRole, PeerId, PeerMetrics,
-    Track, TrackId, TrackPatchCommand, TrackPatchEvent, TrackUpdate,
+    PeerUpdate, Track, TrackId, TrackPatchCommand, TrackPatchEvent,
     VideoSettings,
 };
 use medea_jason::{
@@ -91,11 +91,11 @@ async fn get_test_room_and_exist_peer(
                 tracks_patches,
             } => {
                 event_tx_clone
-                    .unbounded_send(Event::TracksApplied {
+                    .unbounded_send(Event::PeerUpdated {
                         peer_id,
                         updates: tracks_patches
                             .into_iter()
-                            .map(|p| TrackUpdate::Updated(p.into()))
+                            .map(|p| PeerUpdate::Updated(p.into()))
                             .collect(),
                         negotiation_role: None,
                     })
@@ -742,9 +742,9 @@ mod disable_send_tracks {
             _ => unreachable!(),
         }
         event_tx
-            .unbounded_send(Event::TracksApplied {
+            .unbounded_send(Event::PeerUpdated {
                 peer_id: PeerId(1),
-                updates: vec![TrackUpdate::Updated(TrackPatchEvent {
+                updates: vec![PeerUpdate::Updated(TrackPatchEvent {
                     id: TrackId(1),
                     enabled_individual: Some(false),
                     enabled_general: Some(false),
@@ -822,9 +822,9 @@ mod disable_send_tracks {
             _ => unreachable!(),
         }
         event_tx
-            .unbounded_send(Event::TracksApplied {
+            .unbounded_send(Event::PeerUpdated {
                 peer_id: PeerId(1),
-                updates: vec![TrackUpdate::Updated(TrackPatchEvent {
+                updates: vec![PeerUpdate::Updated(TrackPatchEvent {
                     id: TrackId(1),
                     enabled_individual: None,
                     enabled_general: None,
@@ -903,9 +903,9 @@ mod disable_send_tracks {
             _ => unreachable!(),
         }
         event_tx
-            .unbounded_send(Event::TracksApplied {
+            .unbounded_send(Event::PeerUpdated {
                 peer_id: PeerId(1),
-                updates: vec![TrackUpdate::Updated(TrackPatchEvent {
+                updates: vec![PeerUpdate::Updated(TrackPatchEvent {
                     id: TrackId(2),
                     enabled_individual: Some(false),
                     enabled_general: Some(false),
@@ -1229,9 +1229,9 @@ mod patches_generation {
             if let Some(audio_track_id) = audio_track_id {
                 let state = (audio_track_media_state_fn)(i);
                 event_tx
-                    .unbounded_send(Event::TracksApplied {
+                    .unbounded_send(Event::PeerUpdated {
                         peer_id: PeerId(i + 1),
-                        updates: vec![TrackUpdate::Updated(TrackPatchEvent {
+                        updates: vec![PeerUpdate::Updated(TrackPatchEvent {
                             id: audio_track_id,
                             enabled_individual: Some(matches!(
                                 state,
@@ -1679,10 +1679,10 @@ async fn disable_by_server() {
     .await;
 
     event_tx
-        .unbounded_send(Event::TracksApplied {
+        .unbounded_send(Event::PeerUpdated {
             peer_id: peer.id(),
             negotiation_role: None,
-            updates: vec![TrackUpdate::Updated(TrackPatchEvent {
+            updates: vec![PeerUpdate::Updated(TrackPatchEvent {
                 id: audio_track_id,
                 enabled_general: Some(false),
                 enabled_individual: Some(false),
@@ -1710,10 +1710,10 @@ async fn enable_by_server() {
     assert_eq!(mock.get_user_media_requests_count(), 1);
 
     event_tx
-        .unbounded_send(Event::TracksApplied {
+        .unbounded_send(Event::PeerUpdated {
             peer_id: peer.id(),
             negotiation_role: None,
-            updates: vec![TrackUpdate::Updated(TrackPatchEvent {
+            updates: vec![PeerUpdate::Updated(TrackPatchEvent {
                 id: audio_track_id,
                 enabled_general: Some(false),
                 enabled_individual: Some(false),
@@ -1727,12 +1727,12 @@ async fn enable_by_server() {
 
     assert_eq!(mock.get_user_media_requests_count(), 1);
     event_tx
-        .unbounded_send(Event::TracksApplied {
+        .unbounded_send(Event::PeerUpdated {
             peer_id: peer.id(),
             negotiation_role: Some(NegotiationRole::Answerer(
                 "SDP".to_string(),
             )),
-            updates: vec![TrackUpdate::Updated(TrackPatchEvent {
+            updates: vec![PeerUpdate::Updated(TrackPatchEvent {
                 id: audio_track_id,
                 enabled_general: Some(true),
                 enabled_individual: Some(true),
@@ -1765,10 +1765,10 @@ async fn only_one_gum_performed_on_enable() {
     assert_eq!(mock.get_user_media_requests_count(), 1);
 
     event_tx
-        .unbounded_send(Event::TracksApplied {
+        .unbounded_send(Event::PeerUpdated {
             peer_id: peer.id(),
             negotiation_role: Some(NegotiationRole::Offerer),
-            updates: vec![TrackUpdate::Updated(TrackPatchEvent {
+            updates: vec![PeerUpdate::Updated(TrackPatchEvent {
                 id: audio_track_id,
                 enabled_general: Some(false),
                 enabled_individual: Some(false),
@@ -1784,10 +1784,10 @@ async fn only_one_gum_performed_on_enable() {
     mock.error_get_user_media("only_one_gum_performed_on_enable".into());
 
     event_tx
-        .unbounded_send(Event::TracksApplied {
+        .unbounded_send(Event::PeerUpdated {
             peer_id: peer.id(),
             negotiation_role: Some(NegotiationRole::Offerer),
-            updates: vec![TrackUpdate::Updated(TrackPatchEvent {
+            updates: vec![PeerUpdate::Updated(TrackPatchEvent {
                 id: audio_track_id,
                 enabled_general: Some(false),
                 enabled_individual: Some(false),
@@ -1886,7 +1886,7 @@ async fn set_media_state_return_media_error() {
 }
 
 /// Checks that only one get user media request will be performed on
-/// [`Event::TracksApplied`] with a failed get user media.
+/// [`Event::PeerUpdated`] with a failed get user media.
 #[wasm_bindgen_test]
 async fn only_one_gum_performed_on_enable_by_server() {
     let mock = MockNavigator::new();
@@ -1900,10 +1900,10 @@ async fn only_one_gum_performed_on_enable_by_server() {
     assert_eq!(mock.get_user_media_requests_count(), 1);
 
     event_tx
-        .unbounded_send(Event::TracksApplied {
+        .unbounded_send(Event::PeerUpdated {
             peer_id: peer.id(),
             negotiation_role: None,
-            updates: vec![TrackUpdate::Updated(TrackPatchEvent {
+            updates: vec![PeerUpdate::Updated(TrackPatchEvent {
                 id: audio_track_id,
                 enabled_general: Some(false),
                 enabled_individual: Some(false),
@@ -1918,10 +1918,10 @@ async fn only_one_gum_performed_on_enable_by_server() {
     mock.error_get_user_media("only_one_gum_performed_on_enable".into());
 
     event_tx
-        .unbounded_send(Event::TracksApplied {
+        .unbounded_send(Event::PeerUpdated {
             peer_id: peer.id(),
             negotiation_role: None,
-            updates: vec![TrackUpdate::Updated(TrackPatchEvent {
+            updates: vec![PeerUpdate::Updated(TrackPatchEvent {
                 id: audio_track_id,
                 enabled_general: Some(false),
                 enabled_individual: Some(false),
@@ -1978,10 +1978,10 @@ async fn send_enabling_holds_local_tracks() {
     // wait until Event::PeerCreated is handled
     delay_for(200).await;
     event_tx
-        .unbounded_send(Event::TracksApplied {
+        .unbounded_send(Event::PeerUpdated {
             peer_id: PeerId(1),
             negotiation_role: None,
-            updates: vec![TrackUpdate::Updated(TrackPatchEvent {
+            updates: vec![PeerUpdate::Updated(TrackPatchEvent {
                 id: video_track_id,
                 enabled_individual: Some(false),
                 enabled_general: Some(false),
@@ -1989,7 +1989,7 @@ async fn send_enabling_holds_local_tracks() {
             })],
         })
         .unwrap();
-    // wait until Event::TracksApplied is handled
+    // wait until Event::PeerUpdated is handled
     delay_for(50).await;
 
     let mock = MockNavigator::new();
@@ -2110,11 +2110,11 @@ mod set_local_media_settings {
                         tracks_patches,
                     } => {
                         event_tx
-                            .unbounded_send(Event::TracksApplied {
+                            .unbounded_send(Event::PeerUpdated {
                                 peer_id,
                                 updates: tracks_patches
                                     .into_iter()
-                                    .map(|p| TrackUpdate::Updated(p.into()))
+                                    .map(|p| PeerUpdate::Updated(p.into()))
                                     .collect(),
                                 negotiation_role: None,
                             })

--- a/proto/client-api/CHANGELOG.md
+++ b/proto/client-api/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.3.0] · 2021-03-19 · To-be-done
+[0.3.0]: /../../tree/medea-client-api-proto-0.3.0/proto/client-api
+
+[Diff](/../../compare/medea-client-api-proto-0.2.0...medea-client-api-proto-0.3.0) | [Milestone](/../../milestone/2)
+
+### BC Breaks
+
+- `TracksApplied` event renamed as `PeerUpdated` ([#139]).
+
+[#139]: /../../pull/139
+
+
+
+
 ## [0.2.0] · 2021-02-01
 [0.2.0]: /../../tree/medea-client-api-proto-0.2.0/proto/client-api
 
@@ -55,7 +69,7 @@ All user visible changes to this project will be documented in this file. This p
     - `RtcIceServerStats`.
 - `Cancelled` state to the `KnownIceCandidatePairState` ([#102]);
 - `required` field to `AudioSettings` and `VideoSettings` ([#106], [#155]);
-- `PeerUpdated` event with `PeerUpdate::Updated` and `PeerUpdate::Added` variants ([#81], [#105], [#139]);
+- `TracksApplied` event with `TrackUpdate::Updated` and `TrackUpdate::Added` variants ([#81], [#105]);
 - `ConnectionQualityUpdated` event ([#132]);
 - `TrackPatchCommand` ([#127]):
     - `enabled` ([#127], [#155]);
@@ -64,7 +78,7 @@ All user visible changes to this project will be documented in this file. This p
     - `enabled_individual` ([#127], [#155]);
     - `enabled_general` ([#127], [#155]);
     - `muted` ([#156]).
-- `IceRestart` variant to `PeerUpdate` ([#138], [#139]);
+- `IceRestart` variant to `TrackUpdate` ([#138]);
 - `source_kind` field to `VideoSettings` type ([#145]);
 - `RoomId` and `Credential` types ([#148]);
 - `JoinRoom` and `LeaveRoom` client messages ([#147]);
@@ -92,7 +106,6 @@ All user visible changes to this project will be documented in this file. This p
 [#132]: /../../pull/132
 [#127]: /../../pull/127
 [#138]: /../../pull/138
-[#139]: /../../pull/139
 [#145]: /../../pull/145
 [#147]: /../../pull/147
 [#148]: /../../pull/148

--- a/proto/client-api/CHANGELOG.md
+++ b/proto/client-api/CHANGELOG.md
@@ -55,7 +55,7 @@ All user visible changes to this project will be documented in this file. This p
     - `RtcIceServerStats`.
 - `Cancelled` state to the `KnownIceCandidatePairState` ([#102]);
 - `required` field to `AudioSettings` and `VideoSettings` ([#106], [#155]);
-- `TracksApplied` event with `TrackUpdate::Updated` and `TrackUpdate::Added` variants ([#81], [#105]);
+- `PeerUpdated` event with `PeerUpdate::Updated` and `PeerUpdate::Added` variants ([#81], [#105]);
 - `ConnectionQualityUpdated` event ([#132]);
 - `TrackPatchCommand` ([#127]):
     - `enabled` ([#127], [#155]);
@@ -64,7 +64,7 @@ All user visible changes to this project will be documented in this file. This p
     - `enabled_individual` ([#127], [#155]);
     - `enabled_general` ([#127], [#155]);
     - `muted` ([#156]).
-- `IceRestart` variant to `TrackUpdate` ([#138]);
+- `IceRestart` variant to `PeerUpdate` ([#138]);
 - `source_kind` field to `VideoSettings` type ([#145]);
 - `RoomId` and `Credential` types ([#148]);
 - `JoinRoom` and `LeaveRoom` client messages ([#147]);

--- a/proto/client-api/CHANGELOG.md
+++ b/proto/client-api/CHANGELOG.md
@@ -55,7 +55,7 @@ All user visible changes to this project will be documented in this file. This p
     - `RtcIceServerStats`.
 - `Cancelled` state to the `KnownIceCandidatePairState` ([#102]);
 - `required` field to `AudioSettings` and `VideoSettings` ([#106], [#155]);
-- `PeerUpdated` event with `PeerUpdate::Updated` and `PeerUpdate::Added` variants ([#81], [#105]);
+- `PeerUpdated` event with `PeerUpdate::Updated` and `PeerUpdate::Added` variants ([#81], [#105], [#139]);
 - `ConnectionQualityUpdated` event ([#132]);
 - `TrackPatchCommand` ([#127]):
     - `enabled` ([#127], [#155]);
@@ -64,7 +64,7 @@ All user visible changes to this project will be documented in this file. This p
     - `enabled_individual` ([#127], [#155]);
     - `enabled_general` ([#127], [#155]);
     - `muted` ([#156]).
-- `IceRestart` variant to `PeerUpdate` ([#138]);
+- `IceRestart` variant to `PeerUpdate` ([#138], [#139]);
 - `source_kind` field to `VideoSettings` type ([#145]);
 - `RoomId` and `Credential` types ([#148]);
 - `JoinRoom` and `LeaveRoom` client messages ([#147]);
@@ -92,6 +92,7 @@ All user visible changes to this project will be documented in this file. This p
 [#132]: /../../pull/132
 [#127]: /../../pull/127
 [#138]: /../../pull/138
+[#139]: /../../pull/139
 [#145]: /../../pull/145
 [#147]: /../../pull/147
 [#148]: /../../pull/148

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -228,7 +228,7 @@ pub enum Command {
     },
 
     /// Web Client asks permission to update [`Track`]s in specified Peer.
-    /// Media Server gives permission by sending [`Event::TracksApplied`].
+    /// Media Server gives permission by sending [`Event::PeerUpdated`].
     UpdateTracks {
         peer_id: PeerId,
         tracks_patches: Vec<TrackPatchCommand>,
@@ -443,12 +443,12 @@ pub enum Event {
 
     /// Media Server notifies about necessity to update [`Track`]s in specified
     /// `Peer`.
-    TracksApplied {
+    PeerUpdated {
         /// [`PeerId`] of `Peer` where [`Track`]s should be updated.
         peer_id: PeerId,
 
-        /// List of [`TrackUpdate`]s which should be applied.
-        updates: Vec<TrackUpdate>,
+        /// List of [`PeerUpdate`]s which should be applied.
+        updates: Vec<PeerUpdate>,
 
         /// Negotiation role basing on which should be sent
         /// [`Command::MakeSdpOffer`] or [`Command::MakeSdpAnswer`].
@@ -492,7 +492,7 @@ pub enum NegotiationRole {
 /// [`Track`] update which should be applied to the `Peer`.
 #[cfg_attr(feature = "medea", derive(Clone, Debug, Eq, PartialEq, Serialize))]
 #[cfg_attr(feature = "jason", derive(Deserialize))]
-pub enum TrackUpdate {
+pub enum PeerUpdate {
     /// New [`Track`] should be added to the `Peer`.
     Added(Track),
 
@@ -543,7 +543,7 @@ pub struct TrackPatchCommand {
 }
 
 /// Patch of the [`Track`] which Media Server can send with
-/// [`Event::TracksApplied`].
+/// [`Event::PeerUpdated`].
 #[cfg_attr(feature = "medea", derive(Clone, Debug, Eq, PartialEq, Serialize))]
 #[cfg_attr(feature = "jason", derive(Deserialize))]
 pub struct TrackPatchEvent {
@@ -638,7 +638,7 @@ pub struct IceServer {
 #[cfg_attr(feature = "medea", derive(Eq, PartialEq, Serialize))]
 #[cfg_attr(feature = "jason", derive(Deserialize))]
 #[derive(Clone, Debug)]
-// TODO: Use different struct without mids in TracksApplied event.
+// TODO: Use different struct without mids in PeerUpdated event.
 pub enum Direction {
     Send {
         receivers: Vec<MemberId>,

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -33,11 +33,11 @@
 //! # Implementing [`Peer`]'s update that requires (re)negotiation
 //!
 //! 1. All changes that require (re)negotiation should be done by adding a new
-//!    variant into [`TrackChange`].
-//! 2. Implement your changing logic in the [`TrackChangeHandler`]
+//!    variant into [`PeerChange`].
+//! 2. Implement your changing logic in the [`PeerChangeHandler`]
 //!    implementation.
 //! 3. Create a function in the [`PeerChangesScheduler`] which will schedule
-//!    your change by adding it into the [`Context::track_changes_queue`].
+//!    your change by adding it into the [`Context::peer_changes_queue`].
 //!
 //! # Applying changes regardless of [`Peer`] state
 //!
@@ -304,7 +304,7 @@ impl PeerStateMachine {
     }
 
     /// Indicates whether this [`PeerStateMachine`] can forcibly commit a
-    /// [`TrackChange::PartnerTrackPatch`].
+    /// [`PeerChange::PartnerTrackPatch`].
     #[inline]
     #[must_use]
     pub fn can_forcibly_commit_partner_patches(&self) -> bool {
@@ -445,12 +445,12 @@ pub struct Context {
     /// Indicator whether this [`Peer`] was created on remote.
     is_known_to_remote: bool,
 
-    /// Tracks changes, that remote [`Peer`] is not aware of.
-    pending_track_updates: Vec<TrackChange>,
+    /// [`Peer`] changes, that remote [`Peer`] is not aware of.
+    pending_peer_changes: Vec<PeerChange>,
 
-    /// Queue of the [`TrackChange`]s that are scheduled to apply when this
+    /// Queue of the [`PeerChange`]s that are scheduled to apply when this
     /// [`Peer`] will be in a [`Stable`] state.
-    track_changes_queue: Vec<TrackChange>,
+    peer_changes_queue: Vec<PeerChange>,
 
     /// Subscriber to the events which indicates that negotiation process
     /// should be started for this [`Peer`].
@@ -472,10 +472,10 @@ pub struct Context {
     initialization_state: InitializationState,
 }
 
-/// Tracks changes, that remote [`Peer`] is not aware of.
+/// [`Peer`] changes, that remote [`Peer`] is not aware of.
 #[dispatchable]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum TrackChange {
+pub enum PeerChange {
     /// [`MediaTrack`]s with [`Direction::Send`] of this [`Peer`] that remote
     /// Peer is not aware of.
     AddSendTrack(Rc<MediaTrack>),
@@ -495,8 +495,8 @@ pub enum TrackChange {
     IceRestart,
 }
 
-impl TrackChange {
-    /// Indicates whether this [`TrackChange`] doesn't require renegotiation.
+impl PeerChange {
+    /// Indicates whether this [`PeerChange`] doesn't require renegotiation.
     #[inline]
     #[must_use]
     fn is_negotiation_state_agnostic(&self) -> bool {
@@ -511,9 +511,9 @@ impl TrackChange {
         )
     }
 
-    /// Tries to return new [`Track`] based on this [`TrackChange`].
+    /// Tries to return new [`Track`] based on this [`PeerChange`].
     ///
-    /// Returns `None` if this [`TrackChange`] doesn't indicates new [`Track`]
+    /// Returns `None` if this [`PeerChange`] doesn't indicates new [`Track`]
     /// creation.
     fn as_new_track(&self, partner_member_id: MemberId) -> Option<Track> {
         match self.as_peer_update(partner_member_id) {
@@ -522,7 +522,7 @@ impl TrackChange {
         }
     }
 
-    /// Returns [`PeerUpdate`] based on this [`TrackChange`].
+    /// Returns [`PeerUpdate`] based on this [`PeerChange`].
     fn as_peer_update(&self, partner_member_id: MemberId) -> PeerUpdate {
         match self {
             Self::AddSendTrack(track) => PeerUpdate::Added(Track {
@@ -549,7 +549,7 @@ impl TrackChange {
         }
     }
 
-    /// Returns `true` if this [`TrackChange`] can be forcibly applied.
+    /// Returns `true` if this [`PeerChange`] can be forcibly applied.
     fn can_force_apply(&self) -> bool {
         match self {
             Self::AddSendTrack(_)
@@ -560,15 +560,15 @@ impl TrackChange {
     }
 }
 
-impl<T> TrackChangeHandler for Peer<T> {
-    type Output = TrackChange;
+impl<T> PeerChangeHandler for Peer<T> {
+    type Output = PeerChange;
 
     /// Inserts provided [`MediaTrack`] into [`Context::senders`].
     #[inline]
     fn on_add_send_track(&mut self, track: Rc<MediaTrack>) -> Self::Output {
         self.context.senders.insert(track.id(), Rc::clone(&track));
 
-        TrackChange::AddSendTrack(track)
+        PeerChange::AddSendTrack(track)
     }
 
     /// Inserts provided [`MediaTrack`] into [`Context::receivers`].
@@ -576,7 +576,7 @@ impl<T> TrackChangeHandler for Peer<T> {
     fn on_add_recv_track(&mut self, track: Rc<MediaTrack>) -> Self::Output {
         self.context.receivers.insert(track.id(), Rc::clone(&track));
 
-        TrackChange::AddRecvTrack(track)
+        PeerChange::AddRecvTrack(track)
     }
 
     /// Applies provided [`TrackPatchEvent`] to [`Peer`]s [`Track`].
@@ -586,7 +586,7 @@ impl<T> TrackChangeHandler for Peer<T> {
         } else if let Some(rx) = self.receivers().get(&patch.id) {
             (rx, false)
         } else {
-            return TrackChange::TrackPatch(patch);
+            return PeerChange::TrackPatch(patch);
         };
 
         if let Some(enabled) = patch.enabled_individual {
@@ -605,7 +605,7 @@ impl<T> TrackChangeHandler for Peer<T> {
             }
         }
 
-        TrackChange::TrackPatch(patch)
+        PeerChange::TrackPatch(patch)
     }
 
     /// Applies provided [`TrackPatchEvent`] that is sourced from this [`Peer`]s
@@ -631,14 +631,14 @@ impl<T> TrackChangeHandler for Peer<T> {
             }
         }
 
-        TrackChange::TrackPatch(patch)
+        PeerChange::TrackPatch(patch)
     }
 
     /// Sets [`Context::ice_restart`] flag to `true`.
     #[inline]
     fn on_ice_restart(&mut self) -> Self::Output {
         self.context.ice_restart = true;
-        TrackChange::IceRestart
+        PeerChange::IceRestart
     }
 }
 
@@ -666,7 +666,7 @@ impl TrackPatchDeduper {
     }
 
     /// Returns new [`TrackPatchDeduper`] with the provided whitelist, meaning
-    /// that [`TrackPatchDeduper::drain_merge`] will drain only [`TrackChange`]s
+    /// that [`TrackPatchDeduper::drain_merge`] will drain only [`PeerChange`]s
     /// with [`TrackId`]s in the provided set.
     fn with_whitelist(whitelist: HashSet<TrackId>) -> Self {
         Self {
@@ -677,14 +677,14 @@ impl TrackPatchDeduper {
 
     /// Drains mergeable [`TrackPatchEvent`]s from the provided [`Vec`], merging
     /// those to accumulative [`TrackPatchEvent`]s list inside this struct.
-    fn drain_merge(&mut self, changes: &mut Vec<TrackChange>) {
+    fn drain_merge(&mut self, changes: &mut Vec<PeerChange>) {
         changes.retain(|change| {
             if !change.can_force_apply() {
                 return true;
             }
             let patch = match change {
-                TrackChange::TrackPatch(patch)
-                | TrackChange::PartnerTrackPatch(patch) => patch,
+                PeerChange::TrackPatch(patch)
+                | PeerChange::PartnerTrackPatch(patch) => patch,
                 _ => return true,
             };
 
@@ -702,11 +702,11 @@ impl TrackPatchDeduper {
         });
     }
 
-    /// Returns [`Iterator`] with all previously merged [`TrackChange`]s.
-    fn into_inner(self) -> impl Iterator<Item = TrackChange> {
+    /// Returns [`Iterator`] with all previously merged [`PeerChange`]s.
+    fn into_inner(self) -> impl Iterator<Item = PeerChange> {
         self.result
             .into_iter()
-            .map(|(_, patch)| TrackChange::TrackPatch(patch))
+            .map(|(_, patch)| PeerChange::TrackPatch(patch))
     }
 }
 
@@ -768,7 +768,7 @@ impl<T> Peer<T> {
     /// [`Event::PeerUpdated`]: medea_client_api_proto::Event::PeerUpdated
     pub fn get_updates(&self) -> Vec<PeerUpdate> {
         self.context
-            .pending_track_updates
+            .pending_peer_changes
             .iter()
             .map(|c| c.as_peer_update(self.partner_member_id()))
             .collect()
@@ -777,7 +777,7 @@ impl<T> Peer<T> {
     /// Returns [`Track`]s that remote [`Peer`] is not aware of.
     pub fn new_tracks(&self) -> Vec<Track> {
         self.context
-            .pending_track_updates
+            .pending_peer_changes
             .iter()
             .filter_map(|c| c.as_new_track(self.partner_member_id()))
             .collect()
@@ -838,19 +838,19 @@ impl<T> Peer<T> {
         &self.context.senders
     }
 
-    /// Forcibly commits all the [`TrackChange::PartnerTrackPatch`]es.
+    /// Forcibly commits all the [`PeerChange::PartnerTrackPatch`]es.
     pub fn force_commit_partner_changes(&mut self) {
         let mut partner_patches = Vec::new();
         // TODO: use drain_filter when its stable
         let mut i = 0;
-        while i != self.context.track_changes_queue.len() {
+        while i != self.context.peer_changes_queue.len() {
             if matches!(
-                self.context.track_changes_queue[i],
-                TrackChange::PartnerTrackPatch(_)
+                self.context.peer_changes_queue[i],
+                PeerChange::PartnerTrackPatch(_)
             ) {
                 let change = self
                     .context
-                    .track_changes_queue
+                    .peer_changes_queue
                     .remove(i)
                     .dispatch_with(self);
                 partner_patches.push(change);
@@ -863,12 +863,12 @@ impl<T> Peer<T> {
             partner_patches
                 .iter()
                 .filter_map(|t| match t {
-                    TrackChange::PartnerTrackPatch(patch) => Some(patch.id),
+                    PeerChange::PartnerTrackPatch(patch) => Some(patch.id),
                     _ => None,
                 })
                 .collect(),
         );
-        deduper.drain_merge(&mut self.context.pending_track_updates);
+        deduper.drain_merge(&mut self.context.pending_peer_changes);
         deduper.drain_merge(&mut partner_patches);
 
         let updates: Vec<_> = deduper
@@ -883,32 +883,32 @@ impl<T> Peer<T> {
         }
     }
 
-    /// Commits all [`TrackChange`]s which are marked as forcible
-    /// ([`TrackChange::can_force_apply`]).
+    /// Commits all [`PeerChange`]s which are marked as forcible
+    /// ([`PeerChange::can_force_apply`]).
     pub fn inner_force_commit_scheduled_changes(&mut self) {
         let mut forcible_changes = Vec::new();
         let mut filtered_changes_queue = Vec::new();
         // TODO: use drain_filter when its stable
-        for change in std::mem::take(&mut self.context.track_changes_queue) {
+        for change in std::mem::take(&mut self.context.peer_changes_queue) {
             if change.can_force_apply() {
                 forcible_changes.push(change.dispatch_with(self));
             } else {
                 filtered_changes_queue.push(change);
             }
         }
-        self.context.track_changes_queue = filtered_changes_queue;
+        self.context.peer_changes_queue = filtered_changes_queue;
 
         let mut deduper = TrackPatchDeduper::with_whitelist(
             forcible_changes
                 .iter()
                 .filter_map(|t| match t {
-                    TrackChange::TrackPatch(patch)
-                    | TrackChange::PartnerTrackPatch(patch) => Some(patch.id),
+                    PeerChange::TrackPatch(patch)
+                    | PeerChange::PartnerTrackPatch(patch) => Some(patch.id),
                     _ => None,
                 })
                 .collect(),
         );
-        deduper.drain_merge(&mut self.context.pending_track_updates);
+        deduper.drain_merge(&mut self.context.pending_peer_changes);
         deduper.drain_merge(&mut forcible_changes);
 
         let updates: Vec<_> = deduper
@@ -948,19 +948,19 @@ impl<T> Peer<T> {
         }
     }
 
-    /// Deduplicates pending [`TrackChange`]s.
+    /// Deduplicates pending [`PeerChange`]s.
     fn dedup_pending_track_updates(&mut self) {
         self.dedup_ice_restarts();
         self.dedup_track_patches();
     }
 
-    /// Dedupes [`TrackChange::IceRestart`]s.
+    /// Dedupes [`PeerChange::IceRestart`]s.
     fn dedup_ice_restarts(&mut self) {
-        let pending_track_updates = &mut self.context.pending_track_updates;
+        let pending_track_updates = &mut self.context.pending_peer_changes;
         let last_ice_restart_rev_index = pending_track_updates
             .iter()
             .rev()
-            .position(|item| matches!(item, TrackChange::IceRestart));
+            .position(|item| matches!(item, PeerChange::IceRestart));
         if let Some(idx) = last_ice_restart_rev_index {
             let last_ice_restart_index = pending_track_updates.len() - 1 - idx;
             pending_track_updates.retain({
@@ -969,18 +969,18 @@ impl<T> Peer<T> {
                     let is_last_ice_restart = i == last_ice_restart_index;
                     i += 1;
                     is_last_ice_restart
-                        || !matches!(item, TrackChange::IceRestart)
+                        || !matches!(item, PeerChange::IceRestart)
                 }
             });
         }
     }
 
-    /// Dedupes [`TrackChange`]s from this [`Peer`].
+    /// Dedupes [`PeerChange`]s from this [`Peer`].
     fn dedup_track_patches(&mut self) {
         let mut deduper = TrackPatchDeduper::new();
-        deduper.drain_merge(&mut self.context.pending_track_updates);
+        deduper.drain_merge(&mut self.context.pending_peer_changes);
         self.context
-            .pending_track_updates
+            .pending_peer_changes
             .extend(deduper.into_inner());
     }
 
@@ -1147,8 +1147,8 @@ impl Peer<Stable> {
             is_force_relayed,
             endpoints: Vec::new(),
             is_known_to_remote: false,
-            pending_track_updates: Vec::new(),
-            track_changes_queue: Vec::new(),
+            pending_peer_changes: Vec::new(),
+            peer_changes_queue: Vec::new(),
             peer_updates_sub,
             ice_candidates: HashSet::new(),
             ice_restart: false,
@@ -1225,7 +1225,7 @@ impl Peer<Stable> {
         Ok(mids)
     }
 
-    /// Applies previously scheduled [`TrackChange`]s to this [`Peer`], marks
+    /// Applies previously scheduled [`PeerChange`]s to this [`Peer`], marks
     /// those changes as applied, so they can be retrieved via
     /// [`PeerStateMachine::get_updates`]. Calls
     /// [`PeerUpdatesSubscriber::negotiation_needed`] notifying subscriber that
@@ -1237,25 +1237,25 @@ impl Peer<Stable> {
         // negotiation, because these changes will be committed by ongoing
         // initializer.
         if self.context.initialization_state == InitializationState::Done
-            && (!self.context.track_changes_queue.is_empty()
+            && (!self.context.peer_changes_queue.is_empty()
                 || matches!(
                     self.context.on_negotiation_finish,
                     OnNegotiationFinish::Renegotiate
                 ))
         {
             let mut negotiationless_changes = Vec::new();
-            for task in std::mem::take(&mut self.context.track_changes_queue) {
+            for task in std::mem::take(&mut self.context.peer_changes_queue) {
                 let change = task.dispatch_with(self);
                 if change.is_negotiation_state_agnostic() {
                     negotiationless_changes.push(change);
                 } else {
-                    self.context.pending_track_updates.push(change);
+                    self.context.pending_peer_changes.push(change);
                 }
             }
 
             self.dedup_pending_track_updates();
 
-            if self.context.pending_track_updates.is_empty()
+            if self.context.pending_peer_changes.is_empty()
                 && matches!(
                     self.context.on_negotiation_finish,
                     OnNegotiationFinish::Noop
@@ -1265,12 +1265,12 @@ impl Peer<Stable> {
                     self.id(),
                     negotiationless_changes
                         .into_iter()
-                        .map(|c| c.as_track_update(self.partner_member_id()))
+                        .map(|c| c.as_peer_update(self.partner_member_id()))
                         .collect(),
                 );
             } else {
                 self.context
-                    .pending_track_updates
+                    .pending_peer_changes
                     .append(&mut negotiationless_changes);
                 self.context.peer_updates_sub.negotiation_needed(self.id());
                 self.context.on_negotiation_finish = OnNegotiationFinish::Noop;
@@ -1290,7 +1290,7 @@ impl Peer<Stable> {
     fn negotiation_finished(&mut self) {
         self.context.ice_restart = false;
         self.context.is_known_to_remote = true;
-        self.context.pending_track_updates.clear();
+        self.context.pending_peer_changes.clear();
         self.context.negotiation_role = None;
         self.commit_scheduled_changes();
     }
@@ -1307,25 +1307,25 @@ pub struct PeerChangesScheduler<'a> {
 
 impl<'a> PeerChangesScheduler<'a> {
     /// Schedules provided [`TrackPatchCommand`]s as
-    /// [`TrackChange::TrackPatch`].
+    /// [`PeerChange::TrackPatch`].
     pub fn patch_tracks(&mut self, patches: Vec<TrackPatchCommand>) {
         for patch in patches {
-            self.schedule_change(TrackChange::TrackPatch(patch.into()));
+            self.schedule_change(PeerChange::TrackPatch(patch.into()));
         }
     }
 
     /// Schedules provided [`TrackPatchCommand`] as
-    /// [`TrackChange::PartnerTrackPatch`].
+    /// [`PeerChange::PartnerTrackPatch`].
     pub fn partner_patch_tracks(&mut self, patches: Vec<TrackPatchCommand>) {
         for patch in patches {
-            self.schedule_change(TrackChange::PartnerTrackPatch(patch.into()));
+            self.schedule_change(PeerChange::PartnerTrackPatch(patch.into()));
         }
     }
 
-    /// Schedules [`TrackChange::IceRestart`].
+    /// Schedules [`PeerChange::IceRestart`].
     #[inline]
     pub fn restart_ice(&mut self) {
-        self.schedule_change(TrackChange::IceRestart);
+        self.schedule_change(PeerChange::IceRestart);
     }
 
     /// Schedules `send` tracks adding to `self` and `recv` tracks for this
@@ -1380,30 +1380,30 @@ impl<'a> PeerChangesScheduler<'a> {
         }
     }
 
-    /// Adds provided [`TrackChange`] to scheduled changes queue.
+    /// Adds provided [`PeerChange`] to scheduled changes queue.
     #[inline]
-    fn schedule_change(&mut self, job: TrackChange) {
-        self.context.track_changes_queue.push(job);
+    fn schedule_change(&mut self, job: PeerChange) {
+        self.context.peer_changes_queue.push(job);
     }
 
     /// Schedules [`Track`] addition to [`Peer`] receive tracks list.
     ///
     /// This [`Track`] will be considered new (not known to remote) and may be
     /// obtained by calling `Peer.new_tracks` after this scheduled
-    /// [`TrackChange`] will be applied.
+    /// [`PeerChange`] will be applied.
     #[inline]
     fn add_receiver(&mut self, track: Rc<MediaTrack>) {
-        self.schedule_change(TrackChange::AddRecvTrack(track));
+        self.schedule_change(PeerChange::AddRecvTrack(track));
     }
 
     /// Schedules [`Track`] addition to [`Peer`] send tracks list.
     ///
     /// This [`Track`] will be considered new (not known to remote) and may be
     /// obtained by calling `Peer.new_tracks` after this scheduled
-    /// [`TrackChange`] will be applied.
+    /// [`PeerChange`] will be applied.
     #[inline]
     fn add_sender(&mut self, track: Rc<MediaTrack>) {
-        self.schedule_change(TrackChange::AddSendTrack(track));
+        self.schedule_change(PeerChange::AddSendTrack(track));
     }
 }
 
@@ -1569,8 +1569,8 @@ pub mod tests {
         let peer = peer.set_remote_answer(String::new());
         assert_eq!(peer.context.receivers.len(), 1);
         assert_eq!(peer.context.senders.len(), 1);
-        assert_eq!(peer.context.pending_track_updates.len(), 2);
-        assert_eq!(peer.context.track_changes_queue.len(), 0);
+        assert_eq!(peer.context.pending_peer_changes.len(), 2);
+        assert_eq!(peer.context.peer_changes_queue.len(), 0);
         assert_eq!(rx.recv().unwrap(), PeerId(0));
     }
 
@@ -1632,7 +1632,7 @@ pub mod tests {
 
         assert_eq!(peer_id, PeerId(0));
         assert_eq!(changes.len(), 2);
-        assert!(peer.context.track_changes_queue.is_empty());
+        assert!(peer.context.peer_changes_queue.is_empty());
         assert!(matches!(
             peer.context.on_negotiation_finish,
             OnNegotiationFinish::Renegotiate
@@ -1717,10 +1717,10 @@ pub mod tests {
 
         let mut track_patches_after: Vec<_> = peer
             .context
-            .pending_track_updates
+            .pending_peer_changes
             .iter()
             .filter_map(|t| {
-                if let TrackChange::TrackPatch(patch) = t {
+                if let PeerChange::TrackPatch(patch) = t {
                     Some(patch.clone())
                 } else {
                     None
@@ -1737,21 +1737,21 @@ pub mod tests {
         assert!(track_patches_after.is_empty());
     }
 
-    /// Checks that [`TrackChange::IceRestart`] correctly dedups.
+    /// Checks that [`PeerChange::IceRestart`] correctly dedups.
     #[test]
     fn ice_restart_dedupping_works() {
         let changes = vec![
-            TrackChange::IceRestart,
-            TrackChange::IceRestart,
-            TrackChange::IceRestart,
-            TrackChange::TrackPatch(TrackPatchEvent {
+            PeerChange::IceRestart,
+            PeerChange::IceRestart,
+            PeerChange::IceRestart,
+            PeerChange::TrackPatch(TrackPatchEvent {
                 id: TrackId(0),
                 enabled_individual: None,
                 enabled_general: None,
                 muted: None,
             }),
-            TrackChange::IceRestart,
-            TrackChange::TrackPatch(TrackPatchEvent {
+            PeerChange::IceRestart,
+            PeerChange::TrackPatch(TrackPatchEvent {
                 id: TrackId(0),
                 enabled_individual: None,
                 enabled_general: None,
@@ -1775,13 +1775,13 @@ pub mod tests {
             Rc::new(negotiation_sub),
         );
 
-        peer.context.pending_track_updates = changes;
+        peer.context.pending_peer_changes = changes;
 
         peer.dedup_ice_restarts();
 
-        let deduped_track_updates = peer.context.pending_track_updates;
+        let deduped_track_updates = peer.context.pending_peer_changes;
         assert_eq!(deduped_track_updates.len(), 3);
-        assert!(matches!(deduped_track_updates[1], TrackChange::IceRestart));
+        assert!(matches!(deduped_track_updates[1], PeerChange::IceRestart));
     }
 
     /// Checks that [`Peer::inner_force_commit_scheduled_changes`] merges
@@ -1811,20 +1811,20 @@ pub mod tests {
             false,
             Rc::new(peer_updates_sub),
         );
-        peer.context.pending_track_updates = vec![
-            TrackChange::TrackPatch(TrackPatchEvent {
+        peer.context.pending_peer_changes = vec![
+            PeerChange::TrackPatch(TrackPatchEvent {
                 id: TrackId(0),
                 enabled_general: Some(false),
                 enabled_individual: Some(false),
                 muted: None,
             }),
-            TrackChange::TrackPatch(TrackPatchEvent {
+            PeerChange::TrackPatch(TrackPatchEvent {
                 id: TrackId(0),
                 enabled_general: Some(true),
                 enabled_individual: Some(true),
                 muted: None,
             }),
-            TrackChange::TrackPatch(TrackPatchEvent {
+            PeerChange::TrackPatch(TrackPatchEvent {
                 id: TrackId(1),
                 enabled_general: Some(false),
                 enabled_individual: Some(false),
@@ -1850,11 +1850,11 @@ pub mod tests {
         ]);
         peer.inner_force_commit_scheduled_changes();
 
-        assert_eq!(peer.context.track_changes_queue.len(), 0);
-        assert_eq!(peer.context.pending_track_updates.len(), 1);
+        assert_eq!(peer.context.peer_changes_queue.len(), 0);
+        assert_eq!(peer.context.pending_peer_changes.len(), 1);
         let filtered_track_change =
-            peer.context.pending_track_updates.pop().unwrap();
-        if let TrackChange::TrackPatch(patch) = filtered_track_change {
+            peer.context.pending_peer_changes.pop().unwrap();
+        if let PeerChange::TrackPatch(patch) = filtered_track_change {
             assert_eq!(patch.id, TrackId(1));
             assert_eq!(patch.enabled_general, Some(false));
         } else {
@@ -1872,13 +1872,13 @@ pub mod tests {
         fn whitelisting_works() {
             let mut deduper =
                 TrackPatchDeduper::with_whitelist(hashset![TrackId(1)]);
-            let filtered_patch = TrackChange::TrackPatch(TrackPatchEvent {
+            let filtered_patch = PeerChange::TrackPatch(TrackPatchEvent {
                 id: TrackId(2),
                 enabled_general: Some(false),
                 enabled_individual: Some(false),
                 muted: None,
             });
-            let whitelisted_patch = TrackChange::TrackPatch(TrackPatchEvent {
+            let whitelisted_patch = PeerChange::TrackPatch(TrackPatchEvent {
                 id: TrackId(1),
                 enabled_general: Some(false),
                 enabled_individual: Some(false),
@@ -1895,7 +1895,7 @@ pub mod tests {
             assert_eq!(merged_changes[0], whitelisted_patch);
         }
 
-        /// Checks that [`TrackPatchDeduper`] merges [`TrackChange`]s correctly.
+        /// Checks that [`TrackPatchDeduper`] merges [`PeerChange`]s correctly.
         #[test]
         fn merging_works() {
             let mut deduper = TrackPatchDeduper::new();
@@ -1933,10 +1933,10 @@ pub mod tests {
                 },
             ]
             .into_iter()
-            .map(|p| TrackChange::TrackPatch(p))
+            .map(|p| PeerChange::TrackPatch(p))
             .collect();
             let unrelated_change =
-                TrackChange::AddSendTrack(Rc::new(MediaTrack::new(
+                PeerChange::AddSendTrack(Rc::new(MediaTrack::new(
                     TrackId(1),
                     MediaType::Audio(AudioSettings { required: true }),
                 )));
@@ -1949,7 +1949,7 @@ pub mod tests {
             let merged_changes: HashMap<_, _> = deduper
                 .into_inner()
                 .filter_map(|t| {
-                    if let TrackChange::TrackPatch(patch) = t {
+                    if let PeerChange::TrackPatch(patch) = t {
                         Some((patch.id, patch))
                     } else {
                         None
@@ -1982,7 +1982,7 @@ pub mod tests {
                 enabled_individual: None,
                 enabled_general: None,
             };
-            let changes = vec![TrackChange::TrackPatch(track_patch.clone())];
+            let changes = vec![PeerChange::TrackPatch(track_patch.clone())];
 
             let mut negotiation_sub = MockPeerUpdatesSubscriber::new();
             negotiation_sub.expect_force_update().times(1).return_once(
@@ -2005,22 +2005,22 @@ pub mod tests {
                 String::new(),
             ));
             peer.set_initialized();
-            peer.context.track_changes_queue = changes;
+            peer.context.peer_changes_queue = changes;
             peer.commit_scheduled_changes();
         }
 
-        /// Checks that [`TrackChange`] which doesn't requires negotiation with
-        /// [`TrackChange`] which requires negotiation will trigger negotiation.
+        /// Checks that [`PeerChange`] which doesn't requires negotiation with
+        /// [`PeerChange`] which requires negotiation will trigger negotiation.
         #[test]
         fn mixed_changeset_will_trigger_negotiation() {
             let changes = vec![
-                TrackChange::TrackPatch(TrackPatchEvent {
+                PeerChange::TrackPatch(TrackPatchEvent {
                     id: TrackId(0),
                     muted: Some(true),
                     enabled_individual: None,
                     enabled_general: None,
                 }),
-                TrackChange::TrackPatch(TrackPatchEvent {
+                PeerChange::TrackPatch(TrackPatchEvent {
                     id: TrackId(1),
                     muted: None,
                     enabled_individual: Some(true),
@@ -2051,7 +2051,7 @@ pub mod tests {
             ));
             peer.set_initialized();
 
-            peer.context.track_changes_queue = changes.clone();
+            peer.context.peer_changes_queue = changes.clone();
             peer.commit_scheduled_changes();
 
             let reversed_changes = {
@@ -2059,14 +2059,14 @@ pub mod tests {
                 changes.reverse();
                 changes
             };
-            assert_eq!(peer.context.pending_track_updates, reversed_changes);
+            assert_eq!(peer.context.pending_peer_changes, reversed_changes);
         }
 
-        /// Checks that [`TrackChange`] which changes negotiationless property
+        /// Checks that [`PeerChange`] which changes negotiationless property
         /// and negotiationful property will trigger negotiation.
         #[test]
         fn mixed_change_will_trigger_negotiation() {
-            let changes = vec![TrackChange::TrackPatch(TrackPatchEvent {
+            let changes = vec![PeerChange::TrackPatch(TrackPatchEvent {
                 id: TrackId(0),
                 muted: Some(true),
                 enabled_individual: Some(true),
@@ -2096,10 +2096,10 @@ pub mod tests {
             ));
             peer.set_initialized();
 
-            peer.context.track_changes_queue = changes.clone();
+            peer.context.peer_changes_queue = changes.clone();
             peer.commit_scheduled_changes();
 
-            assert_eq!(peer.context.pending_track_updates, changes);
+            assert_eq!(peer.context.pending_peer_changes, changes);
         }
     }
 

--- a/src/signalling/peers/mod.rs
+++ b/src/signalling/peers/mod.rs
@@ -798,7 +798,7 @@ mod tests {
     use std::{collections::HashSet, time::Duration};
 
     use futures::{channel::mpsc, future, Stream, StreamExt as _};
-    use medea_client_api_proto::TrackUpdate;
+    use medea_client_api_proto::PeerUpdate;
     use tokio::time::timeout;
 
     use crate::{
@@ -845,7 +845,7 @@ mod tests {
     #[derive(Debug, Clone)]
     struct NegotiationSubMock(
         Rc<RefCell<Vec<mpsc::UnboundedSender<PeerId>>>>,
-        Rc<RefCell<Vec<mpsc::UnboundedSender<(PeerId, Vec<TrackUpdate>)>>>>,
+        Rc<RefCell<Vec<mpsc::UnboundedSender<(PeerId, Vec<PeerUpdate>)>>>>,
     );
 
     impl NegotiationSubMock {
@@ -863,11 +863,11 @@ mod tests {
         }
 
         /// Returns [`Stream`] into which will be sent all [`PeerId`]s and
-        /// [`TrackUpdate`]s of [`Peer`] which are should be forcibly updated.
+        /// [`PeerUpdate`]s of [`Peer`] which are should be forcibly updated.
         #[allow(dead_code)]
         pub fn on_force_update(
             &self,
-        ) -> impl Stream<Item = (PeerId, Vec<TrackUpdate>)> {
+        ) -> impl Stream<Item = (PeerId, Vec<PeerUpdate>)> {
             let (tx, rx) = mpsc::unbounded();
             self.1.borrow_mut().push(tx);
             rx
@@ -885,7 +885,7 @@ mod tests {
 
         /// Sends [`PeerId`] to the [`NegotiationSubMock::on_force_update`]
         /// [`Stream`].
-        fn force_update(&self, peer_id: PeerId, changes: Vec<TrackUpdate>) {
+        fn force_update(&self, peer_id: PeerId, changes: Vec<PeerUpdate>) {
             self.1.borrow().iter().for_each(|sender| {
                 let _ = sender.unbounded_send((peer_id, changes.clone()));
             })

--- a/src/signalling/room/command_handler.rs
+++ b/src/signalling/room/command_handler.rs
@@ -60,7 +60,7 @@ impl CommandHandler for Room {
         })?;
 
         let event = if from_peer.is_known_to_remote() {
-            Event::TracksApplied {
+            Event::PeerUpdated {
                 peer_id: to_peer.id(),
                 negotiation_role: Some(NegotiationRole::Answerer(
                     sdp_offer.clone(),
@@ -195,7 +195,7 @@ impl CommandHandler for Room {
         Ok(())
     }
 
-    /// Sends [`Event::TracksApplied`] with data from the received
+    /// Sends [`Event::PeerUpdated`] with data from the received
     /// [`Command::UpdateTracks`].
     ///
     /// Starts renegotiation process.

--- a/src/signalling/room/mod.rs
+++ b/src/signalling/room/mod.rs
@@ -290,7 +290,7 @@ impl Room {
         }
     }
 
-    /// Sends [`Event::TracksApplied`] with latest [`Peer`] changes to specified
+    /// Sends [`Event::PeerUpdated`] with latest [`Peer`] changes to specified
     /// [`Member`]. Starts renegotiation, marking provided [`Peer`] as
     /// [`NegotiationRole::Offerer`].
     ///
@@ -313,7 +313,7 @@ impl Room {
 
         self.members.send_event_to_member(
             member_id,
-            Event::TracksApplied {
+            Event::PeerUpdated {
                 updates,
                 negotiation_role: Some(NegotiationRole::Offerer),
                 peer_id,

--- a/tests/integration/grpc_control_api/create.rs
+++ b/tests/integration/grpc_control_api/create.rs
@@ -232,7 +232,7 @@ mod endpoint {
     use std::time::Duration;
 
     use futures::{channel::mpsc, StreamExt as _};
-    use medea_client_api_proto::{Event, TrackUpdate};
+    use medea_client_api_proto::{Event, PeerUpdate};
     use tokio::time::timeout;
 
     use super::*;
@@ -404,10 +404,10 @@ mod endpoint {
             credentials.get("publisher").unwrap(),
             Some(Box::new(move |event, _, _| {
                 match event {
-                    Event::TracksApplied { updates, .. } => {
+                    Event::PeerUpdated { updates, .. } => {
                         if updates
                             .iter()
-                            .any(|u| enum_eq!(TrackUpdate::Added, u))
+                            .any(|u| enum_eq!(PeerUpdate::Added, u))
                         {
                             publisher_tx.unbounded_send(()).unwrap();
                         }
@@ -427,8 +427,8 @@ mod endpoint {
         let _responder = TestMember::connect(
             credentials.get("responder").unwrap(),
             Some(Box::new(move |event, _, events| {
-                if let Event::TracksApplied { updates, .. } = event {
-                    if updates.iter().any(|u| enum_eq!(TrackUpdate::Added, u)) {
+                if let Event::PeerUpdated { updates, .. } = event {
+                    if updates.iter().any(|u| enum_eq!(PeerUpdate::Added, u)) {
                         responder_tx.unbounded_send(()).unwrap();
                         let sdp_answer_made_count = events
                             .iter()

--- a/tests/integration/signalling/ice_restart.rs
+++ b/tests/integration/signalling/ice_restart.rs
@@ -7,8 +7,8 @@ use function_name::named;
 use futures::{channel::mpsc::*, StreamExt as _};
 use medea::hashmap;
 use medea_client_api_proto::{
-    Command, Event, NegotiationRole, PeerConnectionState, PeerMetrics, TrackId,
-    TrackUpdate,
+    Command, Event, NegotiationRole, PeerConnectionState, PeerMetrics,
+    PeerUpdate, TrackId,
 };
 
 use crate::{
@@ -168,7 +168,7 @@ async fn ice_restart() {
     {
         let event = responder_rx.next().await.unwrap();
         match event {
-            Event::TracksApplied {
+            Event::PeerUpdated {
                 peer_id,
                 updates,
                 negotiation_role,
@@ -177,7 +177,7 @@ async fn ice_restart() {
                 assert_eq!(negotiation_role, Some(NegotiationRole::Offerer));
                 let is_ice_restart = updates
                     .iter()
-                    .find(|upd| matches!(upd, TrackUpdate::IceRestart))
+                    .find(|upd| matches!(upd, PeerUpdate::IceRestart))
                     .is_some();
                 assert!(is_ice_restart);
             }
@@ -205,7 +205,7 @@ async fn ice_restart() {
     {
         let event = publisher_rx.next().await.unwrap();
         match event {
-            Event::TracksApplied {
+            Event::PeerUpdated {
                 peer_id,
                 updates: _,
                 negotiation_role,

--- a/tests/integration/signalling/mod.rs
+++ b/tests/integration/signalling/mod.rs
@@ -28,8 +28,8 @@ use awc::{
 use futures::{executor, stream::SplitSink, SinkExt as _, StreamExt as _};
 use medea_client_api_proto::{
     ClientMsg, Command, Credential, Event, IceCandidate, MemberId,
-    NegotiationRole, PeerId, RoomId, RpcSettings, ServerMsg, Track, TrackId,
-    TrackUpdate,
+    NegotiationRole, PeerId, PeerUpdate, RoomId, RpcSettings, ServerMsg, Track,
+    TrackId,
 };
 use url::Url;
 
@@ -377,7 +377,7 @@ impl StreamHandler<Result<Frame, WsProtocolError>> for TestMember {
                                     },
                                 });
                             }
-                            Event::TracksApplied {
+                            Event::PeerUpdated {
                                 peer_id,
                                 negotiation_role,
                                 updates,
@@ -385,7 +385,7 @@ impl StreamHandler<Result<Frame, WsProtocolError>> for TestMember {
                                 assert!(self.known_peers.contains(peer_id));
                                 updates.iter().for_each(|t| {
                                     use medea_client_api_proto::Direction;
-                                    if let TrackUpdate::Added(track) = t {
+                                    if let PeerUpdate::Added(track) = t {
                                         let mid = match &track.direction {
                                             Direction::Send { mid, .. }
                                             | Direction::Recv { mid, .. } => {

--- a/tests/integration/signalling/track_disable.rs
+++ b/tests/integration/signalling/track_disable.rs
@@ -13,8 +13,8 @@ use futures::{
     future, Stream, StreamExt,
 };
 use medea_client_api_proto::{
-    Command, Direction, Event, NegotiationRole, PeerId, TrackId,
-    TrackPatchCommand, TrackUpdate,
+    Command, Direction, Event, NegotiationRole, PeerId, PeerUpdate, TrackId,
+    TrackPatchCommand,
 };
 use medea_control_api_proto::grpc::api as proto;
 use tokio::time::timeout;
@@ -32,9 +32,9 @@ use crate::{
 };
 
 // Sends 2 UpdateTracks with provided `enabled`.
-// Waits for single/multiple TracksApplied with expected track changes on on
+// Waits for single/multiple PeerUpdated with expected track changes on on
 // `publisher_rx`.
-// Waits for single/multiple TracksApplied with expected track
+// Waits for single/multiple PeerUpdated with expected track
 // changes on on `subscriber_rx`.
 async fn helper(
     enabled: bool,
@@ -74,14 +74,14 @@ async fn helper(
         let mut first_disabled = false;
         let mut second_disabled = false;
         loop {
-            if let Event::TracksApplied {
+            if let Event::PeerUpdated {
                 peer_id, updates, ..
             } = rx.select_next_some().await
             {
                 assert_eq!(peer_id, expected_peer_id);
                 for update in updates {
                     match update {
-                        TrackUpdate::Updated(patch) => {
+                        PeerUpdate::Updated(patch) => {
                             if let Some(enabled_general) = patch.enabled_general
                             {
                                 assert_eq!(enabled_general, enabled);
@@ -170,20 +170,20 @@ async fn track_disables_and_enables_are_instant() {
     ) -> impl Stream<Item = (bool, Option<NegotiationRole>)> {
         rx.filter_map(|val| async {
             match val {
-                Event::TracksApplied {
+                Event::PeerUpdated {
                     mut updates,
                     negotiation_role,
                     ..
                 } => {
                     match updates.len() {
                         0 => {
-                            // 0 updates means that TracksApplied must proc
+                            // 0 updates means that PeerUpdated must proc
                             // negotiation
                             negotiation_role.unwrap();
                             None
                         }
                         1 => {
-                            if let TrackUpdate::Updated(patch) =
+                            if let PeerUpdate::Updated(patch) =
                                 updates.pop().unwrap()
                             {
                                 Some((patch.enabled_general?, negotiation_role))
@@ -278,9 +278,9 @@ async fn track_disables_and_enables_are_instant() {
     mutes_received_by_pub.dedup();
     assert_eq!(mutes_received_by_pub.len(), mutes_received_by_pub_len);
 
-    // make sure that all TracksApplied events received by sub have
+    // make sure that all PeerUpdated events received by sub have
     // Some(NegotiationRole), meaning that there no point to force push
-    // TracksApplied to other member
+    // PeerUpdated to other member
     assert!(mutes_received_by_sub.iter().all(|val| val.1.is_some()));
 
     assert_eq!(
@@ -387,7 +387,7 @@ async fn track_disables_and_enables_are_instant2() {
         .await
         .unwrap();
     if_let_next! {
-        Event::TracksApplied {
+        Event::PeerUpdated {
             peer_id,
             negotiation_role,
             ..
@@ -409,7 +409,7 @@ async fn track_disables_and_enables_are_instant2() {
         .await
         .unwrap();
     loop {
-        if let Event::TracksApplied {
+        if let Event::PeerUpdated {
             peer_id,
             updates: _,
             negotiation_role,
@@ -453,7 +453,7 @@ async fn force_update_works() {
                         }],
                     }));
                 }
-                Event::TracksApplied {
+                Event::PeerUpdated {
                     negotiation_role,
                     peer_id,
                     ..
@@ -511,7 +511,7 @@ async fn force_update_works() {
                     }],
                 }));
             }
-            Event::TracksApplied {
+            Event::PeerUpdated {
                 negotiation_role, ..
             } => {
                 if negotiation_role.is_none() {
@@ -563,7 +563,7 @@ async fn force_update_works() {
 ///
 /// 5. `Alice` sends SDP offer
 ///
-/// 6. `Bob` should receive [`Event::TracksApplied`] with empty updates
+/// 6. `Bob` should receive [`Event::PeerUpdated`] with empty updates
 #[actix_rt::test]
 #[named]
 async fn ordering_on_force_update_is_correct() {
@@ -674,14 +674,14 @@ async fn ordering_on_force_update_is_correct() {
         .await
         .unwrap();
     if_let_next! {
-        Event::TracksApplied {
+        Event::PeerUpdated {
                 peer_id,
                 negotiation_role,
                 mut updates,
         } = alice_events_rx {
             assert_eq!(peer_id, alice_peer_id);
             let update = updates.pop().unwrap();
-            if let TrackUpdate::Updated(patch) = update {
+            if let PeerUpdate::Updated(patch) = update {
                 assert_eq!(patch.id, alice_sender_id);
                 assert_eq!(patch.enabled_individual, Some(true));
                 assert_eq!(patch.enabled_general, Some(true));
@@ -703,7 +703,7 @@ async fn ordering_on_force_update_is_correct() {
         .await
         .unwrap();
     if_let_next! {
-        Event::TracksApplied {
+        Event::PeerUpdated {
             peer_id,
             negotiation_role,
             mut updates,
@@ -711,7 +711,7 @@ async fn ordering_on_force_update_is_correct() {
         {
             assert_eq!(peer_id, alice_peer_id);
             let update = updates.pop().unwrap();
-            if let TrackUpdate::Updated(patch) = update {
+            if let PeerUpdate::Updated(patch) = update {
                 assert_eq!(patch.id, alice_sender_id);
                 assert_eq!(patch.enabled_individual, Some(false));
                 assert_eq!(patch.enabled_general, Some(false));
@@ -733,7 +733,7 @@ async fn ordering_on_force_update_is_correct() {
     .unwrap();
 
     if_let_next! {
-        Event::TracksApplied {
+        Event::PeerUpdated {
             peer_id,
             negotiation_role,
             updates,
@@ -743,7 +743,7 @@ async fn ordering_on_force_update_is_correct() {
             let mut patches: Vec<_> = updates
                 .into_iter()
                 .map(|upd| {
-                    if let TrackUpdate::Updated(patch) = upd {
+                    if let PeerUpdate::Updated(patch) = upd {
                         patch
                     } else {
                         panic!("Expected TrackPatch fount {:?}", upd);
@@ -776,7 +776,7 @@ async fn ordering_on_force_update_is_correct() {
         .unwrap();
 
     if_let_next! {
-        Event::TracksApplied {
+        Event::PeerUpdated {
             peer_id,
             updates,
             negotiation_role,
@@ -815,13 +815,13 @@ async fn individual_and_general_mute_states_works() {
             let mut stage3_finished = false;
 
             Box::new(move |event, ctx, _| match event {
-                Event::TracksApplied {
+                Event::PeerUpdated {
                     peer_id, updates, ..
                 } => {
                     assert_eq!(peer_id, &PeerId(1));
                     let update = updates.last().unwrap();
                     match update {
-                        TrackUpdate::Updated(patch) => {
+                        PeerUpdate::Updated(patch) => {
                             if STAGE1_PROGRESS.load(Ordering::Relaxed) < 2
                                 && !stage1_finished
                             {
@@ -928,10 +928,10 @@ async fn individual_and_general_mute_states_works() {
                         is_inited = true;
                     }
                 }
-                Event::TracksApplied { updates, .. } => {
+                Event::PeerUpdated { updates, .. } => {
                     let update = updates.last().unwrap();
                     match update {
-                        TrackUpdate::Updated(patch) => {
+                        PeerUpdate::Updated(patch) => {
                             if STAGE1_PROGRESS.load(Ordering::Relaxed) < 2
                                 && !is_stage1_finished
                             {

--- a/tests/integration/signalling/track_mute.rs
+++ b/tests/integration/signalling/track_mute.rs
@@ -1,8 +1,8 @@
 use function_name::named;
 use futures::{channel::mpsc, StreamExt as _};
 use medea_client_api_proto::{
-    Command, Event, PeerId, TrackId, TrackPatchCommand, TrackPatchEvent,
-    TrackUpdate,
+    Command, Event, PeerId, PeerUpdate, TrackId, TrackPatchCommand,
+    TrackPatchEvent,
 };
 
 use crate::{
@@ -63,7 +63,7 @@ async fn track_mute_doesnt_renegotiates() {
         .unwrap();
 
     loop {
-        if let Event::TracksApplied {
+        if let Event::PeerUpdated {
             peer_id,
             updates,
             negotiation_role,
@@ -76,7 +76,7 @@ async fn track_mute_doesnt_renegotiates() {
             assert_eq!(updates.len(), 1);
             assert_eq!(
                 updates[0],
-                TrackUpdate::Updated(TrackPatchEvent {
+                PeerUpdate::Updated(TrackPatchEvent {
                     muted: Some(true),
                     id: TrackId(0),
                     enabled_general: None,
@@ -88,7 +88,7 @@ async fn track_mute_doesnt_renegotiates() {
     }
 
     loop {
-        if let Event::TracksApplied {
+        if let Event::PeerUpdated {
             peer_id,
             updates,
             negotiation_role,
@@ -101,7 +101,7 @@ async fn track_mute_doesnt_renegotiates() {
             assert_eq!(updates.len(), 1);
             assert_eq!(
                 updates[0],
-                TrackUpdate::Updated(TrackPatchEvent {
+                PeerUpdate::Updated(TrackPatchEvent {
                     muted: Some(true),
                     id: TrackId(0),
                     enabled_general: None,
@@ -164,7 +164,7 @@ async fn track_mute_with_disable_will_start_renegotiation() {
         .unwrap();
 
     loop {
-        if let Event::TracksApplied {
+        if let Event::PeerUpdated {
             peer_id,
             updates,
             negotiation_role,
@@ -177,7 +177,7 @@ async fn track_mute_with_disable_will_start_renegotiation() {
             assert_eq!(updates.len(), 1);
             assert_eq!(
                 updates[0],
-                TrackUpdate::Updated(TrackPatchEvent {
+                PeerUpdate::Updated(TrackPatchEvent {
                     muted: Some(true),
                     id: TrackId(0),
                     enabled_general: Some(false),
@@ -189,7 +189,7 @@ async fn track_mute_with_disable_will_start_renegotiation() {
     }
 
     loop {
-        if let Event::TracksApplied {
+        if let Event::PeerUpdated {
             peer_id,
             updates,
             negotiation_role,
@@ -202,7 +202,7 @@ async fn track_mute_with_disable_will_start_renegotiation() {
             assert_eq!(updates.len(), 1);
             assert_eq!(
                 updates[0],
-                TrackUpdate::Updated(TrackPatchEvent {
+                PeerUpdate::Updated(TrackPatchEvent {
                     muted: Some(true),
                     id: TrackId(0),
                     enabled_general: Some(false),


### PR DESCRIPTION
Part of #27




## Synopsis

#138 changes purpose of `Event::TracksApplied` and related objects. Now this objects are used for `Peer` updating instead of `Track`.




## Solution

Rename `Event::TracksApplied` to `PeerUpdated` and all related objects.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
