### PR TITLE
Improve Jason media constraints to support multiple video tracks (#27)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
  "serde_urlencoded",
  "sha-1",
  "slab",
- "time 0.2.21",
+ "time 0.2.22",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a60f9ba7c4e6df97f3aacb14bb5c0cd7d98a49dcbaed0d7f292912ad9a6a3ed2"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -292,7 +292,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "socket2",
- "time 0.2.21",
+ "time 0.2.22",
  "tinyvec",
  "url",
 ]
@@ -319,9 +319,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "750ca8fb60bbdc79491991650ba5d2ae7cd75f3fc00ead51390cfe9efda0d4d8"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -330,9 +330,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95aceadaf327f18f0df5962fedc1bde2f870566a0b9f65c89508a3b1f79334c"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -409,7 +409,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
 dependencies = [
- "async-task 4.0.2",
+ "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
@@ -419,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5586e693d02f9b439742e9d5d68bd64d923c6861954f7d78f91001a0e152d589"
+checksum = "fefeb39da249f4c33af940b779a56723ce45809ef5c54dad84bb538d4ffb6d9e"
 dependencies = [
  "async-executor",
  "async-io",
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9951f92a2b4f7793f8fc06a80bdb89b62c618c993497d4606474fb8c34941b5"
+checksum = "6e727cebd055ab2861a854f79def078c4b99ea722d54c6800a0e274389882d4c"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -459,14 +459,13 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.6.4"
+version = "1.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c92085acfce8b32e5b261d0b59b8f3309aee69fea421ea3f271f8b93225754f"
+checksum = "a9fa76751505e8df1c7a77762f60486f60c71bbd9b8557f4da6ad47d083732ed"
 dependencies = [
  "async-global-executor",
  "async-io",
  "async-mutex",
- "async-task 3.0.0",
  "blocking",
  "crossbeam-utils",
  "futures-channel",
@@ -501,16 +500,10 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
-
-[[package]]
-name = "async-task"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-task"
@@ -524,9 +517,9 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -577,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
+checksum = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -708,13 +701,15 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "libc",
  "num-integer",
  "num-traits 0.2.12",
  "time 0.1.44",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -817,7 +812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1373a16a4937bc34efec7b391f9c1500c30b8478a701a4f44c9165cc0475a6e0"
 dependencies = [
  "percent-encoding",
- "time 0.2.21",
+ "time 0.2.22",
  "version_check",
 ]
 
@@ -932,10 +927,10 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "strsim 0.9.3",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -946,7 +941,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -986,9 +981,9 @@ checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling",
  "derive_builder_core",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -998,20 +993,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.10"
+version = "0.99.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcfabdab475c16a93d669dddfc393027803e347d09663f524447f642fbb84ba"
+checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -1096,9 +1091,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
 dependencies = [
  "heck",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -1123,9 +1118,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
  "synstructure",
 ]
 
@@ -1143,9 +1138,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766d0e77a2c1502169d4a93ff3b8c15a71fd946cd0126309752104e5f3c46d94"
+checksum = "da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -1292,9 +1287,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -1409,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
@@ -1642,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
 
 [[package]]
 name = "linked-hash-map"
@@ -1865,9 +1860,9 @@ dependencies = [
  "Inflector",
  "async-trait",
  "medea-jason",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
  "synstructure",
 ]
 
@@ -1980,9 +1975,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b873f753808fe0c3827ce76edb3ace27804966dfde3043adfac1c24d0a2559df"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -1993,9 +1988,9 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "nb-connect"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847c76b390f44529c2071ef06d0b52fbb4bdb04cc8987a5cfa63954c000abca"
+checksum = "701f47aeb98466d0a7fea67e2c2f667c33efa1f2e4fd7f76743aac1153196f72"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -2159,29 +2154,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.23"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
+checksum = "2b9e280448854bd91559252582173b3bd1f8e094a0e644791c0628ca9b1f144f"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.23"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
+checksum = "c8c8b352676bc6a4c3d71970560b913cea444a7a921cc2e2d920225e4b91edaa"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.7"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
+checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
 
 [[package]]
 name = "pin-utils"
@@ -2269,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.21"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -2312,9 +2307,9 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2354,7 +2349,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
 ]
 
 [[package]]
@@ -2649,16 +2644,16 @@ version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
 dependencies = [
  "itoa",
  "ryu",
@@ -2702,9 +2697,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4070d2c9b9d258465ad1d82aabb985b84cd9a3afa94da25ece5a9938ba5f1606"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2736,9 +2731,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65f59259be9fc1bf677d06cc1456e97756004a1a5a577480f71430bd7c17ba33"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2869,9 +2864,9 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2921,11 +2916,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "serde 1.0.116",
  "serde_derive",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2935,13 +2930,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "serde 1.0.116",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2975,11 +2970,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
 ]
@@ -2990,9 +2985,9 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
  "unicode-xid 0.2.1",
 ]
 
@@ -3050,9 +3045,9 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3086,9 +3081,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2e31fb28e2a9f01f5ed6901b066c1ba2333c04b64dc61254142bafcb3feb2c"
+checksum = "55b7151c9065e80917fbf285d9a5d1432f60db41d170ccafc749a136b41a93af"
 dependencies = [
  "const_fn",
  "libc",
@@ -3101,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
 dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
@@ -3116,10 +3111,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
  "standback",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3157,9 +3152,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3222,10 +3217,10 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19970cf58f3acc820962be74c4021b8bbc8e8a1c4e3a02095d0aa60cde5f3633"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "prost-build",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3417,12 +3412,13 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
+checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if",
  "log",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3433,16 +3429,16 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
 ]
@@ -3635,9 +3631,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
  "wasm-bindgen-shared",
 ]
 
@@ -3669,9 +3665,9 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3702,7 +3698,7 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fb9c67be7439ee8ab1b7db502a49c05e51e2835b66796c705134d9b8e1a585"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.24",
  "quote 1.0.7",
 ]
 

--- a/jason/CHANGELOG.md
+++ b/jason/CHANGELOG.md
@@ -52,7 +52,7 @@ All user visible changes to this project will be documented in this file. This p
             - `Room.mute_remote_audio`;
             - `Room.unmute_remote_audio`;
             - `Room.mute_remote_video`;
