### PR TITLE
Refactor ControlApiService to more idiomatic async/.await

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "actix-router"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7a10ca4d94e8c8e7a87c5173aba1b97ba9a6563ca02b0e1cd23531093d3ec8"
+checksum = "bbd1f7dbda1645bf7da33554db60891755f6c01c1b2169e2f4c492098d30c235"
 dependencies = [
  "bytestring",
  "http",
@@ -409,7 +409,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
 dependencies = [
- "async-task 4.0.0",
+ "async-task 4.0.1",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
@@ -514,9 +514,9 @@ checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-task"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c37ba09c1b5185eb9897a5cef32770031f58fa92d9a5f79eb50cae5030b39c1"
+checksum = "6725e96011a83fae25074a8734932e8d67763522839be7473dcfe8a0d6a378b1"
 
 [[package]]
 name = "async-trait"
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.4.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cd41440ae7e4734bbd42302f63eaba892afc93a3912dad84006247f0dedb0e"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "failure"
@@ -1424,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
 dependencies = [
  "libc",
 ]

--- a/src/api/control/grpc/server.rs
+++ b/src/api/control/grpc/server.rs
@@ -11,7 +11,6 @@ use actix::{Actor, Addr, Arbiter, Context, Handler, MailboxError};
 use async_trait::async_trait;
 use derive_more::{Display, From};
 use failure::Fail;
-use futures::future::{self, BoxFuture, FutureExt as _, TryFutureExt as _};
 use medea_client_api_proto::MemberId;
 use medea_control_api_proto::grpc::{
     api as proto,
@@ -65,214 +64,142 @@ pub enum GrpcControlApiError {
 }
 
 /// Service which provides gRPC [Control API] implementation.
-#[derive(Clone)]
-struct ControlApiService {
-    /// [`Addr`] of [`RoomService`].
-    room_service: Addr<RoomService>,
+struct ControlApiService(Addr<RoomService>);
 
-    /// Public URL of server. Address for exposed [Client API].
-    ///
-    /// [Client API]: https://tinyurl.com/yx9thsnr
-    public_url: String,
-}
-
-// TODO: This can be easily refactored to async fn's.
 impl ControlApiService {
     /// Implementation of `Create` method for [`Room`].
-    fn create_room(
+    async fn create_room(
         &self,
         spec: RoomSpec,
-    ) -> BoxFuture<'static, Result<Sids, GrpcControlApiError>> {
-        let send_result = self.room_service.send(CreateRoom { spec });
-        async {
-            Ok(send_result
-                .await
-                .map_err(GrpcControlApiError::RoomServiceMailboxError)??)
-        }
-        .boxed()
+    ) -> Result<Sids, GrpcControlApiError> {
+        Ok(self.0.send(CreateRoom { spec }).await??)
     }
 
     /// Implementation of `Create` method for [`Member`] element.
-    fn create_member(
+    async fn create_member(
         &self,
         id: MemberId,
         parent_fid: Fid<ToRoom>,
         spec: MemberSpec,
-    ) -> BoxFuture<'static, Result<Sids, GrpcControlApiError>> {
-        let send_result = self.room_service.send(CreateMemberInRoom {
-            id,
-            parent_fid,
-            spec,
-        });
-        async {
-            Ok(send_result
-                .await
-                .map_err(GrpcControlApiError::RoomServiceMailboxError)??)
-        }
-        .boxed()
+    ) -> Result<Sids, GrpcControlApiError> {
+        Ok(self
+            .0
+            .send(CreateMemberInRoom {
+                id,
+                parent_fid,
+                spec,
+            })
+            .await??)
     }
 
     /// Implementation of `Create` method for [`Endpoint`] element.
-    fn create_endpoint(
+    async fn create_endpoint(
         &self,
         id: EndpointId,
         parent_fid: Fid<ToMember>,
         spec: EndpointSpec,
-    ) -> BoxFuture<'static, Result<Sids, GrpcControlApiError>> {
-        let send_result = self.room_service.send(CreateEndpointInRoom {
-            id,
-            parent_fid,
-            spec,
-        });
-        async {
-            Ok(send_result
-                .await
-                .map_err(GrpcControlApiError::RoomServiceMailboxError)??)
-        }
-        .boxed()
+    ) -> Result<Sids, GrpcControlApiError> {
+        Ok(self
+            .0
+            .send(CreateEndpointInRoom {
+                id,
+                parent_fid,
+                spec,
+            })
+            .await??)
     }
 
     /// Creates element based on provided [`proto::CreateRequest`].
-    pub fn create_element(
+    async fn create_element(
         &self,
         req: proto::CreateRequest,
-    ) -> BoxFuture<'static, Result<Sids, ErrorResponse>> {
+    ) -> Result<Sids, ErrorResponse> {
         let unparsed_parent_fid = req.parent_fid;
         let elem = if let Some(elem) = req.el {
             elem
         } else {
-            return future::err(ErrorResponse::new(
+            return Err(ErrorResponse::new(
                 ErrorCode::NoElement,
                 &unparsed_parent_fid,
-            ))
-            .boxed();
+            ));
         };
 
         if unparsed_parent_fid.is_empty() {
-            return match RoomSpec::try_from(elem).map_err(ErrorResponse::from) {
-                Ok(spec) => self.create_room(spec).err_into().boxed(),
-                Err(e) => future::err(e).boxed(),
-            };
+            return Ok(self.create_room(RoomSpec::try_from(elem)?).await?);
         }
 
-        let parent_fid = match StatefulFid::try_from(unparsed_parent_fid) {
-            Ok(parent_fid) => parent_fid,
-            Err(e) => {
-                return future::err(e.into()).boxed();
-            }
-        };
-
+        let parent_fid = StatefulFid::try_from(unparsed_parent_fid)?;
         match parent_fid {
             StatefulFid::Room(parent_fid) => match elem {
                 proto::create_request::El::Member(member) => {
                     let id: MemberId = member.id.clone().into();
-                    match MemberSpec::try_from(member)
-                        .map_err(ErrorResponse::from)
-                    {
-                        Ok(spec) => self
-                            .create_member(id, parent_fid, spec)
-                            .err_into()
-                            .boxed(),
-                        Err(e) => future::err(e).boxed(),
-                    }
+                    let member_spec = MemberSpec::try_from(member)?;
+                    Ok(self.create_member(id, parent_fid, member_spec).await?)
                 }
-                _ => future::err(ErrorResponse::new(
-                    ElementIdMismatch,
-                    &parent_fid,
-                ))
-                .boxed(),
+                _ => Err(ErrorResponse::new(ElementIdMismatch, &parent_fid)),
             },
             StatefulFid::Member(parent_fid) => {
-                let (endpoint, id) = match elem {
+                let (endpoint_spec, id) = match elem {
                     proto::create_request::El::WebrtcPlay(play) => (
-                        WebRtcPlayEndpoint::try_from(&play)
-                            .map(EndpointSpec::from),
+                        EndpointSpec::from(WebRtcPlayEndpoint::try_from(
+                            &play,
+                        )?),
                         play.id.into(),
                     ),
                     proto::create_request::El::WebrtcPub(publish) => (
-                        Ok(WebRtcPublishEndpoint::from(&publish))
-                            .map(EndpointSpec::from),
+                        EndpointSpec::from(WebRtcPublishEndpoint::from(
+                            &publish,
+                        )),
                         publish.id.into(),
                     ),
                     _ => {
-                        return future::err(ErrorResponse::new(
+                        return Err(ErrorResponse::new(
                             ElementIdMismatch,
                             &parent_fid,
                         ))
-                        .boxed()
                     }
                 };
 
-                match endpoint.map_err(ErrorResponse::from) {
-                    Ok(spec) => self
-                        .create_endpoint(id, parent_fid, spec)
-                        .err_into()
-                        .boxed(),
-                    Err(e) => future::err(e).boxed(),
-                }
+                Ok(self.create_endpoint(id, parent_fid, endpoint_spec).await?)
             }
             StatefulFid::Endpoint(_) => {
-                future::err(ErrorResponse::new(ElementIdIsTooLong, &parent_fid))
-                    .boxed()
+                Err(ErrorResponse::new(ElementIdIsTooLong, &parent_fid))
             }
         }
     }
 
     /// Deletes element by [`proto::IdRequest`].
-    pub fn delete_element(
+    async fn delete_element(
         &self,
         req: proto::IdRequest,
-    ) -> BoxFuture<'static, Result<(), ErrorResponse>> {
-        let room_service = self.room_service.clone();
-        async move {
-            let mut delete_elements_msg = DeleteElements::new();
-            for id in req.fid {
-                let fid = StatefulFid::try_from(id)?;
-                delete_elements_msg.add_fid(fid);
-            }
-            room_service
-                .send(delete_elements_msg.validate()?)
-                .await
-                .map_err(|e| {
-                    ErrorResponse::from(
-                        GrpcControlApiError::RoomServiceMailboxError(e),
-                    )
-                })??;
-            Ok(())
+    ) -> Result<(), GrpcControlApiError> {
+        let mut delete_elements_msg = DeleteElements::new();
+        for id in req.fid {
+            let fid = StatefulFid::try_from(id)?;
+            delete_elements_msg.add_fid(fid);
         }
-        .boxed()
+        self.0.send(delete_elements_msg.validate()?).await??;
+        Ok(())
     }
 
     /// Returns requested by [`proto::IdRequest`] [`proto::Element`]s serialized
     /// to protobuf.
-    pub fn get_element(
+    async fn get_element(
         &self,
         req: proto::IdRequest,
-    ) -> BoxFuture<
-        'static,
-        Result<HashMap<String, proto::Element>, ErrorResponse>,
-    > {
-        let room_service = self.room_service.clone();
-        async move {
-            let mut fids = Vec::new();
-            for id in req.fid {
-                let fid = StatefulFid::try_from(id)?;
-                fids.push(fid);
-            }
-
-            let elements =
-                room_service.send(Get(fids)).await.map_err(|err| {
-                    ErrorResponse::from(
-                        GrpcControlApiError::RoomServiceMailboxError(err),
-                    )
-                })??;
-
-            Ok(elements
-                .into_iter()
-                .map(|(id, value)| (id.to_string(), value))
-                .collect())
+    ) -> Result<HashMap<String, proto::Element>, GrpcControlApiError> {
+        let mut fids = Vec::new();
+        for id in req.fid {
+            let fid = StatefulFid::try_from(id)?;
+            fids.push(fid);
         }
-        .boxed()
+
+        let elements = self.0.send(Get(fids)).await??;
+
+        Ok(elements
+            .into_iter()
+            .map(|(id, value)| (id.to_string(), value))
+            .collect())
     }
 }
 
@@ -302,7 +229,7 @@ impl ControlApi for ControlApiService {
         let response = match self.delete_element(request.into_inner()).await {
             Ok(_) => proto::Response { error: None },
             Err(e) => proto::Response {
-                error: Some(e.into()),
+                error: Some(ErrorResponse::from(e).into()),
             },
         };
         Ok(tonic::Response::new(response))
@@ -320,7 +247,7 @@ impl ControlApi for ControlApiService {
             },
             Err(e) => proto::GetResponse {
                 elements: HashMap::new(),
-                error: Some(e.into()),
+                error: Some(ErrorResponse::from(e).into()),
             },
         };
         Ok(tonic::Response::new(response))
@@ -363,16 +290,11 @@ impl Handler<ShutdownGracefully> for GrpcServer {
 ///
 /// [Control API]: https://tinyurl.com/yxsqplq7
 pub async fn run(
-    room_repo: Addr<RoomService>,
+    room_service: Addr<RoomService>,
     app: &AppContext,
 ) -> Addr<GrpcServer> {
     let bind_ip = app.config.server.control.grpc.bind_ip.to_string();
     let bind_port = app.config.server.control.grpc.bind_port;
-
-    let service = TonicControlApiServer::new(ControlApiService {
-        public_url: app.config.server.client.http.public_url.clone(),
-        room_service: room_repo,
-    });
 
     info!("Starting gRPC server on {}:{}", bind_ip, bind_port);
 
@@ -382,7 +304,9 @@ pub async fn run(
     let addr = format!("{}:{}", bind_ip, bind_port).parse().unwrap();
     Arbiter::spawn(async move {
         Server::builder()
-            .add_service(service)
+            .add_service(TonicControlApiServer::new(ControlApiService(
+                room_service,
+            )))
             .serve_with_shutdown(addr, async move {
                 grpc_shutdown_rx.await.ok();
             })


### PR DESCRIPTION
## Solution

Refactor ControlApiService to more idiomatic async/.await



## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