-            - `Room.unmute_remote_video`;
+            - `Room.unmute_remote_video`.
         - `MediaTrack.media_source_kind` function ([#145]).
     - Optional tracks support ([#106]);
     - `RtcIceTransportPolicy` configuration ([#79]).

--- a/jason/CHANGELOG.md
+++ b/jason/CHANGELOG.md
@@ -53,7 +53,7 @@ All user visible changes to this project will be documented in this file. This p
             - `Room.unmute_remote_audio`;
             - `Room.mute_remote_video`;
             - `Room.unmute_remote_video`;
-        - `MediaTrack.is_display` function ([#145]).
+        - `MediaTrack.media_source_kind` function ([#145]).
     - Optional tracks support ([#106]);
     - `RtcIceTransportPolicy` configuration ([#79]).
 - Room management:

--- a/jason/CHANGELOG.md
+++ b/jason/CHANGELOG.md
@@ -43,7 +43,7 @@ All user visible changes to this project will be documented in this file. This p
         - Room initialization ([#46]):
             - `Jason.init_room()`;
             - `Room.join()`;
-        - Ability to configure local media stream used by `Room` via `Room.set_local_media_settings()` ([#54], [#97]);
+        - Ability to configure local media stream used by `Room` via `Room.set_local_media_settings()` ([#54], [#97], [#145]);
         - `Room.on_failed_local_media` callback ([#54], [#143]);
         - `Room.on_close` callback for WebSocket close initiated by server ([#55]);
         - `MediaTrack.on_enabled` and `MediaTrack.on_disabled` callbacks being called when `MediaTrack` is enabled or disabled ([#123], [#143]);
@@ -52,7 +52,8 @@ All user visible changes to this project will be documented in this file. This p
             - `Room.mute_remote_audio`;
             - `Room.unmute_remote_audio`;
             - `Room.mute_remote_video`;
-            - `Room.unmute_remote_video`.
+            - `Room.unmute_remote_video`;
+        - `MediaTrack.is_display` function ([#145]).
     - Optional tracks support ([#106]);
     - `RtcIceTransportPolicy` configuration ([#79]).
 - Room management:
@@ -105,6 +106,7 @@ All user visible changes to this project will be documented in this file. This p
 [#137]: /../../pull/137
 [#138]: /../../pull/138
 [#143]: /../../pull/143
+[#145]: /../../pull/145
 
 
 

--- a/jason/src/media/constraints.rs
+++ b/jason/src/media/constraints.rs
@@ -140,8 +140,8 @@ impl Default for AudioMediaTracksSettings {
     }
 }
 
-/// Returns `true` if provided [`SysMediaStreamTrack`] basically satisfies
-/// any constraints with a provided [`TransceiverKind`].
+/// Returns `true` if provided [`SysMediaStreamTrack`] basically satisfies any
+/// constraints with a provided [`TransceiverKind`].
 #[inline]
 fn satisfies_track(track: &SysMediaStreamTrack, kind: TransceiverKind) -> bool {
     track.kind() == kind.as_str()
@@ -155,7 +155,7 @@ fn satisfies_track(track: &SysMediaStreamTrack, kind: TransceiverKind) -> bool {
 pub struct VideoTrackConstraints<C> {
     /// Constraints applicable to video tracks.
     ///
-    /// If `None` then this kind of video (device or display) is disabled by
+    /// If [`None`] then this kind of video (device or display) is disabled by
     /// [`MediaStreamSettings`].
     constraints: Option<C>,
 
@@ -168,10 +168,7 @@ pub struct VideoTrackConstraints<C> {
     is_enabled: bool,
 }
 
-impl<C> Default for VideoTrackConstraints<C>
-where
-    C: Default,
-{
+impl<C: Default> Default for VideoTrackConstraints<C> {
     fn default() -> Self {
         Self {
             constraints: Some(C::default()),
@@ -182,33 +179,33 @@ where
 
 impl<C> VideoTrackConstraints<C> {
     /// Returns `true` if this [`VideoTrackConstraints`] are enabled by the
-    /// [`Room`] and constrained with [`VideoTrackConstraints::
-    /// constraints`].
+    /// [`Room`] and constrained with [`VideoTrackConstraints::constraints`].
     #[inline]
     fn is_enabled(&self) -> bool {
         self.is_enabled && self.is_constrained()
     }
 
-    /// Sets [`VideoTrackConstraints::constraints`] to the provided `cons`.
+    /// Sets these [`VideoTrackConstraints::constraints`] to the provided
+    /// `cons`.
     #[inline]
     fn set(&mut self, cons: C) {
         self.constraints = Some(cons);
     }
 
-    /// Resets [`VideoTrackConstraints::constraints`] to `None`.
+    /// Resets these [`VideoTrackConstraints::constraints`] to [`None`].
     #[inline]
     fn unconstrain(&mut self) {
         self.constraints.take();
     }
 
-    /// Returns `true` if [`VideoTrackConstraints::constraints`] is set to
-    /// `Some` value.
+    /// Returns `true` if these [`VideoTrackConstraints::constraints`] are set
+    /// to [`Some`] value.
     #[inline]
     fn is_constrained(&self) -> bool {
         self.constraints.is_some()
     }
 
-    /// Constraints this [`VideoTrackConstraints`] with a provided `other`
+    /// Constraints these [`VideoTrackConstraints`] with a provided `other`
     /// [`VideoTrackConstraints`].
     #[inline]
     fn constrain(&mut self, other: Self) {
@@ -217,7 +214,7 @@ impl<C> VideoTrackConstraints<C> {
 }
 
 impl VideoTrackConstraints<DeviceVideoTrackConstraints> {
-    /// Returns `true` if provided [`SysMediaStreamTrack`] satisfies device
+    /// Returns `true` if the provided [`SysMediaStreamTrack`] satisfies device
     /// [`VideoTrackConstraints::constraints`].
     ///
     /// Returns `false` if [`VideoTrackConstraints::constraints`] is not set.
@@ -230,7 +227,7 @@ impl VideoTrackConstraints<DeviceVideoTrackConstraints> {
 }
 
 impl VideoTrackConstraints<DisplayVideoTrackConstraints> {
-    /// Returns `true` if provided [`SysMediaStreamTrack`] satisfies device
+    /// Returns `true` if the provided [`SysMediaStreamTrack`] satisfies device
     /// [`VideoTrackConstraints::constraints`].
     ///
     /// Returns `false` if [`VideoTrackConstraints::constraints`] is not set.
@@ -246,7 +243,7 @@ impl VideoTrackConstraints<DisplayVideoTrackConstraints> {
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams/#dom-mediastreamconstraints
 #[wasm_bindgen]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MediaStreamSettings {
     /// [MediaStreamConstraints][1] for the audio media type.
     ///
@@ -262,16 +259,6 @@ pub struct MediaStreamSettings {
     ///
     /// [1]: https://w3.org/TR/mediacapture-streams/#dom-mediastreamconstraints
     display_video: VideoTrackConstraints<DisplayVideoTrackConstraints>,
-}
-
-impl Default for MediaStreamSettings {
-    fn default() -> Self {
-        Self {
-            audio: AudioMediaTracksSettings::default(),
-            device_video: VideoTrackConstraints::default(),
-            display_video: VideoTrackConstraints::default(),
-        }
-    }
 }
 
 #[wasm_bindgen]
@@ -348,7 +335,7 @@ impl MediaStreamSettings {
     /// Returns reference to [`DisplayVideoTrackConstraints`] from this
     /// [`MediaStreamSettings`].
     ///
-    /// Returns `None` if [`DisplayVideoTrackConstraints`] is unconstrained.
+    /// Returns [`None`] if [`DisplayVideoTrackConstraints`] is unconstrained.
     #[inline]
     pub fn get_display_video(&self) -> Option<&DisplayVideoTrackConstraints> {
         self.display_video.constraints.as_ref()
@@ -357,7 +344,7 @@ impl MediaStreamSettings {
     /// Returns reference to [`DeviceVideoTrackConstraints`] from this
     /// [`MediaStreamSettings`].
     ///
-    /// Returns `None` if [`DeviceVideoTrackConstraints`] is unconstrained.
+    /// Returns [`None`] if [`DeviceVideoTrackConstraints`] is unconstrained.
     #[inline]
     pub fn get_device_video(&self) -> Option<&DeviceVideoTrackConstraints> {
         self.device_video.constraints.as_ref()
@@ -554,8 +541,7 @@ impl VideoSource {
         }
     }
 
-    /// Checks if provided [MediaStreamTrack][1] satisfies this
-    /// [`VideoSource`].
+    /// Checks if provided [MediaStreamTrack][1] satisfies this [`VideoSource`].
     ///
     /// [1]: https://w3.org/TR/mediacapture-streams/#mediastreamtrack
     #[inline]
@@ -948,14 +934,16 @@ impl DisplayVideoTrackConstraints {
     ///
     /// [1]: https://w3.org/TR/mediacapture-streams/#mediastreamtrack
     #[allow(clippy::unused_self)]
+    #[inline]
     pub fn satisfies(&self, track: &SysMediaStreamTrack) -> bool {
         satisfies_track(track, TransceiverKind::Video)
             && guess_is_from_display(&track)
     }
 
-    /// Merges this [`DisplayVideoTrackConstraints`] with `another` one ,
-    /// meaning that if some constraint is not set on this one, then it will
-    /// be applied from `another`.
+    /// Merges this [`DisplayVideoTrackConstraints`] with `another` one,
+    /// meaning that if some constraint is not set on this one, then it will be
+    /// applied from `another`.
+    #[inline]
     pub fn merge(&mut self, another: &Self) {
         if !self.is_required && another.is_required {
             self.is_required = another.is_required;
@@ -982,10 +970,10 @@ impl DisplayVideoTrackConstraints {
     }
 }
 
-/// Detects if video track captured from display searching
-/// [specific fields][1] in its settings. Only works in Chrome atm.
+/// Detects if video track captured from display searching [specific fields][1]
+/// in its settings. Only works in Chrome atm.
 ///
-/// [1]: https://tinyurl.com/ufx7mcw
+/// [1]: https://w3.org/TR/screen-capture/#extensions-to-mediatracksettings
 fn guess_is_from_display(track: &SysMediaStreamTrack) -> bool {
     let settings = track.get_settings();
 

--- a/jason/src/media/constraints.rs
+++ b/jason/src/media/constraints.rs
@@ -8,7 +8,7 @@ use std::{
 use derive_more::AsRef;
 use medea_client_api_proto::{
     AudioSettings as ProtoAudioConstraints, MediaType as ProtoTrackConstraints,
-    MediaType, VideoSettings as ProtoVideoConstraints,
+    MediaType, VideoSettings,
 };
 use wasm_bindgen::prelude::*;
 use web_sys::{
@@ -23,57 +23,6 @@ use crate::{peer::TransceiverKind, utils::get_property_by_name};
 /// Local media stream for injecting into new created [`PeerConnection`]s.
 #[derive(Clone, Debug, Default)]
 pub struct LocalTracksConstraints(Rc<RefCell<MediaStreamSettings>>);
-
-/// Constraints to the media received from remote. Used to disable or enable
-/// media receiving.
-pub struct RecvConstraints {
-    /// Is audio receiving enabled.
-    is_audio_enabled: Cell<bool>,
-
-    /// Is video receiving enabled.
-    is_video_enabled: Cell<bool>,
-}
-
-impl Default for RecvConstraints {
-    fn default() -> Self {
-        Self {
-            is_audio_enabled: Cell::new(true),
-            is_video_enabled: Cell::new(true),
-        }
-    }
-}
-
-impl RecvConstraints {
-    /// Enables or disables audio or video receiving.
-    pub fn set_enabled(&self, enabled: bool, kind: TransceiverKind) {
-        match kind {
-            TransceiverKind::Audio => {
-                self.is_audio_enabled.set(enabled);
-            }
-            TransceiverKind::Video => {
-                self.is_video_enabled.set(enabled);
-            }
-        }
-    }
-
-    /// Returns is audio receiving enabled.
-    pub fn is_audio_enabled(&self) -> bool {
-        self.is_audio_enabled.get()
-    }
-
-    /// Returns is video receiving enabled.
-    pub fn is_video_enabled(&self) -> bool {
-        self.is_video_enabled.get()
-    }
-}
-
-#[cfg(feature = "mockable")]
-impl From<MediaStreamSettings> for LocalTracksConstraints {
-    #[inline]
-    fn from(from: MediaStreamSettings) -> Self {
-        Self(Rc::new(RefCell::new(from)))
-    }
-}
 
 impl LocalTracksConstraints {
     /// Returns new [`LocalStreamConstraints`] with default values.
@@ -113,38 +62,70 @@ impl LocalTracksConstraints {
     pub fn is_enabled(&self, kind: &MediaType) -> bool {
         self.0.borrow_mut().is_enabled(kind)
     }
+
+    /// Returns `true` if display video is constrained.
+    #[inline]
+    pub fn is_display_video_constrained(&self) -> bool {
+        self.0.borrow().is_display_constrained()
+    }
+
+    /// Returns `true` if device video is constrained.
+    #[inline]
+    pub fn is_device_video_constrained(&self) -> bool {
+        self.0.borrow().is_device_constrained()
+    }
 }
 
-/// Helper to distinguish objects related to media captured from device and
-/// media captured from display.
-#[derive(Clone, Debug)]
-enum MediaSource<D, S> {
-    Device(D),
-    Display(S),
+#[cfg(feature = "mockable")]
+impl From<MediaStreamSettings> for LocalTracksConstraints {
+    #[inline]
+    fn from(from: MediaStreamSettings) -> Self {
+        Self(Rc::new(RefCell::new(from)))
+    }
 }
 
-impl MediaSource<DeviceVideoTrackConstraints, DisplayVideoTrackConstraints> {
-    fn merge(
-        &mut self,
-        other: MediaSource<
-            DeviceVideoTrackConstraints,
-            DisplayVideoTrackConstraints,
-        >,
-    ) {
-        use MediaSource::{Device, Display};
+/// Constraints to the media received from remote. Used to disable or enable
+/// media receiving.
+pub struct RecvConstraints {
+    /// Is audio receiving enabled.
+    is_audio_enabled: Cell<bool>,
 
-        match self {
-            Device(this) => {
-                if let Device(that) = other {
-                    this.merge(that);
-                }
+    /// Is video receiving enabled.
+    is_video_enabled: Cell<bool>,
+}
+
+impl Default for RecvConstraints {
+    fn default() -> Self {
+        Self {
+            is_audio_enabled: Cell::new(true),
+            is_video_enabled: Cell::new(true),
+        }
+    }
+}
+
+impl RecvConstraints {
+    /// Enables or disables audio or video receiving.
+    pub fn set_enabled(&self, enabled: bool, kind: TransceiverKind) {
+        match kind {
+            TransceiverKind::Audio => {
+                self.is_audio_enabled.set(enabled);
             }
-            Display(this) => {
-                if let Display(that) = other {
-                    this.merge(that);
-                }
+            TransceiverKind::Video => {
+                self.is_video_enabled.set(enabled);
             }
-        };
+        }
+    }
+
+    /// Returns is audio receiving enabled.
+    #[inline]
+    pub fn is_audio_enabled(&self) -> bool {
+        self.is_audio_enabled.get()
+    }
+
+    /// Returns is video receiving enabled.
+    #[inline]
+    pub fn is_video_enabled(&self) -> bool {
+        self.is_video_enabled.get()
     }
 }
 
@@ -171,26 +152,126 @@ impl Default for AudioMediaTracksSettings {
     }
 }
 
+/// Detects if video track captured from display searching
+/// [specific fields][1] in its settings. Only works in Chrome atm.
+///
+/// [1]: https://tinyurl.com/ufx7mcw
+fn guess_is_from_display(track: &SysMediaStreamTrack) -> bool {
+    let settings = track.get_settings();
+
+    let has_display_surface =
+        get_property_by_name(&settings, "displaySurface", |val| {
+            val.as_string()
+        })
+        .is_some();
+
+    if has_display_surface {
+        true
+    } else {
+        get_property_by_name(&settings, "logicalSurface", |val| val.as_string())
+            .is_some()
+    }
+}
+
+/// Returns `true` if provided [`SysMediaStreamTrack`] basically satisfies
+/// any constraints with a provided [`TransceiverKind`].
+#[inline]
+fn satisfies_track(track: &SysMediaStreamTrack, kind: TransceiverKind) -> bool {
+    track.kind() == kind.as_str()
+        || track.ready_state() != MediaStreamTrackState::Live
+}
+
 /// [MediaStreamConstraints][1] for the video media type.
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams/#dom-mediastreamconstraints
 #[derive(Clone, Debug)]
-struct VideoMediaTracksSettings {
+pub struct VideoTrackConstraints<C> {
     /// Constraints applicable to video tracks.
-    constraints: VideoTrackConstraints,
+    ///
+    /// If `None` then this kind of video (device or display) is disabled by
+    /// [`MediaStreamSettings`].
+    constraints: Option<C>,
 
     /// Indicator whether video is enabled and this constraints should be
     /// injected into `Peer`.
+    ///
+    /// Any action with this flag should be performed only while mute/unmute
+    /// actions by [`Room`]. This flag can't be changed by
+    /// [`MediaStreamSettings`] updating.
     is_enabled: bool,
 }
 
-impl Default for VideoMediaTracksSettings {
-    #[inline]
+impl<C> Default for VideoTrackConstraints<C>
+where
+    C: Default,
+{
     fn default() -> Self {
         Self {
-            constraints: VideoTrackConstraints::default(),
+            constraints: Some(C::default()),
             is_enabled: true,
         }
+    }
+}
+
+impl<C> VideoTrackConstraints<C> {
+    /// Returns `true` if this [`VideoTrackConstraints`] are enabled by the
+    /// [`Room`] and constrained with [`VideoTrackConstraints::
+    /// constraints`].
+    #[inline]
+    fn is_enabled(&self) -> bool {
+        self.is_enabled && self.is_constrained()
+    }
+
+    /// Sets [`VideoTrackConstraints::constraints`] to the provided `cons`.
+    #[inline]
+    fn set(&mut self, cons: C) {
+        self.constraints = Some(cons);
+    }
+
+    /// Resets [`VideoTrackConstraints::constraints`] to `None`.
+    #[inline]
+    fn unconstrain(&mut self) {
+        self.constraints.take();
+    }
+
+    /// Returns `true` if [`VideoTrackConstraints::constraints`] is set to
+    /// `Some` value.
+    #[inline]
+    fn is_constrained(&self) -> bool {
+        self.constraints.is_some()
+    }
+
+    /// Constraints this [`VideoTrackConstraints`] with a provided `other`
+    /// [`VideoTrackConstraints`].
+    #[inline]
+    fn constrain(&mut self, other: Self) {
+        self.constraints = other.constraints;
+    }
+}
+
+impl VideoTrackConstraints<DeviceVideoTrackConstraints> {
+    /// Returns `true` if provided [`SysMediaStreamTrack`] satisfies device
+    /// [`VideoTrackConstraints::constraints`].
+    ///
+    /// Returns `false` if [`VideoTrackConstraints::constraints`] is not set.
+    fn satisfies(&self, track: &SysMediaStreamTrack) -> bool {
+        self.constraints
+            .as_ref()
+            .filter(|_| self.is_enabled())
+            .map_or(false, |device| device.satisfies(track))
+    }
+}
+
+impl VideoTrackConstraints<DisplayVideoTrackConstraints> {
+    /// Returns `true` if provided [`SysMediaStreamTrack`] satisfies device
+    /// [`VideoTrackConstraints::constraints`].
+    ///
+    /// Returns `false` if [`VideoTrackConstraints::constraints`] is not set.
+    fn satisfies(&self, track: &SysMediaStreamTrack) -> bool {
+        self.constraints
+            .as_ref()
+            .filter(|_| self.is_enabled())
+            .map_or(false, |display| display.satisfies(track))
     }
 }
 
@@ -198,17 +279,32 @@ impl Default for VideoMediaTracksSettings {
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams/#dom-mediastreamconstraints
 #[wasm_bindgen]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct MediaStreamSettings {
     /// [MediaStreamConstraints][1] for the audio media type.
     ///
     /// [1]: https://w3.org/TR/mediacapture-streams/#dom-mediastreamconstraints
     audio: AudioMediaTracksSettings,
 
-    /// [MediaStreamConstraints][1] for the video media type.
+    /// [MediaStreamConstraints][1] for the device video media type.
     ///
     /// [1]: https://w3.org/TR/mediacapture-streams/#dom-mediastreamconstraints
-    video: VideoMediaTracksSettings,
+    device_video: VideoTrackConstraints<DeviceVideoTrackConstraints>,
+
+    /// [MediaStreamConstraints][1] for the display video media type.
+    ///
+    /// [1]: https://w3.org/TR/mediacapture-streams/#dom-mediastreamconstraints
+    display_video: VideoTrackConstraints<DisplayVideoTrackConstraints>,
+}
+
+impl Default for MediaStreamSettings {
+    fn default() -> Self {
+        Self {
+            audio: AudioMediaTracksSettings::default(),
+            device_video: VideoTrackConstraints::default(),
+            display_video: VideoTrackConstraints::default(),
+        }
+    }
 }
 
 #[wasm_bindgen]
@@ -221,9 +317,13 @@ impl MediaStreamSettings {
                 constraints: AudioTrackConstraints::default(),
                 is_enabled: false,
             },
-            video: VideoMediaTracksSettings {
-                constraints: VideoTrackConstraints::default(),
-                is_enabled: false,
+            display_video: VideoTrackConstraints {
+                is_enabled: true,
+                constraints: None,
+            },
+            device_video: VideoTrackConstraints {
+                is_enabled: true,
+                constraints: None,
             },
         }
     }
@@ -239,36 +339,73 @@ impl MediaStreamSettings {
     /// Set constraints that will be used to obtain local video sourced from
     /// media device.
     pub fn device_video(&mut self, constraints: DeviceVideoTrackConstraints) {
-        self.video.is_enabled = true;
-        self.video.constraints = constraints.into();
+        self.device_video.set(constraints);
     }
 
     /// Set constraints that will be used to capture local video from user
     /// display.
     pub fn display_video(&mut self, constraints: DisplayVideoTrackConstraints) {
-        self.video.is_enabled = true;
-        self.video.constraints = constraints.into();
+        self.display_video.set(constraints);
     }
 }
 
 impl MediaStreamSettings {
+    /// Returns `true` if provided [`SysMediaStreamTrack`] satisfies some of the
+    /// [`VideoTrackConstraints`] from this [`MediaStreamSettings`].
+    ///
+    /// Unconstrains [`VideoTrackConstraints`] which this
+    /// [`SysMediaStreamTrack`] satisfies by calling
+    /// [`VideoTrackConstraints::unconstrain`].
+    pub fn unconstrain_if_satisfies_video<T>(&mut self, track: T) -> bool
+    where
+        T: AsRef<SysMediaStreamTrack>,
+    {
+        let track = track.as_ref();
+        if self.device_video.satisfies(track.as_ref()) {
+            self.device_video.unconstrain();
+            true
+        } else if self.display_video.satisfies(track.as_ref()) {
+            self.display_video.unconstrain();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns `true` if [`MediaStreamSettings::device_video`] is constrained.
+    #[inline]
+    pub fn is_device_constrained(&self) -> bool {
+        self.device_video.is_constrained()
+    }
+
+    /// Returns `true` if [`MediaStreamSettings::display_video`] is constrained.
+    #[inline]
+    pub fn is_display_constrained(&self) -> bool {
+        self.display_video.is_constrained()
+    }
+
     /// Returns only audio constraints.
     #[inline]
     pub fn get_audio(&self) -> &AudioTrackConstraints {
         &self.audio.constraints
     }
 
-    /// Returns only video constraints.
+    /// Returns reference to [`DisplayVideoTrackConstraints`] from this
+    /// [`MediaStreamSettings`].
+    ///
+    /// Returns `None` if [`DisplayVideoTrackConstraints`] is unconstrained.
     #[inline]
-    pub fn get_video(&self) -> &VideoTrackConstraints {
-        &self.video.constraints
+    pub fn get_display_video(&self) -> Option<&DisplayVideoTrackConstraints> {
+        self.display_video.constraints.as_ref()
     }
 
-    /// Set [`VideoTrackConstraints`].
+    /// Returns reference to [`DeviceVideoTrackConstraints`] from this
+    /// [`MediaStreamSettings`].
+    ///
+    /// Returns `None` if [`DeviceVideoTrackConstraints`] is unconstrained.
     #[inline]
-    pub fn video(&mut self, constraints: VideoTrackConstraints) {
-        self.video.is_enabled = true;
-        self.video.constraints = constraints;
+    pub fn get_device_video(&self) -> Option<&DeviceVideoTrackConstraints> {
+        self.device_video.constraints.as_ref()
     }
 
     /// Enables or disables audio or video type in this [`MediaStreamSettings`].
@@ -294,11 +431,12 @@ impl MediaStreamSettings {
         self.audio.is_enabled = is_enabled;
     }
 
-    /// Sets the underlying [`VideoMediaTracksSettings::is_enabled`] to the
-    /// given value.
+    /// Sets the all underlying [`VideoTrackConstraints::is_enabled`] (device
+    /// and display) to the given value.
     #[inline]
     pub fn toggle_publish_video(&mut self, is_enabled: bool) {
-        self.video.is_enabled = is_enabled;
+        self.display_video.is_enabled = is_enabled;
+        self.device_video.is_enabled = is_enabled;
     }
 
     /// Indicates whether audio is enabled in this [`MediaStreamSettings`].
@@ -307,18 +445,32 @@ impl MediaStreamSettings {
         self.audio.is_enabled
     }
 
-    /// Indicates whether video is enabled in this [`MediaStreamSettings`].
+    /// Returns `true` if [`DeviceVideoMediaStreamSettings`] are currently
+    /// constrained and enabled.
     #[inline]
-    pub fn is_video_enabled(&self) -> bool {
-        self.video.is_enabled
+    pub fn is_device_video_enabled(&self) -> bool {
+        self.device_video.is_enabled()
     }
 
-    /// Indicates whether the given [`MediaType`] is enabled in this
-    /// [`MediaStreamSettings`].
+    /// Returns `true` if [`DisplayVideoMediaStreamSettings`] are currently
+    /// constrained and enabled.
+    #[inline]
+    pub fn is_display_video_enabled(&self) -> bool {
+        self.display_video.is_enabled()
+    }
+
+    /// Indicates whether the given [`MediaType`] is enabled and constrained in
+    /// this [`MediaStreamSettings`].
     #[inline]
     pub fn is_enabled(&self, kind: &MediaType) -> bool {
         match kind {
-            MediaType::Video(_) => self.video.is_enabled,
+            MediaType::Video(video) => {
+                if video.is_display {
+                    self.display_video.is_enabled()
+                } else {
+                    self.device_video.is_enabled()
+                }
+            }
             MediaType::Audio(_) => self.audio.is_enabled,
         }
     }
@@ -330,10 +482,9 @@ impl MediaStreamSettings {
         // `&=` cause we should not unmute muted Room, but we can mute not muted
         // room.
         self.audio.is_enabled &= other.audio.is_enabled;
-        self.video.is_enabled &= other.video.is_enabled;
-
         self.audio.constraints = other.audio.constraints;
-        self.video.constraints = other.video.constraints;
+        self.display_video.constrain(other.display_video);
+        self.device_video.constrain(other.device_video);
     }
 }
 
@@ -345,6 +496,7 @@ impl MediaStreamSettings {
 /// sources.
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams/#mediastreamconstraints
+#[derive(Debug)]
 pub enum MultiSourceTracksConstraints {
     /// Only [getUserMedia()][1] request is required.
     ///
@@ -363,77 +515,119 @@ pub enum MultiSourceTracksConstraints {
     DeviceAndDisplay(SysMediaStreamConstraints, SysMediaStreamConstraints),
 }
 
-/// TL;DR:
-/// `{None, None}` => `None`
-/// `{None, Device}` => `Device`
-/// `{None, Display}` => `Display`
-/// `{None, Any}` => `Device`
-/// `{Some, None}` => `Device`
-/// `{Some, Device}` => `Device`
-/// `{Some, Display}` => `DeviceAndDisplay`
-/// `{Some, Any}` => `Device`
 impl From<MediaStreamSettings> for Option<MultiSourceTracksConstraints> {
     fn from(constraints: MediaStreamSettings) -> Self {
-        use MultiSourceTracksConstraints as C;
+        let is_device_video_enabled = constraints.is_device_video_enabled();
+        let is_display_video_enabled = constraints.is_display_video_enabled();
+        let is_device_audio_enabled = constraints.is_audio_enabled();
 
-        let (audio, video) = (constraints.audio, constraints.video);
-        let mut sys_constraints = SysMediaStreamConstraints::new();
-        let video = if video.is_enabled {
-            match video.constraints.constraints {
-                Some(MediaSource::Device(device)) => {
-                    sys_constraints
-                        .video(&SysMediaTrackConstraints::from(device).into());
-                    Some(MediaSource::Device(sys_constraints))
-                }
-                Some(MediaSource::Display(display)) => {
-                    sys_constraints
-                        .video(&SysMediaTrackConstraints::from(display).into());
-                    Some(MediaSource::Display(sys_constraints))
-                }
-                None => {
-                    // defaults to device video
-                    sys_constraints
-                        .video(&SysMediaTrackConstraints::new().into());
-                    Some(MediaSource::Device(sys_constraints))
-                }
+        let mut device_cons = None;
+        let mut display_cons = None;
+
+        if is_device_video_enabled {
+            if let Some(device_video_cons) =
+                constraints.device_video.constraints
+            {
+                device_cons
+                    .get_or_insert_with(SysMediaStreamConstraints::new)
+                    .video(
+                        &SysMediaTrackConstraints::from(device_video_cons)
+                            .into(),
+                    );
             }
+        }
+        if is_display_video_enabled {
+            if let Some(display_video_cons) =
+                constraints.display_video.constraints
+            {
+                display_cons
+                    .get_or_insert_with(SysMediaStreamConstraints::new)
+                    .video(
+                        &SysMediaTrackConstraints::from(display_video_cons)
+                            .into(),
+                    );
+            }
+        }
+        if is_device_audio_enabled {
+            device_cons
+                .get_or_insert_with(SysMediaStreamConstraints::new)
+                .audio(
+                    &SysMediaTrackConstraints::from(
+                        constraints.audio.constraints,
+                    )
+                    .into(),
+                );
+        }
+
+        match (device_cons, display_cons) {
+            (Some(device_cons), Some(display_cons)) => {
+                Some(MultiSourceTracksConstraints::DeviceAndDisplay(
+                    device_cons,
+                    display_cons,
+                ))
+            }
+            (Some(device_cons), None) => {
+                Some(MultiSourceTracksConstraints::Device(device_cons))
+            }
+            (None, Some(display_cons)) => {
+                Some(MultiSourceTracksConstraints::Display(display_cons))
+            }
+            (None, None) => None,
+        }
+    }
+}
+
+/// Constraints for the [`TransceiverKind::Video`] [`MediaStreamTrack`].
+#[derive(Clone, Debug)]
+pub enum VideoSource {
+    /// [`MediaStreamTrack`] should be received from the `getUserMedia`
+    /// request.
+    Device(DeviceVideoTrackConstraints),
+
+    /// [`MediaStreamTrack`] should be received from the `getDisplayMedia`
+    /// request.
+    Display(DisplayVideoTrackConstraints),
+}
+
+impl VideoSource {
+    /// Returns importance of this [`VideoSource`].
+    ///
+    /// If this [`VideoSource`] is important then without this [`VideoSource`]
+    /// call session can't be started.
+    #[inline]
+    pub fn is_required(&self) -> bool {
+        match self {
+            VideoSource::Device(device) => device.is_required,
+            VideoSource::Display(display) => display.is_required,
+        }
+    }
+
+    /// Checks if provided [MediaStreamTrack][1] satisfies this
+    /// [`VideoSource`].
+    ///
+    /// [1]: https://w3.org/TR/mediacapture-streams/#mediastreamtrack
+    #[inline]
+    pub fn satisfies<T: AsRef<SysMediaStreamTrack>>(&self, track: T) -> bool {
+        let track = track.as_ref();
+        match self {
+            VideoSource::Display(display) => display.satisfies(&track),
+            VideoSource::Device(device) => device.satisfies(track),
+        }
+    }
+}
+
+impl From<VideoSettings> for VideoSource {
+    fn from(settings: VideoSettings) -> Self {
+        if settings.is_display {
+            VideoSource::Display(DisplayVideoTrackConstraints {
+                is_required: settings.is_required,
+            })
         } else {
-            None
-        };
-
-        if audio.is_enabled {
-            match video {
-                Some(MediaSource::Device(mut caps)) => {
-                    caps.audio(
-                        &SysMediaTrackConstraints::from(audio.constraints)
-                            .into(),
-                    );
-                    Some(C::Device(caps))
-                }
-                Some(MediaSource::Display(caps)) => {
-                    let mut audio_caps = SysMediaStreamConstraints::new();
-                    audio_caps.audio(
-                        &SysMediaTrackConstraints::from(audio.constraints)
-                            .into(),
-                    );
-
-                    Some(C::DeviceAndDisplay(audio_caps, caps))
-                }
-                None => {
-                    let mut audio_caps = SysMediaStreamConstraints::new();
-                    audio_caps.audio(
-                        &SysMediaTrackConstraints::from(audio.constraints)
-                            .into(),
-                    );
-                    Some(C::Device(audio_caps))
-                }
-            }
-        } else {
-            match video {
-                Some(MediaSource::Device(caps)) => Some(C::Device(caps)),
-                Some(MediaSource::Display(caps)) => Some(C::Display(caps)),
-                None => None,
-            }
+            VideoSource::Device(DeviceVideoTrackConstraints {
+                device_id: None,
+                facing_mode: None,
+                is_required: settings.is_required,
+            })
         }
     }
 }
@@ -446,7 +640,7 @@ pub enum TrackConstraints {
     /// Audio constraints.
     Audio(AudioTrackConstraints),
     /// Video constraints.
-    Video(VideoTrackConstraints),
+    Video(VideoSource),
 }
 
 impl TrackConstraints {
@@ -467,9 +661,23 @@ impl TrackConstraints {
     /// [`TrackConstraints`] call session can't be started.
     pub fn is_required(&self) -> bool {
         match self {
-            TrackConstraints::Video(video) => video.is_required,
+            TrackConstraints::Video(video) => video.is_required(),
             TrackConstraints::Audio(audio) => audio.is_required,
         }
+    }
+
+    /// Returns `true` if this [`TrackConstraints`]'s media should be received
+    /// from `getDisplayMedia`.
+    #[inline]
+    pub fn is_display_video(&self) -> bool {
+        matches!(self, Self::Video(VideoSource::Display(_)))
+    }
+
+    /// Returns `true` if this [`TrackConstraints`]'s media should be received
+    /// from `getUserMedia`.
+    #[inline]
+    pub fn is_device_video(&self) -> bool {
+        matches!(self, Self::Video(VideoSource::Device(_)))
     }
 }
 
@@ -527,15 +735,8 @@ impl AudioTrackConstraints {
     /// [1]: https://w3.org/TR/mediacapture-streams/#mediastreamtrack
     pub fn satisfies<T: AsRef<SysMediaStreamTrack>>(&self, track: T) -> bool {
         let track = track.as_ref();
-        if track.kind() != "audio" {
-            return false;
-        }
-
-        if track.ready_state() != MediaStreamTrackState::Live {
-            return false;
-        }
-
-        ConstrainString::satisfies(&self.device_id, track)
+        satisfies_track(track, TransceiverKind::Audio)
+            && ConstrainString::satisfies(&self.device_id, track)
         // TODO returns Result<bool, Error>
     }
 
@@ -581,21 +782,6 @@ impl From<AudioTrackConstraints> for SysMediaTrackConstraints {
 
         constraints
     }
-}
-
-/// Constraints applicable to video tracks.
-#[derive(Clone, Debug, Default)]
-pub struct VideoTrackConstraints {
-    /// Constraints applicable to video tracks.
-    constraints: Option<
-        MediaSource<DeviceVideoTrackConstraints, DisplayVideoTrackConstraints>,
-    >,
-
-    /// Importance of this [`VideoTrackConstraints`].
-    ///
-    /// If `true` then without this [`VideoTrackConstraints`] call session
-    /// can't be started.
-    is_required: bool,
 }
 
 /// Constraints applicable to [MediaStreamTrack][1].
@@ -724,10 +910,21 @@ pub struct DeviceVideoTrackConstraints {
 }
 
 impl DeviceVideoTrackConstraints {
+    /// Checks if provided [MediaStreamTrack][1] satisfies
+    /// [`DeviceVideoTrackConstraints`] contained.
+    ///
+    /// [1]: https://w3.org/TR/mediacapture-streams/#mediastreamtrack
+    pub fn satisfies(&self, track: &SysMediaStreamTrack) -> bool {
+        satisfies_track(track, TransceiverKind::Video)
+            && ConstrainString::satisfies(&self.device_id, track)
+            && ConstrainString::satisfies(&self.facing_mode, track)
+            && !guess_is_from_display(&track)
+    }
+
     /// Merges this [`DeviceVideoTrackConstraints`] with `another` one , meaning
     /// that if some constraint is not set on this one, then it will be applied
     /// from `another`.
-    fn merge(&mut self, another: DeviceVideoTrackConstraints) {
+    pub fn merge(&mut self, another: DeviceVideoTrackConstraints) {
         if self.device_id.is_none() && another.device_id.is_some() {
             self.device_id = another.device_id;
         }
@@ -783,15 +980,41 @@ impl DeviceVideoTrackConstraints {
 /// Constraints applicable to video tracks sourced from screen capture.
 #[wasm_bindgen]
 #[derive(Clone, Debug, Default)]
-pub struct DisplayVideoTrackConstraints {}
+pub struct DisplayVideoTrackConstraints {
+    /// Importance of this [`DisplayVideoTrackConstraints`].
+    ///
+    /// If `true` then without this [`DisplayVideoTrackConstraints`] call
+    /// session can't be started.
+    is_required: bool,
+}
 
 impl DisplayVideoTrackConstraints {
-    /// Merges this [`DisplayVideoTrackConstraints`] with `another` one, meaning
-    /// that if some constraint is not set on this one, then it will be applied
-    /// from `another`.
+    /// Checks if provided [MediaStreamTrack][1] satisfies
+    /// [`DisplayVideoTrackConstraints`] contained.
+    ///
+    /// [1]: https://w3.org/TR/mediacapture-streams/#mediastreamtrack
     #[allow(clippy::unused_self)]
-    fn merge(&mut self, _: DisplayVideoTrackConstraints) {
-        // no constraints => nothing to do here atm
+    pub fn satisfies(&self, track: &SysMediaStreamTrack) -> bool {
+        satisfies_track(track, TransceiverKind::Video)
+            && guess_is_from_display(&track)
+    }
+
+    /// Merges this [`DisplayVideoTrackConstraints`] with `another` one ,
+    /// meaning that if some constraint is not set on this one, then it will
+    /// be applied from `another`.
+    pub fn merge(&mut self, another: &Self) {
+        if !self.is_required && another.is_required {
+            self.is_required = another.is_required;
+        }
+    }
+
+    /// Returns importance of this [`DisplayVideoTrackConstraints`].
+    ///
+    /// If this [`DisplayVideoTrackConstraints`] is important then without this
+    /// [`DisplayVideoTrackConstraints`] call session can't be started.
+    #[inline]
+    pub fn is_required(&self) -> bool {
+        self.is_required
     }
 }
 
@@ -802,96 +1025,6 @@ impl DisplayVideoTrackConstraints {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Self::default()
-    }
-}
-
-impl VideoTrackConstraints {
-    /// Checks if provided [MediaStreamTrack][1] satisfies constraints
-    /// contained.
-    ///
-    /// [1]: https://w3.org/TR/mediacapture-streams/#mediastreamtrack
-    pub fn satisfies<T: AsRef<SysMediaStreamTrack>>(&self, track: T) -> bool {
-        let track = track.as_ref();
-        if track.kind() != "video" {
-            return false;
-        }
-
-        if track.ready_state() != MediaStreamTrackState::Live {
-            return false;
-        }
-
-        match &self.constraints {
-            None => true,
-            Some(MediaSource::Device(constraints)) => {
-                ConstrainString::satisfies(&constraints.device_id, track)
-                    && ConstrainString::satisfies(
-                        &constraints.facing_mode,
-                        track,
-                    )
-                    && !Self::guess_is_from_display(&track)
-            }
-            Some(MediaSource::Display(_)) => {
-                Self::guess_is_from_display(&track)
-            }
-        }
-    }
-
-    /// Detects if video track captured from display searching
-    /// [specific fields][1] in its settings. Only works in Chrome atm.
-    ///
-    /// [1]: https://tinyurl.com/ufx7mcw
-    fn guess_is_from_display(track: &SysMediaStreamTrack) -> bool {
-        let settings = track.get_settings();
-
-        let has_display_surface =
-            get_property_by_name(&settings, "displaySurface", |val| {
-                val.as_string()
-            })
-            .is_some();
-
-        if has_display_surface {
-            true
-        } else {
-            get_property_by_name(&settings, "logicalSurface", |val| {
-                val.as_string()
-            })
-            .is_some()
-        }
-    }
-
-    /// Merges this [`VideoTrackConstraints`] with `another` one, meaning that
-    /// if some constraint is not set on this one, then it will be applied from
-    /// `another`.
-    pub fn merge(&mut self, another: VideoTrackConstraints) {
-        if !self.is_required && another.is_required {
-            self.is_required = another.is_required;
-        }
-        match (self.constraints.as_mut(), another.constraints) {
-            (None, Some(another)) => {
-                self.constraints.replace(another);
-            }
-            (Some(this), Some(another)) => {
-                this.merge(another);
-            }
-            _ => {}
-        };
-    }
-
-    /// Returns importance of this [`VideoTrackConstraints`].
-    ///
-    /// If this [`VideoTrackConstraints`] is important then without this
-    /// [`VideoTrackConstraints`] call session can't be started.
-    pub fn is_required(&self) -> bool {
-        self.is_required
-    }
-}
-
-impl From<ProtoVideoConstraints> for VideoTrackConstraints {
-    fn from(caps: ProtoVideoConstraints) -> Self {
-        Self {
-            constraints: None,
-            is_required: caps.is_required,
-        }
     }
 }
 
@@ -915,23 +1048,5 @@ impl From<DeviceVideoTrackConstraints> for SysMediaTrackConstraints {
 impl From<DisplayVideoTrackConstraints> for SysMediaTrackConstraints {
     fn from(_: DisplayVideoTrackConstraints) -> Self {
         Self::new()
-    }
-}
-
-impl From<DeviceVideoTrackConstraints> for VideoTrackConstraints {
-    fn from(constraints: DeviceVideoTrackConstraints) -> Self {
-        Self {
-            is_required: constraints.is_required,
-            constraints: Some(MediaSource::Device(constraints)),
-        }
-    }
-}
-
-impl From<DisplayVideoTrackConstraints> for VideoTrackConstraints {
-    fn from(constraints: DisplayVideoTrackConstraints) -> Self {
-        Self {
-            is_required: true,
-            constraints: Some(MediaSource::Display(constraints)),
-        }
     }
 }

--- a/jason/src/media/manager.rs
+++ b/jason/src/media/manager.rs
@@ -9,6 +9,7 @@ use std::{
 
 use derive_more::Display;
 use js_sys::Promise;
+use medea_client_api_proto::MediaSourceKind;
 use tracerr::Traced;
 use wasm_bindgen::{prelude::*, JsValue};
 use wasm_bindgen_futures::{future_to_promise, JsFuture};
@@ -274,7 +275,9 @@ impl InnerMediaManager {
         let tracks: Vec<_> = js_sys::try_iter(&stream.get_tracks())
             .unwrap()
             .unwrap()
-            .map(|tr| MediaStreamTrack::new(tr.unwrap(), false))
+            .map(|track| {
+                MediaStreamTrack::new(track.unwrap(), MediaSourceKind::Device)
+            })
             .inspect(|track| {
                 storage.insert(track.id(), track.downgrade());
             })
@@ -320,7 +323,9 @@ impl InnerMediaManager {
         let tracks: Vec<_> = js_sys::try_iter(&stream.get_tracks())
             .unwrap()
             .unwrap()
-            .map(|tr| MediaStreamTrack::new(tr.unwrap(), true))
+            .map(|tr| {
+                MediaStreamTrack::new(tr.unwrap(), MediaSourceKind::Display)
+            })
             .inspect(|track| {
                 storage.insert(track.id(), track.downgrade());
             })

--- a/jason/src/media/mod.rs
+++ b/jason/src/media/mod.rs
@@ -13,7 +13,7 @@ pub use self::{
         AudioTrackConstraints, DeviceVideoTrackConstraints,
         DisplayVideoTrackConstraints, FacingMode, LocalTracksConstraints,
         MediaStreamSettings, MultiSourceTracksConstraints, RecvConstraints,
-        TrackConstraints, VideoTrackConstraints,
+        TrackConstraints, VideoSource,
     },
     device_info::InputDeviceInfo,
     manager::{MediaManager, MediaManagerError, MediaManagerHandle},

--- a/jason/src/media/track.rs
+++ b/jason/src/media/track.rs
@@ -184,8 +184,8 @@ impl MediaStreamTrack {
     }
 
     /// Returns a [`String`] set to `device` if track is sourced from some
-    /// device (webcam/microphone) and to `display`, if track is captured
-    /// via [MediaDevices.getDisplayMedia()][1].
+    /// device (webcam/microphone) and to `display`, if track is captured via
+    /// [MediaDevices.getDisplayMedia()][1].
     ///
     /// [1]: https://w3.org/TR/screen-capture/#dom-mediadevices-getdisplaymedia
     #[wasm_bindgen(js_name = media_source_kind)]

--- a/jason/src/media/track.rs
+++ b/jason/src/media/track.rs
@@ -6,6 +6,7 @@ use std::rc::{Rc, Weak};
 
 use derive_more::Display;
 use futures::StreamExt;
+use medea_client_api_proto::MediaSourceKind;
 use medea_reactive::ObservableCell;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
@@ -35,7 +36,7 @@ struct InnerMediaStreamTrack {
 
     /// Flag which indicates that this [`MediaStreamTrack`] was received from
     /// `getDisplayMedia`.
-    is_display: bool,
+    media_source_kind: MediaSourceKind,
 
     /// Callback to be invoked when this [`MediaStreamTrack`] is enabled.
     on_enabled: Callback0,
@@ -63,7 +64,7 @@ pub struct MediaStreamTrack(Rc<InnerMediaStreamTrack>);
 impl MediaStreamTrack {
     /// Creates new [`MediaStreamTrack`], spawns listener for
     /// [`InnerMediaStreamTrack::enabled`] state changes.
-    pub fn new<T>(track: T, is_display: bool) -> Self
+    pub fn new<T>(track: T, media_source_kind: MediaSourceKind) -> Self
     where
         SysMediaStreamTrack: From<T>,
     {
@@ -72,7 +73,7 @@ impl MediaStreamTrack {
             enabled: ObservableCell::new(track.enabled()),
             on_enabled: Callback0::default(),
             on_disabled: Callback0::default(),
-            is_display,
+            media_source_kind,
             track,
         }));
 
@@ -141,6 +142,12 @@ impl MediaStreamTrack {
     pub fn downgrade(&self) -> WeakMediaStreamTrack {
         WeakMediaStreamTrack(Rc::downgrade(&self.0))
     }
+
+    /// Returns this [`MediaStreamTrack`] media source kind.
+    #[inline]
+    pub fn media_source_kind(&self) -> MediaSourceKind {
+        self.0.media_source_kind
+    }
 }
 
 #[wasm_bindgen(js_class = MediaTrack)]
@@ -176,10 +183,14 @@ impl MediaStreamTrack {
         self.kind().to_string()
     }
 
-    /// Returns `true` if this [`MediaStreamTrack`] was received from
-    /// `getDisplayMedia`.
-    pub fn is_display(&self) -> bool {
-        self.0.is_display
+    /// Returns a [`String`] set to `device` if track is sourced from some
+    /// device (webcam/microphone) and to `display`, if track is captured
+    /// via [MediaDevices.getDisplayMedia()][1].
+    ///
+    /// [1]: https://w3.org/TR/screen-capture/#dom-mediadevices-getdisplaymedia
+    #[wasm_bindgen(js_name = media_source_kind)]
+    pub fn js_media_source_kind(&self) -> String {
+        self.0.media_source_kind.to_string()
     }
 }
 

--- a/jason/src/peer/media/mod.rs
+++ b/jason/src/peer/media/mod.rs
@@ -424,17 +424,16 @@ impl MediaConnections {
             let is_required = track.is_required();
             match track.direction {
                 Direction::Send { mid, .. } => {
-                    let mute_state;
-                    if send_constraints.is_enabled(&track.media_type) {
-                        mute_state = StableMuteState::Unmuted;
-                    } else if is_required {
-                        use MediaConnectionsError as Error;
-                        return Err(tracerr::new!(
-                            Error::CannotDisableRequiredSender
+                    let mute_state =
+                        if send_constraints.is_enabled(&track.media_type) {
+                            StableMuteState::Unmuted
+                        } else if is_required {
+                            return Err(tracerr::new!(
+                            MediaConnectionsError::CannotDisableRequiredSender
                         ));
-                    } else {
-                        mute_state = StableMuteState::Muted;
-                    }
+                        } else {
+                            StableMuteState::Muted
+                        };
                     let sndr = SenderBuilder {
                         peer_id: inner.peer_id,
                         track_id: track.id,

--- a/jason/src/peer/media/receiver.rs
+++ b/jason/src/peer/media/receiver.rs
@@ -126,7 +126,7 @@ impl Receiver {
         }
 
         let new_track =
-            MediaStreamTrack::new(new_track, self.caps.is_display_video());
+            MediaStreamTrack::new(new_track, self.caps.media_source_kind());
 
         transceiver.set_direction(self.transceiver_direction.get().into());
         new_track.set_enabled(self.is_not_muted());

--- a/jason/src/peer/media/receiver.rs
+++ b/jason/src/peer/media/receiver.rs
@@ -125,7 +125,8 @@ impl Receiver {
             }
         }
 
-        let new_track = MediaStreamTrack::from(new_track);
+        let new_track =
+            MediaStreamTrack::new(new_track, self.caps.is_display_video());
 
         transceiver.set_direction(self.transceiver_direction.get().into());
         new_track.set_enabled(self.is_not_muted());

--- a/jason/src/peer/tracks_request.rs
+++ b/jason/src/peer/tracks_request.rs
@@ -122,26 +122,19 @@ impl SimpleTracksRequest {
     ///
     /// # Errors
     ///
-    /// Errors with [`TracksRequestError::InvalidAudioTrack`] if some audio
-    /// track from provided [`MediaStream`] not satisfies
-    /// contained constrains.
-    ///
-    /// Errors with [`TracksRequestError::ExpectedAudioTracks`] if provided
-    /// [`HashMap`] doesn't have expected audio track.
-    ///
-    /// Errors with [`TracksRequestError::InvalidVideoTrack`] if some
-    /// device video track from provided [`HashMap`] not satisfies
-    /// contained constrains.
-    ///
-    /// Errors with [`TracksRequestError::ExpectedDeviceVideoTracks`] if
-    /// provided [`HashMap`] doesn't have expected device video track.
-    ///
-    /// Errors with [`TracksRequestError::InvalidVideoTrack`] if some
-    /// display video track from provided [`HashMap`] not satisfies
-    /// contained constrains.
-    ///
-    /// Errors with [`TracksRequestError::ExpectedDisplayVideoTracks`] if
-    /// provided [`HashMap`] doesn't have expected display video track.
+    /// - [`TracksRequestError::InvalidAudioTrack`] when some audio track from
+    ///   the provided [`MediaStream`] not satisfies contained constrains.
+    /// - [`TracksRequestError::ExpectedAudioTracks`] when the provided
+    ///   [`HashMap`] doesn't have the expected audio track.
+    /// - [`TracksRequestError::InvalidVideoTrack`] when some device video track
+    ///   from the provided [`HashMap`] doesn't satisfy contained constrains.
+    /// - [`TracksRequestError::ExpectedDeviceVideoTracks`] when the provided
+    ///   [`HashMap`] doesn't have the expected device video track.
+    /// - [`TracksRequestError::InvalidVideoTrack`] when some display video
+    ///   track from the provided [`HashMap`] doesn't satisfy contained
+    ///   constrains.
+    /// - [`TracksRequestError::ExpectedDisplayVideoTracks`] when the provided
+    ///   [`HashMap`] doesn't have the expected display video track.
     pub fn parse_tracks(
         &self,
         tracks: Vec<MediaStreamTrack>,
@@ -208,20 +201,18 @@ impl SimpleTracksRequest {
     ///
     /// # Errors
     ///
-    /// Errors with [`TracksRequestError::ExpectedAudioTracks`] if
-    /// [`SimpleTracksRequest`] contains [`AudioTrackConstraints`], but provided
-    /// [`MediaStreamSettings`] doesn't and this [`AudioTrackConstraints`] are
-    /// important.
-    ///
-    /// Errors with [`TracksRequestError::ExpectedDeviceVideoTracks`] if
-    /// [`SimpleTracksRequest`] contains [`DeviceVideoTrackConstraints`], but
-    /// provided [`MediaStreamSettings`] doesn't and this
-    /// [`DeviceVideoTrackConstraints`] are important.
-    ///
-    /// Errors with [`TracksRequestError::ExpectedDisplayVideoTracks`] if
-    /// [`SimpleTracksRequest`] contains [`DisplayVideoTrackConstraints`], but
-    /// provided [`MediaStreamSettings`] doesn't and this
-    /// [`DisplayVideoTrackConstraints`] are important.
+    /// - [`TracksRequestError::ExpectedAudioTracks`] when
+    ///   [`SimpleTracksRequest`] contains [`AudioTrackConstraints`], but the
+    ///   provided [`MediaStreamSettings`] doesn't and these
+    ///   [`AudioTrackConstraints`] are important.
+    /// - [`TracksRequestError::ExpectedDeviceVideoTracks`] when
+    ///   [`SimpleTracksRequest`] contains [`DeviceVideoTrackConstraints`], but
+    ///   the provided [`MediaStreamSettings`] doesn't and these
+    ///   [`DeviceVideoTrackConstraints`] are important.
+    /// - [`TracksRequestError::ExpectedDisplayVideoTracks`] when
+    ///   [`SimpleTracksRequest`] contains [`DisplayVideoTrackConstraints`], but
+    ///   the provided [`MediaStreamSettings`] doesn't and these
+    ///   [`DisplayVideoTrackConstraints`] are important.
     pub fn merge<T: Into<MediaStreamSettings>>(
         &mut self,
         other: T,

--- a/jason/src/peer/tracks_request.rs
+++ b/jason/src/peer/tracks_request.rs
@@ -11,9 +11,10 @@ use tracerr::Traced;
 use crate::{
     media::{
         AudioTrackConstraints, MediaStreamSettings, MediaStreamTrack,
-        TrackConstraints, TrackKind, VideoTrackConstraints,
+        TrackConstraints, TrackKind, VideoSource,
     },
     utils::{JsCaused, JsError},
+    DeviceVideoTrackConstraints, DisplayVideoTrackConstraints,
 };
 
 /// Errors that may occur when validating [`TracksRequest`] or
@@ -24,9 +25,17 @@ pub enum TracksRequestError {
     #[display(fmt = "only one audio track is allowed in SimpleTracksRequest")]
     TooManyAudioTracks,
 
-    /// [`TracksRequest`] contains multiple [`VideoTrackConstraints`].
-    #[display(fmt = "only one video track is allowed in SimpleTracksRequest")]
-    TooManyVideoTracks,
+    /// [`TracksRequest`] contains multiple [`DeviceVideoTrackConstraints`].
+    #[display(
+        fmt = "only one device video track is allowed in SimpleTracksRequest"
+    )]
+    TooManyDeviceVideoTracks,
+
+    /// [`TracksRequest`] contains multiple [`DisplayVideoTrackConstraints`].
+    #[display(
+        fmt = "only one display video track is allowed in SimpleTracksRequest"
+    )]
+    TooManyDisplayVideoTracks,
 
     /// [`TracksRequest`] contains no track constraints at all.
     #[display(fmt = "SimpleTracksRequest should have at least one track")]
@@ -36,9 +45,13 @@ pub enum TracksRequestError {
     #[display(fmt = "provided multiple audio MediaStreamTracks")]
     ExpectedAudioTracks,
 
-    /// Provided multiple video [`MediaStreamTrack`]s.
-    #[display(fmt = "provided multiple video MediaStreamTracks")]
-    ExpectedVideoTracks,
+    /// Provided multiple device video [`MediaStreamTrack`]s.
+    #[display(fmt = "provided multiple device video MediaStreamTracks")]
+    ExpectedDeviceVideoTracks,
+
+    /// Provided multiple display video [`MediaStreamTrack`]s.
+    #[display(fmt = "provided multiple display video MediaStreamTracks")]
+    ExpectedDisplayVideoTracks,
 
     /// Audio track fails to satisfy specified constraints.
     #[display(
@@ -46,11 +59,15 @@ pub enum TracksRequestError {
     )]
     InvalidAudioTrack,
 
-    /// Video track fails to satisfy specified constraints.
-    #[display(
-        fmt = "provided video track does not satisfy specified constraints"
-    )]
-    InvalidVideoTrack,
+    /// Device video track fails to satisfy specified constraints.
+    #[display(fmt = "provided device video track does not satisfy specified \
+                     constraints")]
+    InvalidDeviceVideoTrack,
+
+    /// Display video track fails to satisfy specified constraints.
+    #[display(fmt = "provided display video track does not satisfy \
+                     specified constraints")]
+    InvalidDisplayVideoTrack,
 }
 
 type Result<T> = std::result::Result<T, Traced<TracksRequestError>>;
@@ -67,7 +84,8 @@ type Result<T> = std::result::Result<T, Traced<TracksRequestError>>;
 #[derive(Debug, Default)]
 pub struct TracksRequest {
     audio: HashMap<TrackId, AudioTrackConstraints>,
-    video: HashMap<TrackId, VideoTrackConstraints>,
+    device_video: HashMap<TrackId, DeviceVideoTrackConstraints>,
+    display_video: HashMap<TrackId, DisplayVideoTrackConstraints>,
 }
 
 impl TracksRequest {
@@ -81,9 +99,14 @@ impl TracksRequest {
             TrackConstraints::Audio(audio) => {
                 self.audio.insert(track_id, audio);
             }
-            TrackConstraints::Video(video) => {
-                self.video.insert(track_id, video);
-            }
+            TrackConstraints::Video(video) => match video {
+                VideoSource::Device(device) => {
+                    self.device_video.insert(track_id, device);
+                }
+                VideoSource::Display(display) => {
+                    self.display_video.insert(track_id, display);
+                }
+            },
         }
     }
 }
@@ -93,7 +116,8 @@ impl TracksRequest {
 #[derive(Debug)]
 pub struct SimpleTracksRequest {
     audio: Option<(TrackId, AudioTrackConstraints)>,
-    video: Option<(TrackId, VideoTrackConstraints)>,
+    display_video: Option<(TrackId, DisplayVideoTrackConstraints)>,
+    device_video: Option<(TrackId, DeviceVideoTrackConstraints)>,
 }
 
 impl SimpleTracksRequest {
@@ -109,25 +133,47 @@ impl SimpleTracksRequest {
     /// Errors with [`TracksRequestError::ExpectedAudioTracks`] if provided
     /// [`HashMap`] doesn't have expected audio track.
     ///
-    /// Errors with [`TracksRequestError::InvalidVideoTrack`] if some video
-    /// track from provided [`HashMap`] not satisfies
+    /// Errors with [`TracksRequestError::InvalidDeviceVideoTrack`] if some
+    /// device video track from provided [`HashMap`] not satisfies
     /// contained constrains.
     ///
-    /// Errors with [`TracksRequestError::ExpectedVideoTracks`] if provided
-    /// [`HashMap`] doesn't have expected video track.
+    /// Errors with [`TracksRequestError::ExpectedDeviceVideoTracks`] if
+    /// provided [`HashMap`] doesn't have expected device video track.
+    ///
+    /// Errors with [`TracksRequestError::InvalidDisplayVideoTrack`] if some
+    /// display video track from provided [`HashMap`] not satisfies
+    /// contained constrains.
+    ///
+    /// Errors with [`TracksRequestError::ExpectedDisplayVideoTracks`] if
+    /// provided [`HashMap`] doesn't have expected display video track.
     pub fn parse_tracks(
         &self,
         tracks: Vec<MediaStreamTrack>,
     ) -> Result<HashMap<TrackId, MediaStreamTrack>> {
-        use TracksRequestError::{InvalidAudioTrack, InvalidVideoTrack};
+        use TracksRequestError::{
+            InvalidAudioTrack, InvalidDeviceVideoTrack,
+            InvalidDisplayVideoTrack,
+        };
 
         let mut parsed_tracks = HashMap::new();
 
-        let (video_tracks, audio_tracks): (Vec<_>, Vec<_>) =
-            tracks.into_iter().partition(|track| match track.kind() {
-                TrackKind::Audio { .. } => false,
-                TrackKind::Video { .. } => true,
-            });
+        let mut display_video_tracks = Vec::new();
+        let mut device_video_tracks = Vec::new();
+        let mut audio_tracks = Vec::new();
+        for track in tracks {
+            match track.kind() {
+                TrackKind::Audio => {
+                    audio_tracks.push(track);
+                }
+                TrackKind::Video => {
+                    if track.is_display() {
+                        display_video_tracks.push(track);
+                    } else {
+                        device_video_tracks.push(track);
+                    }
+                }
+            }
+        }
 
         if let Some((id, audio)) = &self.audio {
             if let Some(track) = audio_tracks.into_iter().next() {
@@ -138,13 +184,21 @@ impl SimpleTracksRequest {
                 }
             }
         }
-
-        if let Some((id, video)) = &self.video {
-            if let Some(track) = video_tracks.into_iter().next() {
-                if video.satisfies(track.as_ref()) {
+        if let Some((id, device_video)) = &self.device_video {
+            if let Some(track) = device_video_tracks.into_iter().next() {
+                if device_video.satisfies(track.as_ref()) {
                     parsed_tracks.insert(*id, track);
                 } else {
-                    return Err(tracerr::new!(InvalidVideoTrack));
+                    return Err(tracerr::new!(InvalidDeviceVideoTrack));
+                }
+            }
+        }
+        if let Some((id, display_video)) = &self.display_video {
+            if let Some(track) = display_video_tracks.into_iter().next() {
+                if display_video.satisfies(track.as_ref()) {
+                    parsed_tracks.insert(*id, track);
+                } else {
+                    return Err(tracerr::new!(InvalidDisplayVideoTrack));
                 }
             }
         }
@@ -165,27 +219,21 @@ impl SimpleTracksRequest {
     /// [`MediaStreamSettings`] doesn't and this [`AudioTrackConstraints`] are
     /// important.
     ///
-    /// Errors with [`TracksRequestError::ExpectedVideoTracks`] if
-    /// [`SimpleTracksRequest`] contains [`VideoTrackConstraints`], but provided
-    /// [`MediaStreamSettings`] doesn't and this [`VideoTrackConstraints`] are
-    /// important.
+    /// Errors with [`TracksRequestError::ExpectedDeviceVideoTracks`] if
+    /// [`SimpleTracksRequest`] contains [`DeviceVideoTrackConstraints`], but
+    /// provided [`MediaStreamSettings`] doesn't and this
+    /// [`DeviceVideoTrackConstraints`] are important.
+    ///
+    /// Errors with [`TracksRequestError::ExpectedDisplayVideoTracks`] if
+    /// [`SimpleTracksRequest`] contains [`DisplayVideoTrackConstraints`], but
+    /// provided [`MediaStreamSettings`] doesn't and this
+    /// [`DisplayVideoTrackConstraints`] are important.
     pub fn merge<T: Into<MediaStreamSettings>>(
         &mut self,
         other: T,
     ) -> Result<()> {
         let other = other.into();
 
-        if let Some((_, video_caps)) = &self.video {
-            if !other.is_video_enabled() {
-                if video_caps.is_required() {
-                    return Err(tracerr::new!(
-                        TracksRequestError::ExpectedVideoTracks
-                    ));
-                } else {
-                    self.video.take();
-                }
-            }
-        }
         if let Some((_, audio_caps)) = &self.audio {
             if !other.is_audio_enabled() {
                 if audio_caps.is_required() {
@@ -197,15 +245,46 @@ impl SimpleTracksRequest {
                 }
             }
         }
+        if let Some((_, device_video_caps)) = &self.device_video {
+            if !other.is_device_video_enabled() {
+                if device_video_caps.is_required() {
+                    return Err(tracerr::new!(
+                        TracksRequestError::ExpectedDeviceVideoTracks
+                    ));
+                } else {
+                    self.device_video.take();
+                }
+            }
+        }
+        if let Some((_, display_video_caps)) = &self.display_video {
+            if !other.is_display_video_enabled() {
+                if display_video_caps.is_required() {
+                    return Err(tracerr::new!(
+                        TracksRequestError::ExpectedDisplayVideoTracks
+                    ));
+                } else {
+                    self.display_video.take();
+                }
+            }
+        }
 
         if other.is_audio_enabled() {
             if let Some((_, audio)) = self.audio.as_mut() {
                 audio.merge(other.get_audio().clone());
             }
         }
-        if other.is_video_enabled() {
-            if let Some((_, video)) = self.video.as_mut() {
-                video.merge(other.get_video().clone());
+        if other.is_display_video_enabled() {
+            if let Some((_, display_video)) = self.display_video.as_mut() {
+                if let Some(other_display_video) = other.get_display_video() {
+                    display_video.merge(other_display_video);
+                }
+            }
+        }
+        if other.is_device_video_enabled() {
+            if let Some((_, device_video)) = self.device_video.as_mut() {
+                if let Some(other_device_video) = other.get_device_video() {
+                    device_video.merge(other_device_video.clone());
+                }
             }
         }
 
@@ -220,27 +299,38 @@ impl TryFrom<TracksRequest> for SimpleTracksRequest {
         value: TracksRequest,
     ) -> std::result::Result<Self, Self::Error> {
         use TracksRequestError::{
-            NoTracks, TooManyAudioTracks, TooManyVideoTracks,
+            NoTracks, TooManyAudioTracks, TooManyDeviceVideoTracks,
+            TooManyDisplayVideoTracks,
         };
 
-        if value.video.len() > 1 {
-            return Err(TooManyVideoTracks);
+        if value.device_video.len() > 1 {
+            return Err(TooManyDeviceVideoTracks);
+        } else if value.display_video.len() > 1 {
+            return Err(TooManyDisplayVideoTracks);
         } else if value.audio.len() > 1 {
             return Err(TooManyAudioTracks);
-        } else if value.video.is_empty() && value.audio.is_empty() {
+        } else if value.device_video.is_empty()
+            && value.display_video.is_empty()
+            && value.audio.is_empty()
+        {
             return Err(NoTracks);
         }
 
         let mut req = Self {
             audio: None,
-            video: None,
+            device_video: None,
+            display_video: None,
         };
         for (id, audio) in value.audio {
             req.audio.replace((id, audio));
         }
-        for (id, video) in value.video {
-            req.video.replace((id, video));
+        for (id, device) in value.device_video {
+            req.device_video.replace((id, device));
         }
+        for (id, display) in value.display_video {
+            req.display_video.replace((id, display));
+        }
+
         Ok(req)
     }
 }
@@ -252,8 +342,11 @@ impl From<&SimpleTracksRequest> for MediaStreamSettings {
         if let Some((_, audio)) = &request.audio {
             constraints.audio(audio.clone());
         }
-        if let Some((_, video)) = &request.video {
-            constraints.video(video.clone());
+        if let Some((_, device_video)) = &request.device_video {
+            constraints.device_video(device_video.clone());
+        }
+        if let Some((_, display_video)) = &request.display_video {
+            constraints.display_video(display_video.clone());
         }
 
         constraints

--- a/jason/tests/api/room.rs
+++ b/jason/tests/api/room.rs
@@ -346,7 +346,8 @@ async fn error_join_room_without_on_connection_loss_callback() {
 
 mod disable_recv_tracks {
     use medea_client_api_proto::{
-        AudioSettings, Direction, MediaType, MemberId, VideoSettings,
+        AudioSettings, Direction, MediaSourceKind, MediaType, MemberId,
+        VideoSettings,
     };
 
     use super::*;
@@ -384,7 +385,7 @@ mod disable_recv_tracks {
                         },
                         media_type: MediaType::Video(VideoSettings {
                             is_required: true,
-                            is_display: false,
+                            source_kind: MediaSourceKind::Device,
                         }),
                     },
                     Track {
@@ -990,8 +991,8 @@ mod patches_generation {
 
     use futures::StreamExt;
     use medea_client_api_proto::{
-        AudioSettings, Direction, MediaType, Track, TrackId, TrackPatchCommand,
-        VideoSettings,
+        AudioSettings, Direction, MediaSourceKind, MediaType, Track, TrackId,
+        TrackPatchCommand, VideoSettings,
     };
     use medea_jason::media::RecvConstraints;
     use wasm_bindgen_futures::spawn_local;
@@ -1031,7 +1032,7 @@ mod patches_generation {
                 id: video_track_id,
                 media_type: MediaType::Video(VideoSettings {
                     is_required: false,
-                    is_display: false,
+                    source_kind: MediaSourceKind::Device,
                 }),
                 direction: Direction::Send {
                     receivers: Vec::new(),

--- a/jason/tests/api/room.rs
+++ b/jason/tests/api/room.rs
@@ -177,7 +177,8 @@ async fn error_inject_invalid_local_stream_into_room_on_exists_peer() {
         cb_assert_eq!(&err.name(), "InvalidLocalTracks");
         cb_assert_eq!(
             &err.message(),
-            "Invalid local tracks: provided multiple video MediaStreamTracks"
+            "Invalid local tracks: provided multiple device video \
+             MediaStreamTracks"
         );
     });
     let (audio_track, video_track) = get_test_required_tracks();
@@ -383,6 +384,7 @@ mod disable_recv_tracks {
                         },
                         media_type: MediaType::Video(VideoSettings {
                             is_required: true,
+                            is_display: false,
                         }),
                     },
                     Track {
@@ -1029,6 +1031,7 @@ mod patches_generation {
                 id: video_track_id,
                 media_type: MediaType::Video(VideoSettings {
                     is_required: false,
+                    is_display: false,
                 }),
                 direction: Direction::Send {
                     receivers: Vec::new(),
@@ -1038,7 +1041,8 @@ mod patches_generation {
             let tracks = vec![audio_track, video_track];
             let peer_id = PeerId(i + 1);
 
-            let mut local_stream = MediaStreamSettings::new();
+            let mut local_stream = MediaStreamSettings::default();
+            local_stream.set_track_enabled(false, TransceiverKind::Video);
             local_stream.set_track_enabled(
                 (audio_track_enabled_state_fn)(i),
                 TransceiverKind::Audio,

--- a/jason/tests/media/constraints.rs
+++ b/jason/tests/media/constraints.rs
@@ -5,7 +5,7 @@ use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 use web_sys::{MediaDeviceInfo, MediaDeviceKind};
 
-use medea_client_api_proto::VideoSettings;
+use medea_client_api_proto::{MediaSourceKind, VideoSettings};
 use medea_jason::{
     media::{
         AudioTrackConstraints, DeviceVideoTrackConstraints, MediaManager,
@@ -39,7 +39,7 @@ async fn video_constraints_satisfies() {
 
     let track = tracks.pop().unwrap().0;
 
-    assert!(track.kind() == TrackKind::Video);
+    assert_eq!(track.kind(), TrackKind::Video);
     assert!(track_constraints.satisfies(track.as_ref()));
 }
 
@@ -64,7 +64,7 @@ async fn audio_constraints_satisfies() {
 
     let track = tracks.pop().unwrap().0;
 
-    assert!(track.kind() == TrackKind::Audio);
+    assert_eq!(track.kind(), TrackKind::Audio);
     assert!(track_constraints.satisfies(&track));
 }
 
@@ -113,10 +113,10 @@ async fn both_constraints_satisfies() {
     let audio_track = audio.pop().unwrap().0;
     let video_track = video.pop().unwrap().0;
 
-    assert!(audio_track.kind() == TrackKind::Audio);
+    assert_eq!(audio_track.kind(), TrackKind::Audio);
     assert!(audio_constraints.satisfies(&audio_track));
 
-    assert!(video_track.kind() == TrackKind::Video);
+    assert_eq!(video_track.kind(), TrackKind::Video);
     assert!(video_constraints.satisfies(video_track.as_ref()));
 }
 
@@ -353,7 +353,7 @@ async fn multi_source_media_stream_constraints_build6() {
 fn get_device_video_track_constraints() -> DeviceVideoTrackConstraints {
     match VideoSource::from(VideoSettings {
         is_required: true,
-        is_display: false,
+        source_kind: MediaSourceKind::Device,
     }) {
         VideoSource::Device(device) => device,
         _ => unreachable!(),

--- a/jason/tests/media/constraints.rs
+++ b/jason/tests/media/constraints.rs
@@ -10,7 +10,7 @@ use medea_jason::{
     media::{
         AudioTrackConstraints, DeviceVideoTrackConstraints, MediaManager,
         MediaStreamSettings, MultiSourceTracksConstraints, TrackKind,
-        VideoTrackConstraints,
+        VideoSource,
     },
     utils::{get_property_by_name, window},
     DisplayVideoTrackConstraints,
@@ -40,7 +40,7 @@ async fn video_constraints_satisfies() {
     let track = tracks.pop().unwrap().0;
 
     assert!(track.kind() == TrackKind::Video);
-    assert!(VideoTrackConstraints::from(track_constraints).satisfies(&track));
+    assert!(track_constraints.satisfies(track.as_ref()));
 }
 
 // 1. Get device id of non default audio device from enumerate_devices();
@@ -98,7 +98,7 @@ async fn both_constraints_satisfies() {
 
     let tracks = media_manager.get_tracks(constraints.clone()).await.unwrap();
 
-    let video_constraints = constraints.get_video().clone();
+    let video_constraints = constraints.get_device_video().clone().unwrap();
     let audio_constraints = constraints.get_audio().clone();
 
     assert_eq!(tracks.len(), 2);
@@ -117,7 +117,7 @@ async fn both_constraints_satisfies() {
     assert!(audio_constraints.satisfies(&audio_track));
 
     assert!(video_track.kind() == TrackKind::Video);
-    assert!(video_constraints.satisfies(&video_track));
+    assert!(video_constraints.satisfies(video_track.as_ref()));
 }
 
 // 1. Get device id of non default audio and video device from
@@ -350,15 +350,23 @@ async fn multi_source_media_stream_constraints_build6() {
     };
 }
 
+fn get_device_video_track_constraints() -> DeviceVideoTrackConstraints {
+    match VideoSource::from(VideoSettings {
+        is_required: true,
+        is_display: false,
+    }) {
+        VideoSource::Device(device) => device,
+        _ => unreachable!(),
+    }
+}
+
 // Make sure that MediaStreamConstraints{audio:true, video:any} =>
 // Device({audio:true, video:true})
 #[wasm_bindgen_test]
 async fn multi_source_media_stream_constraints_build7() {
     let mut constraints = MediaStreamSettings::new();
     constraints.audio(AudioTrackConstraints::new());
-    constraints.video(VideoTrackConstraints::from(VideoSettings {
-        is_required: true,
-    }));
+    constraints.device_video(get_device_video_track_constraints());
 
     let constraints: Option<MultiSourceTracksConstraints> = constraints.into();
 
@@ -383,9 +391,7 @@ async fn multi_source_media_stream_constraints_build7() {
 #[wasm_bindgen_test]
 async fn multi_source_media_stream_constraints_build8() {
     let mut constraints = MediaStreamSettings::new();
-    constraints.video(VideoTrackConstraints::from(VideoSettings {
-        is_required: true,
-    }));
+    constraints.device_video(get_device_video_track_constraints());
 
     let constraints: Option<MultiSourceTracksConstraints> = constraints.into();
 

--- a/jason/tests/media/manager.rs
+++ b/jason/tests/media/manager.rs
@@ -136,7 +136,7 @@ async fn same_track_for_same_constraints() {
     let (track1, track1_is_new) = tracks.pop().unwrap();
 
     assert!(track1_is_new);
-    assert!(track1.kind() == TrackKind::Audio);
+    assert_eq!(track1.kind(), TrackKind::Audio);
     assert_eq!(mock_navigator.get_user_media_requests_count(), 1);
 
     // second request, same track, no additional getUserMedia requests
@@ -148,7 +148,7 @@ async fn same_track_for_same_constraints() {
 
     assert!(!track2_is_new);
     assert_eq!(track1.id(), track2.id());
-    assert!(track2.kind() == TrackKind::Audio);
+    assert_eq!(track2.kind(), TrackKind::Audio);
     assert_eq!(mock_navigator.get_user_media_requests_count(), 1);
 }
 
@@ -175,7 +175,7 @@ async fn new_track_if_previous_dropped() {
     assert_eq!(tracks.len(), 1);
     let (track1, track1_is_new) = tracks.pop().unwrap();
 
-    assert!(track1.kind() == TrackKind::Audio);
+    assert_eq!(track1.kind(), TrackKind::Audio);
     assert!(track1_is_new);
     assert_eq!(mock_navigator.get_user_media_requests_count(), 1);
 
@@ -189,7 +189,7 @@ async fn new_track_if_previous_dropped() {
 
     assert!(track2_is_new);
     assert_ne!(track2.id(), track1_id);
-    assert!(track2.kind() == TrackKind::Audio);
+    assert_eq!(track2.kind(), TrackKind::Audio);
     assert_eq!(mock_navigator.get_user_media_requests_count(), 2);
 
     mock_navigator.stop();

--- a/jason/tests/peer/mod.rs
+++ b/jason/tests/peer/mod.rs
@@ -609,6 +609,7 @@ impl InterconnectedPeers {
                 },
                 media_type: MediaType::Video(VideoSettings {
                     is_required: true,
+                    is_display: false,
                 }),
             },
         ]
@@ -635,6 +636,7 @@ impl InterconnectedPeers {
                 },
                 media_type: MediaType::Video(VideoSettings {
                     is_required: true,
+                    is_display: false,
                 }),
             },
         ]
@@ -985,6 +987,7 @@ async fn new_remote_track() {
                         },
                         media_type: MediaType::Video(VideoSettings {
                             is_required: true,
+                            is_display: false,
                         }),
                     },
                 ],

--- a/jason/tests/peer/mod.rs
+++ b/jason/tests/peer/mod.rs
@@ -15,8 +15,8 @@ use medea_client_api_proto::{
         RtcInboundRtpStreamMediaType, RtcOutboundRtpStreamMediaType, RtcStat,
         RtcStatsType, StatId, TrackStats, TrackStatsKind,
     },
-    AudioSettings, Direction, IceConnectionState, MediaType, MemberId, PeerId,
-    Track, TrackId, TrackPatchEvent, VideoSettings,
+    AudioSettings, Direction, IceConnectionState, MediaSourceKind, MediaType,
+    MemberId, PeerId, Track, TrackId, TrackPatchEvent, VideoSettings,
 };
 use medea_jason::{
     media::{LocalTracksConstraints, MediaManager, RecvConstraints, TrackKind},
@@ -609,7 +609,7 @@ impl InterconnectedPeers {
                 },
                 media_type: MediaType::Video(VideoSettings {
                     is_required: true,
-                    is_display: false,
+                    source_kind: MediaSourceKind::Device,
                 }),
             },
         ]
@@ -636,7 +636,7 @@ impl InterconnectedPeers {
                 },
                 media_type: MediaType::Video(VideoSettings {
                     is_required: true,
-                    is_display: false,
+                    source_kind: MediaSourceKind::Device,
                 }),
             },
         ]
@@ -987,7 +987,7 @@ async fn new_remote_track() {
                         },
                         media_type: MediaType::Video(VideoSettings {
                             is_required: true,
-                            is_display: false,
+                            source_kind: MediaSourceKind::Device,
                         }),
                     },
                 ],

--- a/jason/tests/web.rs
+++ b/jason/tests/web.rs
@@ -83,8 +83,8 @@ mod utils;
 use futures::{channel::oneshot, future::Either, Future};
 use js_sys::Promise;
 use medea_client_api_proto::{
-    AudioSettings, Direction, MediaType, MemberId, Track, TrackId,
-    VideoSettings,
+    AudioSettings, Direction, MediaSourceKind, MediaType, MemberId, Track,
+    TrackId, VideoSettings,
 };
 use medea_jason::{
     media::{LocalTracksConstraints, MediaManager, MediaStreamTrack},
@@ -171,7 +171,7 @@ pub fn get_test_tracks(
             },
             media_type: MediaType::Video(VideoSettings {
                 is_required: is_video_required,
-                is_display: false,
+                source_kind: MediaSourceKind::Device,
             }),
         },
     )
@@ -199,7 +199,7 @@ pub fn get_test_recv_tracks() -> (Track, Track) {
             },
             media_type: MediaType::Video(VideoSettings {
                 is_required: false,
-                is_display: false,
+                source_kind: MediaSourceKind::Device,
             }),
         },
     )

--- a/jason/tests/web.rs
+++ b/jason/tests/web.rs
@@ -87,10 +87,7 @@ use medea_client_api_proto::{
     VideoSettings,
 };
 use medea_jason::{
-    media::{
-        LocalTracksConstraints, MediaManager, MediaStreamTrack,
-        VideoTrackConstraints,
-    },
+    media::{LocalTracksConstraints, MediaManager, MediaStreamTrack},
     peer::TransceiverKind,
     utils::{window, JasonError},
     AudioTrackConstraints, DeviceVideoTrackConstraints, MediaStreamSettings,
@@ -174,6 +171,7 @@ pub fn get_test_tracks(
             },
             media_type: MediaType::Video(VideoSettings {
                 is_required: is_video_required,
+                is_display: false,
             }),
         },
     )
@@ -199,7 +197,10 @@ pub fn get_test_recv_tracks() -> (Track, Track) {
                 sender: "bob".into(),
                 mid: Some("mid1".to_string()),
             },
-            media_type: MediaType::Video(VideoSettings { is_required: false }),
+            media_type: MediaType::Video(VideoSettings {
+                is_required: false,
+                is_display: false,
+            }),
         },
     )
 }
@@ -226,7 +227,7 @@ fn media_stream_settings(
         settings.audio(AudioTrackConstraints::default());
     }
     if is_video_enabled {
-        settings.video(VideoTrackConstraints::default());
+        settings.device_video(DeviceVideoTrackConstraints::default());
     }
 
     settings

--- a/proto/client-api/CHANGELOG.md
+++ b/proto/client-api/CHANGELOG.md
@@ -57,7 +57,7 @@ All user visible changes to this project will be documented in this file. This p
 - `ConnectionQualityUpdated` event ([#132]);
 - `TrackPatchEvent` and `TrackPatchCommand` types ([#127]);
 - `IceRestart` variant to `TrackUpdate` ([#138]);
-- `is_display` field to `VideoSettings` type ([#145]).
+- `source_kind` field to `VideoSettings` type ([#145]).
 
 [#28]: /../../pull/28
 [#58]: /../../pull/58

--- a/proto/client-api/CHANGELOG.md
+++ b/proto/client-api/CHANGELOG.md
@@ -56,7 +56,8 @@ All user visible changes to this project will be documented in this file. This p
 - `TracksApplied` event with `TrackUpdate::Updated` and `TrackUpdate::Added` variants ([#81], [#105]);
 - `ConnectionQualityUpdated` event ([#132]);
 - `TrackPatchEvent` and `TrackPatchCommand` types ([#127]);
-- `IceRestart` variant to `TrackUpdate` ([#138]).
+- `IceRestart` variant to `TrackUpdate` ([#138]);
+- `is_display` field to `VideoSettings` type ([#145]).
 
 [#28]: /../../pull/28
 [#58]: /../../pull/58
@@ -73,6 +74,7 @@ All user visible changes to this project will be documented in this file. This p
 [#132]: /../../pull/132
 [#127]: /../../pull/127
 [#138]: /../../pull/138
+[#145]: /../../pull/145
 
 
 

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -608,7 +608,20 @@ pub struct VideoSettings {
     /// screen.
     ///
     /// If `false` then this should be obtained video from the user camera.
-    pub is_display: bool,
+    pub source_kind: MediaSourceKind,
+}
+
+/// Media source kind.
+#[cfg_attr(feature = "medea", derive(Debug, Eq, PartialEq, Serialize))]
+#[cfg_attr(feature = "jason", derive(Deserialize))]
+#[derive(Clone, Copy, Display)]
+pub enum MediaSourceKind {
+    /// Media is sourced by some media device (webcam or microphone).
+    #[display(fmt = "device")]
+    Device,
+    /// Media is obtained with screen-capture.
+    #[display(fmt = "display")]
+    Display,
 }
 
 /// Estimated connection quality.

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -604,8 +604,7 @@ pub struct VideoSettings {
     /// If `false` then video may be not published.
     pub is_required: bool,
 
-    /// Whether media is sourced by some device (webcam) or captured from user
-    /// display.
+    /// Source kind of this [`VideoSettings`] media.
     pub source_kind: MediaSourceKind,
 }
 
@@ -617,6 +616,7 @@ pub enum MediaSourceKind {
     /// Media is sourced by some media device (webcam or microphone).
     #[display(fmt = "device")]
     Device,
+
     /// Media is obtained with screen-capture.
     #[display(fmt = "display")]
     Display,

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -603,6 +603,12 @@ pub struct VideoSettings {
     ///
     /// If `false` then video may be not published.
     pub is_required: bool,
+
+    /// Flag which indicates that this video should be obtained from the user
+    /// screen.
+    ///
+    /// If `false` then this should be obtained video from the user camera.
+    pub is_display: bool,
 }
 
 /// Estimated connection quality.

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -604,10 +604,8 @@ pub struct VideoSettings {
     /// If `false` then video may be not published.
     pub is_required: bool,
 
-    /// Flag which indicates that this video should be obtained from the user
-    /// screen.
-    ///
-    /// If `false` then this should be obtained video from the user camera.
+    /// Whether media is sourced by some device (webcam) or captured from user
+    /// display.
     pub source_kind: MediaSourceKind,
 }
 

--- a/proto/client-api/src/stats.rs
+++ b/proto/client-api/src/stats.rs
@@ -1354,7 +1354,7 @@ pub struct RtcIceCandidateStats {
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Hash, PartialEq, Serialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
-pub enum MediaSourceKind {
+pub enum MediaKind {
     /// Fields when `kind` is `video`.
     Video {
         /// Width (in pixels) of the last frame originating from the source.
@@ -1408,7 +1408,7 @@ pub struct MediaSourceStats {
 
     /// Fields which should be in the [`RtcStat`] based on `kind`.
     #[serde(flatten)]
-    pub kind: MediaSourceKind,
+    pub kind: MediaKind,
 }
 
 #[cfg(feature = "extended-stats")]

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -59,9 +59,9 @@ use std::{
 use derive_more::Display;
 use failure::Fail;
 use medea_client_api_proto::{
-    AudioSettings, Direction, IceServer, MediaType, MemberId, PeerId as Id,
-    PeerId, Track, TrackId, TrackPatchCommand, TrackPatchEvent, TrackUpdate,
-    VideoSettings,
+    AudioSettings, Direction, IceServer, MediaSourceKind, MediaType, MemberId,
+    PeerId as Id, PeerId, Track, TrackId, TrackPatchCommand, TrackPatchEvent,
+    TrackUpdate, VideoSettings,
 };
 use medea_macro::{dispatchable, enum_delegate};
 
@@ -991,7 +991,7 @@ impl<'a> PeerChangesScheduler<'a> {
                 tracks_counter.next_id(),
                 MediaType::Video(VideoSettings {
                     is_required: video_settings.publish_policy.is_required(),
-                    is_display: false,
+                    source_kind: MediaSourceKind::Device,
                 }),
             ));
             self.add_sender(Rc::clone(&track_video));
@@ -1074,7 +1074,7 @@ pub mod tests {
                 track_id,
                 MediaType::Video(VideoSettings {
                     is_required: true,
-                    is_display: false,
+                    source_kind: MediaSourceKind::Device,
                 }),
             );
             peer.context.senders.insert(track_id, Rc::new(track));
@@ -1095,7 +1095,7 @@ pub mod tests {
                 track_id,
                 MediaType::Video(VideoSettings {
                     is_required: true,
-                    is_display: false,
+                    source_kind: MediaSourceKind::Device,
                 }),
             );
             peer.context.receivers.insert(track_id, Rc::new(track));
@@ -1109,7 +1109,7 @@ pub mod tests {
             TrackId(track_id),
             MediaType::Video(VideoSettings {
                 is_required: true,
-                is_display: false,
+                source_kind: MediaSourceKind::Device,
             }),
         ))
     }

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -991,6 +991,7 @@ impl<'a> PeerChangesScheduler<'a> {
                 tracks_counter.next_id(),
                 MediaType::Video(VideoSettings {
                     is_required: video_settings.publish_policy.is_required(),
+                    is_display: false,
                 }),
             ));
             self.add_sender(Rc::clone(&track_video));
@@ -1071,7 +1072,10 @@ pub mod tests {
             let track_id = track_id_counter.next_id();
             let track = MediaTrack::new(
                 track_id,
-                MediaType::Video(VideoSettings { is_required: true }),
+                MediaType::Video(VideoSettings {
+                    is_required: true,
+                    is_display: false,
+                }),
             );
             peer.context.senders.insert(track_id, Rc::new(track));
         }
@@ -1089,7 +1093,10 @@ pub mod tests {
             let track_id = track_id_counter.next_id();
             let track = MediaTrack::new(
                 track_id,
-                MediaType::Video(VideoSettings { is_required: true }),
+                MediaType::Video(VideoSettings {
+                    is_required: true,
+                    is_display: false,
+                }),
             );
             peer.context.receivers.insert(track_id, Rc::new(track));
         }
@@ -1100,7 +1107,10 @@ pub mod tests {
     fn media_track(track_id: u32) -> Rc<MediaTrack> {
         Rc::new(MediaTrack::new(
             TrackId(track_id),
-            MediaType::Video(VideoSettings { is_required: true }),
+            MediaType::Video(VideoSettings {
+                is_required: true,
+                is_display: false,
+            }),
         ))
     }
 


### PR DESCRIPTION
Part of #27

Required for #144




## Synopsis

Currently, in `MediaStreamSettings` can be specified only one type of video, but in #144 we need to simultaneous specify device and display video constraints.



## Solution

Refactor Jason to constrain device and display video simultaneous.



## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
