### PR TITLE
Return enums instead of strings in Jason's exported functions 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36de80175eb1f0a5c518024ce0d23646b54a23008279e090ca1848f6f1448bf4"
+checksum = "c1b12fe25e11cd9ed2ef2e428427eb6178a1b363f3f7f0dab8278572f11b2da1"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -293,7 +293,7 @@ dependencies = [
  "serde_urlencoded",
  "socket2",
  "time 0.2.22",
- "tinyvec",
+ "tinyvec 1.0.1",
  "url",
 ]
 
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
 
 [[package]]
 name = "arc-swap"
@@ -394,9 +394,9 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "async-channel"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21279cfaa4f47df10b1816007e738ca3747ef2ee53ffc51cdbf57a8bb266fee3"
+checksum = "55576d57ea9e255e709ea13169645a9427987a6504791cf19b59908d5c922b3d"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -432,13 +432,14 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e727cebd055ab2861a854f79def078c4b99ea722d54c6800a0e274389882d4c"
+checksum = "1a027f4b662e59d7070791e33baafd36affe67388965701b50039db5ebb240d2"
 dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
+ "libc",
  "log",
  "nb-connect",
  "once_cell",
@@ -446,6 +447,7 @@ dependencies = [
  "polling",
  "vec-arena",
  "waker-fn",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -513,9 +515,9 @@ checksum = "8ab27c1aa62945039e44edaeee1dc23c74cc0c303dd5fe0fb462a184f1c3a518"
 
 [[package]]
 name = "async-trait"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
+checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -622,16 +624,16 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2640778f8053e72c11f621b0a5175a0560a269282aa98ed85107773ab8e2a556"
+checksum = "c5aba2c74d15fe950254784fe497a999345606169c2288ccb771b72acdf41241"
 dependencies = [
  "async-channel",
+ "async-task",
  "atomic-waker",
  "fastrand",
  "futures-lite",
  "once_cell",
- "waker-fn",
 ]
 
 [[package]]
@@ -967,7 +969,7 @@ dependencies = [
  "async-trait",
  "config",
  "deadpool",
- "futures 0.3.5",
+ "futures 0.3.6",
  "log",
  "redis",
  "serde 1.0.116",
@@ -1126,9 +1128,12 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.3.5"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c85295147490b8fcf2ea3d104080a105a8b2c63f9c319e82c02d8e952388919"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -1213,15 +1218,15 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+checksum = "5d8e3078b7b2a8a671cb7a3d17b4760e4181ea243227776ba83fd043b4ca034e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1234,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+checksum = "a7a4d35f7401e948629c9c3d6638fb9bf94e0b2121e96c3b428cc4e631f3eb74"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1244,15 +1249,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+checksum = "cc709ca1da6f66143b8c9bec8e6260181869893714e9b5a490b169b0414144ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1261,15 +1266,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
 
 [[package]]
 name = "futures-lite"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db18c5f58083b54b0c416638ea73066722c2815c1e54dd8ba85ee3def593c3a"
+checksum = "7c48d23e382e1f50ad68d16cd23dd3c467f420d4933b629c3f183f33e9f560d8"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1282,9 +1287,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+checksum = "f57ed14da4603b2554682e9f2ff3c65d7567b53188db96cb71538217fc64581b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
@@ -1294,26 +1299,26 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+checksum = "0d8764258ed64ebc5d9ed185cf86a95db5cac810269c5d20ececb32e0088abbd"
 
 [[package]]
 name = "futures-task"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+checksum = "4dd26820a9f3637f1302da8bceba3ff33adbe53464b54ca24d4e2d4f1db30f94"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+checksum = "8a894a0acddba51a2d49a6f4263b1e64b8c579ece8af50fa86503d52cd1eea34"
 dependencies = [
- "futures 0.1.29",
+ "futures 0.1.30",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1419,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
@@ -1637,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "linked-hash-map"
@@ -1733,7 +1738,7 @@ dependencies = [
  "dotenv",
  "failure",
  "function_name",
- "futures 0.3.5",
+ "futures 0.3.6",
  "humantime-serde",
  "lazy_static",
  "medea-client-api-proto",
@@ -1818,7 +1823,7 @@ dependencies = [
  "bytes",
  "deadpool",
  "derive_more",
- "futures 0.3.5",
+ "futures 0.3.6",
  "once_cell",
  "regex",
  "tokio",
@@ -1834,7 +1839,7 @@ dependencies = [
  "derive_more",
  "downcast",
  "fragile",
- "futures 0.3.5",
+ "futures 0.3.6",
  "js-sys",
  "log",
  "medea-client-api-proto",
@@ -1870,7 +1875,7 @@ dependencies = [
 name = "medea-reactive"
 version = "0.1.0-dev"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.6",
  "tokio",
 ]
 
@@ -1903,9 +1908,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
+checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
  "autocfg",
@@ -1988,9 +1993,9 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "nb-connect"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701f47aeb98466d0a7fea67e2c2f667c33efa1f2e4fd7f76743aac1153196f72"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -2154,18 +2159,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b9e280448854bd91559252582173b3bd1f8e094a0e644791c0628ca9b1f144f"
+checksum = "13fbdfd6bdee3dc9be46452f86af4a4072975899cf8592466668620bebfbcc17"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8c8b352676bc6a4c3d71970560b913cea444a7a921cc2e2d920225e4b91edaa"
+checksum = "c82fb1329f632c3552cf352d14427d57a511b1cf41db93b3a7d77906a82dcc8e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2186,14 +2191,14 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "polling"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0720e0b9ea9d52451cf29d3413ba8a9303f8815d9d9653ef70e03ff73e65566"
+checksum = "7215a098a80ab8ebd6349db593dc5faf741781bad0c4b7c5701fea6af548d52c"
 dependencies = [
  "cfg-if",
  "libc",
  "log",
- "wepoll-sys-stjepang",
+ "wepoll-sys",
  "winapi 0.3.9",
 ]
 
@@ -2324,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.17.0"
+version = "2.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb14183cc7f213ee2410067e1ceeadba2a7478a59432ff0747a335202798b1e2"
+checksum = "6d147edb77bcccbfc81fabffdc7bd50c13e103b15ca1e27515fe40de69a5776b"
 
 [[package]]
 name = "quick-error"
@@ -2558,9 +2563,9 @@ checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
 
 [[package]]
 name = "rustc-serialize"
@@ -2683,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.4.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d3d595d64120bbbc70b7f6d5ae63298b62a3d9f373ec2f56acf5365ca8a444"
+checksum = "8bac272128fb3b1e98872dca27a05c18d8b78b9bd089d3edb7b5871501b50bce"
 dependencies = [
  "serde 1.0.116",
  "serde_with_macros",
@@ -2693,10 +2698,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "1.1.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4070d2c9b9d258465ad1d82aabb985b84cd9a3afa94da25ece5a9938ba5f1606"
+checksum = "3c747a9ab2e833b807f74f6b6141530655010bfa9c9c06d5508bce75c8f8072f"
 dependencies = [
+ "darling",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.42",
@@ -2883,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "standback"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a71ea1ea5f8747d1af1979bfb7e65c3a025a70609f04ceb78425bc5adad8e6"
+checksum = "f4e0831040d2cf2bdfd51b844be71885783d489898a192f254ae25d57cce725c"
 dependencies = [
  "version_check",
 ]
@@ -3032,18 +3038,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -3122,6 +3128,21 @@ name = "tinyvec"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+
+[[package]]
+name = "tinyvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -3468,7 +3489,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "enum-as-inner",
- "futures 0.3.5",
+ "futures 0.3.6",
  "idna",
  "lazy_static",
  "log",
@@ -3487,7 +3508,7 @@ checksum = "0f23cdfdc3d8300b3c50c9e84302d3bd6d860fb9529af84ace6cf9665f181b77"
 dependencies = [
  "backtrace",
  "cfg-if",
- "futures 0.3.5",
+ "futures 0.3.6",
  "ipconfig",
  "lazy_static",
  "log",
@@ -3526,7 +3547,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
 dependencies = [
- "tinyvec",
+ "tinyvec 0.3.4",
 ]
 
 [[package]]
@@ -3736,10 +3757,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-sys-stjepang"
-version = "1.0.8"
+name = "wepoll-sys"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdfbb03f290ca0b27922e8d48a0997b4ceea12df33269b9f75e713311eb178d"
+checksum = "142bc2cba3fe88be1a8fcb55c727fa4cd5b0cf2d7438722792e22f26f04bc1e0"
 dependencies = [
  "cc",
 ]
@@ -3755,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a763e303c0e0f23b0da40888724762e802a8ffefbc22de4127ef42493c2ea68c"
+checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"

--- a/jason/CHANGELOG.md
+++ b/jason/CHANGELOG.md
@@ -44,7 +44,7 @@ All user visible changes to this project will be documented in this file. This p
         - `MediaSourceKind` enum that provides `MediaTrack` media source kind (`Device` or `Display`) ([#146]);
         - Room initialization ([#46]):
             - `Jason.init_room()`;
-            - `Room.join()`;
+            - `Room.join()`.
         - Ability to configure local media stream used by `Room` via `Room.set_local_media_settings()` ([#54], [#97], [#145]);
         - `Room.on_failed_local_media` callback ([#54], [#143]);
         - `Room.on_close` callback for WebSocket close initiated by server ([#55]);
@@ -110,6 +110,7 @@ All user visible changes to this project will be documented in this file. This p
 [#143]: /../../pull/143
 [#145]: /../../pull/145
 [#146]: /../../pull/146
+
 
 
 

--- a/jason/CHANGELOG.md
+++ b/jason/CHANGELOG.md
@@ -40,6 +40,8 @@ All user visible changes to this project will be documented in this file. This p
             - `DeviceVideoTrackConstraints`, `DisplayVideoTrackConstraints` classes ([#78]);
             - `DeviceVideoTrackConstraints.ideal_facing_mode` and `DeviceVideoTrackConstraints.exact_facing_mode` functions ([#137]);
             - `FacingMode` enum ([#137]).
+        - `MediaKind` enum that provides `MediaTrack` and `InputDeviceInfo` kind ([#146]);
+        - `MediaSourceKind` enum that provides `MediaTrack` media source kind (`Device` or `Display`) ([#146]);
         - Room initialization ([#46]):
             - `Jason.init_room()`;
             - `Room.join()`;
@@ -53,7 +55,7 @@ All user visible changes to this project will be documented in this file. This p
             - `Room.unmute_remote_audio`;
             - `Room.mute_remote_video`;
             - `Room.unmute_remote_video`.
-        - `MediaTrack.media_source_kind` function ([#145]).
+        - `MediaTrack.media_source_kind` function ([#145], [#146]).
     - Optional tracks support ([#106]);
     - `RtcIceTransportPolicy` configuration ([#79]).
 - Room management:
@@ -107,7 +109,7 @@ All user visible changes to this project will be documented in this file. This p
 [#138]: /../../pull/138
 [#143]: /../../pull/143
 [#145]: /../../pull/145
-
+[#146]: /../../pull/146
 
 
 

--- a/jason/demo/index.html
+++ b/jason/demo/index.html
@@ -15,6 +15,7 @@
       DeviceVideoTrackConstraints,
       DisplayVideoTrackConstraints,
       FacingMode,
+      MediaKind,
     } from './js/medea_jason.js';
 
     const controlUrl = document.location.protocol + "//" +
@@ -197,7 +198,7 @@
       let currentAudio = 'disable';
       let currentVideo = 'disable';
       for (const track of localTracks) {
-        if (track.kind() === 'video') {
+        if (track.kind() === MediaKind.Video) {
           currentVideo = track.get_track().label || 'disable';
         } else {
           currentAudio = track.get_track().label || 'disable';
@@ -208,11 +209,11 @@
       for (const device_info of device_infos) {
         const option = document.createElement('option');
         option.value = device_info.device_id();
-        if (device_info.kind() === 'audio') {
+        if (device_info.kind() === MediaKind.Audio) {
           option.text = device_info.label() || `Microphone ${audio_select.length + 1}`;
           option.selected = option.text === currentAudio;
           audio_select.append(option);
-        } else if (device_info.kind() === 'video') {
+        } else if (device_info.kind() === MediaKind.Video) {
           option.text = device_info.label() || `Camera ${video_select.length + 1}`;
           option.selected = option.text === currentVideo;
           video_select.append(option);
@@ -309,7 +310,7 @@
 
     async function updateLocalVideo(stream) {
       for (const track of stream) {
-        if (track.kind() == 'audio') {
+        if (track.kind() === MediaKind.Audio) {
           continue;
         }
         let mediaStream = new MediaStream();
@@ -545,7 +546,7 @@
         });
 
         connection.on_remote_track_added((track) => {
-          if (track.kind() === 'video') {
+          if (track.kind() === MediaKind.Video) {
               let cameraVideoEl = memberVideoDiv.getElementsByClassName('camera-video')[0];
               if (cameraVideoEl === undefined) {
                 cameraVideoEl = document.createElement('video');
@@ -627,7 +628,7 @@
           await room.mute_audio();
           for (const track of localTracks) {
             if (track.ptr > 0) {
-              if (track.kind() === 'audio' && track.ptr > 0) {
+              if (track.kind() === MediaKind.Audio && track.ptr > 0) {
                 track.free();
               }
             }
@@ -648,7 +649,7 @@
           await room.mute_video();
           for (const track of localTracks) {
             if (track.ptr > 0) {
-              if (track.kind() === 'video' && track.ptr > 0) {
+              if (track.kind() === MediaKind.Video && track.ptr > 0) {
                 track.free();
               }
             }

--- a/jason/e2e-demo/js/index.js
+++ b/jason/e2e-demo/js/index.js
@@ -2,9 +2,10 @@ const controlDomain = 'http://127.0.0.1:8000';
 const controlUrl = controlDomain + '/control-api/';
 const baseUrl = 'ws://127.0.0.1:8080/ws/';
 
+let rust;
 let roomId = window.location.hash.replace("#", "");
-let remote_videos = {};
 
+let remote_videos = {};
 let joinCallerButton = document.getElementById('connection-settings__connect');
 let usernameInput = document.getElementById('connection-settings__username');
 let usernameMenuButton = document.getElementById('username-menu-button');
@@ -389,7 +390,7 @@ async function startPublishing() {
 
 async function updateLocalVideo(stream) {
   for (const track of stream) {
-    if (track.kind() == 'audio') {
+    if (track.kind() === rust.MediaKind.Audio) {
       continue;
     }
     let mediaStream = new MediaStream();
@@ -407,7 +408,7 @@ async function updateLocalVideo(stream) {
 }
 
 window.onload = async function() {
-  let rust = await import("../../pkg");
+  rust = await import("../../pkg");
   let jason = new rust.Jason();
   console.log(baseUrl);
   usernameInput.addEventListener('change', (e) => {
@@ -475,7 +476,7 @@ window.onload = async function() {
     let currentAudio = 'disable';
     let currentVideo = 'disable';
     for (const track of localTracks) {
-      if (track.kind() === 'video') {
+      if (track.kind() === rust.MediaKind.Video) {
         currentVideo = track.get_track().label || 'disable';
       } else {
         currentAudio = track.get_track().label || 'disable';
@@ -486,11 +487,11 @@ window.onload = async function() {
     for (const device_info of device_infos) {
       const option = document.createElement('option');
       option.value = device_info.device_id();
-      if (device_info.kind() === 'audio') {
+      if (device_info.kind() === rust.MediaKind.Audio) {
         option.text = device_info.label() || `Microphone ${audio_select.length + 1}`;
         option.selected = option.text === currentAudio;
         audio_select.append(option);
-      } else if (device_info.kind() === 'video') {
+      } else if (device_info.kind() === rust.MediaKind.Video) {
         option.text = device_info.label() || `Camera ${video_select.length + 1}`;
         option.selected = option.text === currentVideo;
         video_select.append(option);
@@ -595,7 +596,7 @@ window.onload = async function() {
       });
 
       connection.on_remote_track_added((track) => {
-        if (track.kind() === 'video') {
+        if (track.kind() === rust.MediaKind.Video) {
             let cameraVideoEl = memberVideoDiv.getElementsByClassName('camera-video')[0];
             if (cameraVideoEl === undefined) {
               cameraVideoEl = document.createElement('video');
@@ -621,8 +622,8 @@ window.onload = async function() {
             audioEl.autoplay = "true";
             memberVideoDiv.appendChild(audioEl);
           }
-            let mediaStream = new MediaStream();
-            mediaStream.addTrack(track.get_track());
+          let mediaStream = new MediaStream();
+          mediaStream.addTrack(track.get_track());
           audioEl.srcObject = mediaStream;
         }
 
@@ -746,7 +747,7 @@ window.onload = async function() {
           await room.mute_audio();
           for (const track of localTracks) {
             if (track.ptr > 0) {
-              if (track.kind() === 'audio' && track.ptr > 0) {
+              if (track.kind() === rust.MediaKind.Audio && track.ptr > 0) {
                 track.free();
               }
             }
@@ -771,7 +772,7 @@ window.onload = async function() {
           await room.mute_video();
           for (const track of localTracks) {
             if (track.ptr > 0) {
-              if (track.kind() === 'video' && track.ptr > 0) {
+              if (track.kind() === rust.MediaKind.Video && track.ptr > 0) {
                 track.free();
               }
             }

--- a/jason/src/api/room.rs
+++ b/jason/src/api/room.rs
@@ -23,13 +23,13 @@ use wasm_bindgen_futures::{future_to_promise, spawn_local};
 use crate::{
     api::connection::Connections,
     media::{
-        LocalTracksConstraints, MediaStreamSettings, MediaStreamTrack,
-        RecvConstraints,
+        LocalTracksConstraints, MediaKind, MediaStreamSettings,
+        MediaStreamTrack, RecvConstraints,
     },
     peer::{
         MediaConnectionsError, MuteState, PeerConnection, PeerError, PeerEvent,
         PeerEventHandler, PeerRepository, RtcStats, StableMuteState,
-        TrackDirection, TransceiverKind, TransceiverSide,
+        TrackDirection, TransceiverSide,
     },
     rpc::{
         ClientDisconnect, CloseReason, ReconnectHandle, RpcClient,
@@ -248,7 +248,7 @@ impl RoomHandle {
     async fn set_track_enabled(
         &self,
         enabled: bool,
-        kind: TransceiverKind,
+        kind: MediaKind,
         direction: TrackDirection,
     ) -> Result<(), JasonError> {
         let inner = upgrade_or_detached!(self.0, JasonError)?;
@@ -367,7 +367,7 @@ impl RoomHandle {
         future_to_promise(async move {
             this.set_track_enabled(
                 false,
-                TransceiverKind::Audio,
+                MediaKind::Audio,
                 TrackDirection::Send,
             )
             .await?;
@@ -381,7 +381,7 @@ impl RoomHandle {
         future_to_promise(async move {
             this.set_track_enabled(
                 true,
-                TransceiverKind::Audio,
+                MediaKind::Audio,
                 TrackDirection::Send,
             )
             .await?;
@@ -395,7 +395,7 @@ impl RoomHandle {
         future_to_promise(async move {
             this.set_track_enabled(
                 false,
-                TransceiverKind::Video,
+                MediaKind::Video,
                 TrackDirection::Send,
             )
             .await?;
@@ -409,7 +409,7 @@ impl RoomHandle {
         future_to_promise(async move {
             this.set_track_enabled(
                 true,
-                TransceiverKind::Video,
+                MediaKind::Video,
                 TrackDirection::Send,
             )
             .await?;
@@ -423,7 +423,7 @@ impl RoomHandle {
         future_to_promise(async move {
             this.set_track_enabled(
                 false,
-                TransceiverKind::Audio,
+                MediaKind::Audio,
                 TrackDirection::Recv,
             )
             .await?;
@@ -437,7 +437,7 @@ impl RoomHandle {
         future_to_promise(async move {
             this.set_track_enabled(
                 false,
-                TransceiverKind::Video,
+                MediaKind::Video,
                 TrackDirection::Recv,
             )
             .await?;
@@ -451,7 +451,7 @@ impl RoomHandle {
         future_to_promise(async move {
             this.set_track_enabled(
                 true,
-                TransceiverKind::Audio,
+                MediaKind::Audio,
                 TrackDirection::Recv,
             )
             .await?;
@@ -465,7 +465,7 @@ impl RoomHandle {
         future_to_promise(async move {
             this.set_track_enabled(
                 true,
-                TransceiverKind::Video,
+                MediaKind::Video,
                 TrackDirection::Recv,
             )
             .await?;
@@ -680,11 +680,11 @@ impl InnerRoom {
 
     /// Toggles [`InnerRoom::recv_constraints`] or
     /// [`InnerRoom::send_constraints`] mute status based on the provided
-    /// [`TrackDirection`] and [`TransceiverKind`].
+    /// [`TrackDirection`] and [`MediaKind`].
     fn toggle_enable_constraints(
         &self,
         enabled: bool,
-        kind: TransceiverKind,
+        kind: MediaKind,
         direction: TrackDirection,
     ) {
         if let TrackDirection::Recv = direction {
@@ -703,14 +703,14 @@ impl InnerRoom {
     }
 
     /// Toggles [`TransceiverSide`]s [`MuteState`] by provided
-    /// [`TransceiverKind`] in all [`PeerConnection`]s in this [`Room`].
+    /// [`MediaKind`] in all [`PeerConnection`]s in this [`Room`].
     ///
     /// [`PeerConnection`]: crate::peer::PeerConnection
     #[allow(clippy::filter_map)]
     async fn toggle_mute(
         &self,
         is_muted: bool,
-        kind: TransceiverKind,
+        kind: MediaKind,
         direction: TrackDirection,
     ) -> Result<(), Traced<RoomError>> {
         let peer_mute_state_changed: Vec<_> = self
@@ -772,10 +772,10 @@ impl InnerRoom {
     }
 
     /// Returns `true` if all [`Sender`]s or [`Receiver`]s with a provided
-    /// [`TransceiverKind`] of this [`Room`] are in the provided `mute_state`.
+    /// [`MediaKind`] of this [`Room`] are in the provided `mute_state`.
     pub fn is_all_peers_in_mute_state(
         &self,
-        kind: TransceiverKind,
+        kind: MediaKind,
         direction: TrackDirection,
         mute_state: StableMuteState,
     ) -> bool {

--- a/jason/src/media/constraints.rs
+++ b/jason/src/media/constraints.rs
@@ -18,7 +18,7 @@ use web_sys::{
     MediaTrackConstraints as SysMediaTrackConstraints,
 };
 
-use crate::{peer::TransceiverKind, utils::get_property_by_name};
+use crate::{media::MediaKind, utils::get_property_by_name};
 
 /// Local media stream for injecting into new created [`PeerConnection`]s.
 #[derive(Clone, Debug, Default)]
@@ -45,12 +45,12 @@ impl Default for RecvConstraints {
 
 impl RecvConstraints {
     /// Enables or disables audio or video receiving.
-    pub fn set_enabled(&self, enabled: bool, kind: TransceiverKind) {
+    pub fn set_enabled(&self, enabled: bool, kind: MediaKind) {
         match kind {
-            TransceiverKind::Audio => {
+            MediaKind::Audio => {
                 self.is_audio_enabled.set(enabled);
             }
-            TransceiverKind::Video => {
+            MediaKind::Video => {
                 self.is_video_enabled.set(enabled);
             }
         }
@@ -105,7 +105,7 @@ impl LocalTracksConstraints {
     /// If some type of the [`MediaStreamSettings`] is disabled, then this kind
     /// of media won't be published.
     #[inline]
-    pub fn set_enabled(&self, enabled: bool, kind: TransceiverKind) {
+    pub fn set_enabled(&self, enabled: bool, kind: MediaKind) {
         self.0.borrow_mut().set_track_enabled(enabled, kind);
     }
 
@@ -141,9 +141,9 @@ impl Default for AudioMediaTracksSettings {
 }
 
 /// Returns `true` if provided [`SysMediaStreamTrack`] basically satisfies any
-/// constraints with a provided [`TransceiverKind`].
+/// constraints with a provided [`MediaKind`].
 #[inline]
-fn satisfies_track(track: &SysMediaStreamTrack, kind: TransceiverKind) -> bool {
+fn satisfies_track(track: &SysMediaStreamTrack, kind: MediaKind) -> bool {
     track.kind() == kind.as_str()
         && track.ready_state() == MediaStreamTrackState::Live
 }
@@ -355,12 +355,12 @@ impl MediaStreamSettings {
     /// If some type of the [`MediaStreamSettings`] is disabled, then this kind
     /// of media won't be published.
     #[inline]
-    pub fn set_track_enabled(&mut self, enabled: bool, kind: TransceiverKind) {
+    pub fn set_track_enabled(&mut self, enabled: bool, kind: MediaKind) {
         match kind {
-            TransceiverKind::Audio => {
+            MediaKind::Audio => {
                 self.toggle_publish_audio(enabled);
             }
-            TransceiverKind::Video => {
+            MediaKind::Video => {
                 self.toggle_publish_video(enabled);
             }
         }
@@ -516,7 +516,7 @@ impl From<MediaStreamSettings> for Option<MultiSourceTracksConstraints> {
     }
 }
 
-/// Constraints for the [`TransceiverKind::Video`] [`MediaStreamTrack`].
+/// Constraints for the [`MediaKind::Video`] [`MediaStreamTrack`].
 #[derive(Clone, Debug)]
 pub enum VideoSource {
     /// [`MediaStreamTrack`] should be received from the `getUserMedia`
@@ -675,7 +675,7 @@ impl AudioTrackConstraints {
     /// [1]: https://w3.org/TR/mediacapture-streams/#mediastreamtrack
     pub fn satisfies<T: AsRef<SysMediaStreamTrack>>(&self, track: T) -> bool {
         let track = track.as_ref();
-        satisfies_track(track, TransceiverKind::Audio)
+        satisfies_track(track, MediaKind::Audio)
             && ConstrainString::satisfies(&self.device_id, track)
         // TODO returns Result<bool, Error>
     }
@@ -855,7 +855,7 @@ impl DeviceVideoTrackConstraints {
     ///
     /// [1]: https://w3.org/TR/mediacapture-streams/#mediastreamtrack
     pub fn satisfies(&self, track: &SysMediaStreamTrack) -> bool {
-        satisfies_track(track, TransceiverKind::Video)
+        satisfies_track(track, MediaKind::Video)
             && ConstrainString::satisfies(&self.device_id, track)
             && ConstrainString::satisfies(&self.facing_mode, track)
             && !guess_is_from_display(&track)
@@ -936,7 +936,7 @@ impl DisplayVideoTrackConstraints {
     #[allow(clippy::unused_self)]
     #[inline]
     pub fn satisfies(&self, track: &SysMediaStreamTrack) -> bool {
-        satisfies_track(track, TransceiverKind::Video)
+        satisfies_track(track, MediaKind::Video)
             && guess_is_from_display(&track)
     }
 

--- a/jason/src/media/device_info.rs
+++ b/jason/src/media/device_info.rs
@@ -8,6 +8,8 @@ use derive_more::Display;
 use wasm_bindgen::prelude::*;
 use web_sys::{MediaDeviceInfo, MediaDeviceKind};
 
+use crate::media::MediaKind;
+
 /// Errors that may occur when parsing [MediaDeviceInfo][1].
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams/#device-info
@@ -23,7 +25,7 @@ pub enum Error {
 /// [1]: https://w3.org/TR/mediacapture-streams/#device-info
 #[wasm_bindgen]
 pub struct InputDeviceInfo {
-    device_type: InputDeviceKind,
+    media_kind: MediaKind,
 
     /// Actual underlying [MediaDeviceInfo][1] object.
     ///
@@ -31,29 +33,7 @@ pub struct InputDeviceInfo {
     info: MediaDeviceInfo,
 }
 
-/// [MediaDeviceKind][1] wrapper, excluding `audiooutput`.
-///
-/// [1]: https://w3.org/TR/mediacapture-streams/#dom-mediadevicekind
-#[derive(Clone, Copy, Eq, PartialEq)]
-enum InputDeviceKind {
-    /// `audioinput` device (for example a microphone).
-    Audio,
-
-    /// `videoinput` device ( for example a webcam).
-    Video,
-}
-
-impl InputDeviceKind {
-    #[inline]
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Audio => "audio",
-            Self::Video => "video",
-        }
-    }
-}
-
-impl TryFrom<MediaDeviceKind> for InputDeviceKind {
+impl TryFrom<MediaDeviceKind> for MediaKind {
     type Error = Error;
 
     fn try_from(value: MediaDeviceKind) -> Result<Self, Self::Error> {
@@ -77,8 +57,8 @@ impl InputDeviceInfo {
     /// This representation of [MediaDeviceInfo][1] ONLY for input device.
     ///
     /// [1]: https://w3.org/TR/mediacapture-streams/#device-info
-    pub fn kind(&self) -> String {
-        self.device_type.as_str().to_owned()
+    pub fn kind(&self) -> MediaKind {
+        self.media_kind
     }
 
     /// Returns label describing the represented device (for example
@@ -106,7 +86,7 @@ impl TryFrom<MediaDeviceInfo> for InputDeviceInfo {
 
     fn try_from(info: MediaDeviceInfo) -> Result<Self, Self::Error> {
         Ok(Self {
-            device_type: InputDeviceKind::try_from(info.kind())?,
+            media_kind: MediaKind::try_from(info.kind())?,
             info,
         })
     }

--- a/jason/src/media/mod.rs
+++ b/jason/src/media/mod.rs
@@ -7,6 +7,8 @@ mod device_info;
 mod manager;
 mod track;
 
+use wasm_bindgen::prelude::*;
+
 #[doc(inline)]
 pub use self::{
     constraints::{
@@ -17,5 +19,28 @@ pub use self::{
     },
     device_info::InputDeviceInfo,
     manager::{MediaManager, MediaManagerError, MediaManagerHandle},
-    track::{MediaStreamTrack, TrackKind},
+    track::{JsMediaSourceKind, MediaStreamTrack},
 };
+
+/// [MediaStreamTrack.kind][1] representation.
+///
+/// [1]: https://w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-kind
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MediaKind {
+    /// Audio track.
+    Audio,
+
+    /// Video track.
+    Video,
+}
+
+impl MediaKind {
+    /// Returns string representation of a [`MediaKind`].
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Audio => "audio",
+            Self::Video => "video",
+        }
+    }
+}

--- a/jason/src/peer/conn.rs
+++ b/jason/src/peer/conn.rs
@@ -20,7 +20,7 @@ use web_sys::{
 };
 
 use crate::{
-    media::TrackConstraints,
+    media::{MediaKind, TrackConstraints},
     peer::stats::{RtcStats, RtcStatsError},
     utils::{
         get_property_by_name, EventListener, EventListenerBindError, JsCaused,
@@ -53,34 +53,11 @@ pub struct IceCandidate {
     pub sdp_mid: Option<String>,
 }
 
-/// Representation of [RTCRtpTransceiver][1]'s [kind][2].
-///
-/// [1]: https://w3.org/TR/webrtc/#dom-rtcrtptransceiver
-/// [2]: https://w3.org/TR/webrtc/#dfn-transceiver-kind
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum TransceiverKind {
-    /// Audio transceiver.
-    Audio,
-
-    /// Video transceiver.
-    Video,
-}
-
-impl From<&TrackConstraints> for TransceiverKind {
+impl From<&TrackConstraints> for MediaKind {
     fn from(media_type: &TrackConstraints) -> Self {
         match media_type {
             TrackConstraints::Audio(_) => Self::Audio,
             TrackConstraints::Video(_) => Self::Video,
-        }
-    }
-}
-
-impl TransceiverKind {
-    /// Returns string representation of a [`TransceiverKind`].
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Audio => "audio",
-            Self::Video => "video",
         }
     }
 }
@@ -680,7 +657,7 @@ impl RtcPeerConnection {
     /// [2]: https://w3.org/TR/webrtc/#transceivers-set
     pub fn add_transceiver(
         &self,
-        kind: TransceiverKind,
+        kind: MediaKind,
         direction: TransceiverDirection,
     ) -> RtcRtpTransceiver {
         let mut init = RtcRtpTransceiverInit::new();

--- a/jason/src/peer/media/mod.rs
+++ b/jason/src/peer/media/mod.rs
@@ -15,15 +15,14 @@ use tracerr::Traced;
 use web_sys::{MediaStreamTrack as SysMediaStreamTrack, RtcRtpTransceiver};
 
 use crate::{
-    media::{LocalTracksConstraints, MediaStreamTrack, RecvConstraints},
+    media::{
+        LocalTracksConstraints, MediaKind, MediaStreamTrack, RecvConstraints,
+    },
     peer::PeerEvent,
     utils::{JsCaused, JsError},
 };
 
-use super::{
-    conn::{RtcPeerConnection, TransceiverKind},
-    tracks_request::TracksRequest,
-};
+use super::{conn::RtcPeerConnection, tracks_request::TracksRequest};
 
 use self::{mute_state::MuteStateController, sender::SenderBuilder};
 
@@ -38,10 +37,10 @@ pub trait TransceiverSide: Muteable {
     /// Returns [`TrackId`] of this [`TransceiverSide`].
     fn track_id(&self) -> TrackId;
 
-    /// Returns [`TransceiverKind`] of this [`TransceiverSide`].
-    fn kind(&self) -> TransceiverKind;
+    /// Returns [`MediaKind`] of this [`TransceiverSide`].
+    fn kind(&self) -> MediaKind;
 
-    /// Returns [`TransceiverKind`] of this [`TransceiverSide`].
+    /// Returns [`MediaKind`] of this [`TransceiverSide`].
     fn mid(&self) -> Option<String>;
 }
 
@@ -222,29 +221,29 @@ struct InnerMediaConnections {
 }
 
 impl InnerMediaConnections {
-    /// Returns [`Iterator`] over [`Sender`]s with provided [`TransceiverKind`].
+    /// Returns [`Iterator`] over [`Sender`]s with provided [`MediaKind`].
     fn iter_senders_with_kind(
         &self,
-        kind: TransceiverKind,
+        kind: MediaKind,
     ) -> impl Iterator<Item = &Rc<Sender>> {
         self.senders.values().filter(move |s| s.kind() == kind)
     }
 
     /// Returns [`Iterator`] over [`Receiver`]s with provided
-    /// [`TransceiverKind`].
+    /// [`MediaKind`].
     fn iter_receivers_with_kind(
         &self,
-        kind: TransceiverKind,
+        kind: MediaKind,
     ) -> impl Iterator<Item = &Rc<Receiver>> {
         self.receivers.values().filter(move |s| s.kind() == kind)
     }
 
     /// Returns all [`TransceiverSide`]s by provided [`TrackDirection`] and
-    /// [`TransceiverKind`].
+    /// [`MediaKind`].
     fn get_transceivers_by_direction_and_kind(
         &self,
         direction: TrackDirection,
-        kind: TransceiverKind,
+        kind: MediaKind,
     ) -> Vec<Rc<dyn TransceiverSide>> {
         match direction {
             TrackDirection::Send => self
@@ -281,10 +280,10 @@ impl MediaConnections {
     }
 
     /// Returns all [`Sender`]s and [`Receiver`]s from this [`MediaConnections`]
-    /// with provided [`TransceiverKind`] and [`TrackDirection`].
+    /// with provided [`MediaKind`] and [`TrackDirection`].
     pub fn get_transceivers_sides(
         &self,
-        kind: TransceiverKind,
+        kind: MediaKind,
         direction: TrackDirection,
     ) -> Vec<Rc<dyn TransceiverSide>> {
         self.0
@@ -293,10 +292,10 @@ impl MediaConnections {
     }
 
     /// Returns `true` if all [`TransceiverSide`]s with provided
-    /// [`TransceiverKind`] and [`TrackDirection`] is in provided [`MuteState`].
+    /// [`MediaKind`] and [`TrackDirection`] is in provided [`MuteState`].
     pub fn is_all_tracks_in_mute_state(
         &self,
-        kind: TransceiverKind,
+        kind: MediaKind,
         direction: TrackDirection,
         mute_state: StableMuteState,
     ) -> bool {
@@ -314,41 +313,41 @@ impl MediaConnections {
     }
 
     /// Returns `true` if all [`Sender`]s with
-    /// [`TransceiverKind::Audio`] are enabled or `false` otherwise.
+    /// [`MediaKind::Audio`] are enabled or `false` otherwise.
     pub fn is_send_audio_enabled(&self) -> bool {
         self.0
             .borrow()
-            .iter_senders_with_kind(TransceiverKind::Audio)
+            .iter_senders_with_kind(MediaKind::Audio)
             .find(|s| s.is_muted())
             .is_none()
     }
 
     /// Returns `true` if all [`Sender`]s with
-    /// [`TransceiverKind::Video`] are enabled or `false` otherwise.
+    /// [`MediaKind::Video`] are enabled or `false` otherwise.
     pub fn is_send_video_enabled(&self) -> bool {
         self.0
             .borrow()
-            .iter_senders_with_kind(TransceiverKind::Video)
+            .iter_senders_with_kind(MediaKind::Video)
             .find(|s| s.is_muted())
             .is_none()
     }
 
-    /// Returns `true` if all [`Receiver`]s with [`TransceiverKind::Video`] are
+    /// Returns `true` if all [`Receiver`]s with [`MediaKind::Video`] are
     /// enabled or `false` otherwise.
     pub fn is_recv_video_enabled(&self) -> bool {
         self.0
             .borrow()
-            .iter_receivers_with_kind(TransceiverKind::Video)
+            .iter_receivers_with_kind(MediaKind::Video)
             .find(|s| s.is_muted())
             .is_none()
     }
 
-    /// Returns `true` if all [`Receiver`]s with [`TransceiverKind::Audio`] are
+    /// Returns `true` if all [`Receiver`]s with [`MediaKind::Audio`] are
     /// enabled or `false` otherwise.
     pub fn is_recv_audio_enabled(&self) -> bool {
         self.0
             .borrow()
-            .iter_receivers_with_kind(TransceiverKind::Audio)
+            .iter_receivers_with_kind(MediaKind::Audio)
             .find(|s| s.is_muted())
             .is_none()
     }

--- a/jason/src/peer/media/receiver.rs
+++ b/jason/src/peer/media/receiver.rs
@@ -12,9 +12,9 @@ use proto::TrackId;
 use web_sys::{MediaStreamTrack as SysMediaStreamTrack, RtcRtpTransceiver};
 
 use crate::{
-    media::{MediaStreamTrack, RecvConstraints, TrackConstraints},
+    media::{MediaKind, MediaStreamTrack, RecvConstraints, TrackConstraints},
     peer::{
-        conn::{RtcPeerConnection, TransceiverDirection, TransceiverKind},
+        conn::{RtcPeerConnection, TransceiverDirection},
         media::{mute_state::MuteStateController, TransceiverSide},
         Muteable, PeerEvent,
     },
@@ -62,10 +62,10 @@ impl Receiver {
         peer_events_sender: mpsc::UnboundedSender<PeerEvent>,
         recv_constraints: &RecvConstraints,
     ) -> Self {
-        let kind = TransceiverKind::from(&caps);
+        let kind = MediaKind::from(&caps);
         let enabled = match kind {
-            TransceiverKind::Audio => recv_constraints.is_audio_enabled(),
-            TransceiverKind::Video => recv_constraints.is_video_enabled(),
+            MediaKind::Audio => recv_constraints.is_audio_enabled(),
+            MediaKind::Video => recv_constraints.is_video_enabled(),
         };
         let transceiver_direction = if enabled {
             TransceiverDirection::Recvonly
@@ -235,8 +235,8 @@ impl TransceiverSide for Receiver {
         self.track_id
     }
 
-    fn kind(&self) -> TransceiverKind {
-        TransceiverKind::from(&self.caps)
+    fn kind(&self) -> MediaKind {
+        MediaKind::from(&self.caps)
     }
 
     fn mid(&self) -> Option<String> {

--- a/jason/src/peer/media/sender.rs
+++ b/jason/src/peer/media/sender.rs
@@ -11,9 +11,9 @@ use wasm_bindgen_futures::{spawn_local, JsFuture};
 use web_sys::RtcRtpTransceiver;
 
 use crate::{
-    media::{MediaStreamTrack, TrackConstraints},
+    media::{MediaKind, MediaStreamTrack, TrackConstraints},
     peer::{
-        conn::{RtcPeerConnection, TransceiverDirection, TransceiverKind},
+        conn::{RtcPeerConnection, TransceiverDirection},
         media::TransceiverSide,
         PeerEvent,
     },
@@ -42,7 +42,7 @@ impl<'a> SenderBuilder<'a> {
     /// provided [`RtcPeerConnection`]. Errors if [`RtcRtpTransceiver`] lookup
     /// fails.
     pub fn build(self) -> Result<Rc<Sender>> {
-        let kind = TransceiverKind::from(&self.caps);
+        let kind = MediaKind::from(&self.caps);
         let transceiver = match self.mid {
             None => self
                 .peer
@@ -254,8 +254,8 @@ impl TransceiverSide for Sender {
         self.track_id
     }
 
-    fn kind(&self) -> TransceiverKind {
-        TransceiverKind::from(&self.caps)
+    fn kind(&self) -> MediaKind {
+        MediaKind::from(&self.caps)
     }
 
     fn mid(&self) -> Option<String> {

--- a/jason/src/peer/mod.rs
+++ b/jason/src/peer/mod.rs
@@ -29,7 +29,7 @@ use web_sys::{RtcIceConnectionState, RtcTrackEvent};
 
 use crate::{
     media::{
-        LocalTracksConstraints, MediaManager, MediaManagerError,
+        LocalTracksConstraints, MediaKind, MediaManager, MediaManagerError,
         MediaStreamTrack, RecvConstraints,
     },
     utils::{JasonError, JsCaused, JsError},
@@ -43,7 +43,7 @@ pub use self::repo::MockPeerRepository;
 pub use self::{
     conn::{
         IceCandidate, RTCPeerConnectionError, RtcPeerConnection, SdpType,
-        TransceiverDirection, TransceiverKind,
+        TransceiverDirection,
     },
     media::{
         MediaConnections, MediaConnectionsError, MuteState,
@@ -402,12 +402,12 @@ impl PeerConnection {
     }
 
     /// Returns `true` if all [`TransceiverSide`]s with a provided
-    /// [`TransceiverKind`] and [`TrackDirection`] is in the provided
+    /// [`MediaKind`] and [`TrackDirection`] is in the provided
     /// [`StableMuteState`].
     #[inline]
     pub fn is_all_transceiver_sides_in_mute_state(
         &self,
-        kind: TransceiverKind,
+        kind: MediaKind,
         direction: TrackDirection,
         mute_state: StableMuteState,
     ) -> bool {
@@ -535,11 +535,11 @@ impl PeerConnection {
     }
 
     /// Returns all [`TransceiverSide`]s from this [`PeerConnection`] with
-    /// provided [`TransceiverKind`] and [`TrackDirection`].
+    /// provided [`MediaKind`] and [`TrackDirection`].
     #[inline]
     pub fn get_transceivers_sides(
         &self,
-        kind: TransceiverKind,
+        kind: MediaKind,
         direction: TrackDirection,
     ) -> Vec<Rc<dyn TransceiverSide>> {
         self.media_connections

--- a/jason/src/peer/tracks_request.rs
+++ b/jason/src/peer/tracks_request.rs
@@ -10,8 +10,8 @@ use tracerr::Traced;
 
 use crate::{
     media::{
-        AudioTrackConstraints, MediaStreamSettings, MediaStreamTrack,
-        TrackConstraints, TrackKind, VideoSource,
+        AudioTrackConstraints, MediaKind, MediaStreamSettings,
+        MediaStreamTrack, TrackConstraints, VideoSource,
     },
     utils::{JsCaused, JsError},
     DeviceVideoTrackConstraints, DisplayVideoTrackConstraints,
@@ -148,10 +148,10 @@ impl SimpleTracksRequest {
         let mut audio_tracks = Vec::new();
         for track in tracks {
             match track.kind() {
-                TrackKind::Audio => {
+                MediaKind::Audio => {
                     audio_tracks.push(track);
                 }
-                TrackKind::Video => match track.media_source_kind() {
+                MediaKind::Video => match track.media_source_kind() {
                     MediaSourceKind::Device => {
                         device_video_tracks.push(track);
                     }

--- a/jason/tests/api/connection.rs
+++ b/jason/tests/api/connection.rs
@@ -7,7 +7,7 @@ use futures::{
 use medea_client_api_proto::PeerId;
 use medea_jason::{
     api::{ConnectionHandle, Connections},
-    media::{MediaStreamTrack, TrackKind},
+    media::{MediaKind, MediaStreamTrack},
 };
 use wasm_bindgen::{closure::Closure, JsValue};
 use wasm_bindgen_test::*;
@@ -45,7 +45,7 @@ async fn on_remote_track_added_fires() {
     let con_handle = con.new_handle();
 
     let (cb, test_result) = js_callback!(|track: MediaStreamTrack| {
-        cb_assert_eq!(track.kind(), TrackKind::Video);
+        cb_assert_eq!(track.kind(), MediaKind::Video);
     });
     con_handle.on_remote_track_added(cb.into()).unwrap();
 
@@ -71,7 +71,7 @@ async fn tracks_are_added_to_connection() {
 
     con.add_remote_track(get_video_track().await);
     let video_track = timeout(100, rx).await.unwrap().unwrap();
-    assert_eq!(video_track.kind(), TrackKind::Video);
+    assert_eq!(video_track.kind(), MediaKind::Video);
 
     let (tx, rx) = oneshot::channel();
     let closure = Closure::once_into_js(move |track: MediaStreamTrack| {
@@ -80,7 +80,7 @@ async fn tracks_are_added_to_connection() {
     con_handle.on_remote_track_added(closure.into()).unwrap();
     con.add_remote_track(get_audio_track().await);
     let audio_track = timeout(200, rx).await.unwrap().unwrap();
-    assert_eq!(audio_track.kind(), TrackKind::Audio);
+    assert_eq!(audio_track.kind(), MediaKind::Audio);
 }
 
 #[wasm_bindgen_test]

--- a/jason/tests/api/room.rs
+++ b/jason/tests/api/room.rs
@@ -14,8 +14,10 @@ use medea_client_api_proto::{
 };
 use medea_jason::{
     api::Room,
-    media::{AudioTrackConstraints, MediaManager, MediaStreamSettings},
-    peer::{MockPeerRepository, PeerConnection, Repository, TransceiverKind},
+    media::{
+        AudioTrackConstraints, MediaKind, MediaManager, MediaStreamSettings,
+    },
+    peer::{MockPeerRepository, PeerConnection, Repository},
     rpc::MockRpcClient,
     utils::JasonError,
     DeviceVideoTrackConstraints,
@@ -434,7 +436,10 @@ mod disable_recv_tracks {
 
 /// Tests disabling tracks publishing.
 mod disable_send_tracks {
-    use medea_jason::peer::{StableMuteState, TrackDirection, TransceiverKind};
+    use medea_jason::{
+        media::MediaKind,
+        peer::{StableMuteState, TrackDirection},
+    };
 
     use super::*;
 
@@ -481,7 +486,7 @@ mod disable_send_tracks {
     ///
     /// 2. Call [`RoomHandle::mute_audio`] simultaneous twice.
     ///
-    /// 3. Check that [`PeerConnection`] with [`TransceiverKind::Audio`] of
+    /// 3. Check that [`PeerConnection`] with [`MediaKind::Audio`] of
     /// [`Room`] is in [`MuteState::Muted`].
     #[wasm_bindgen_test]
     async fn join_two_audio_mutes() {
@@ -503,7 +508,7 @@ mod disable_send_tracks {
         second.unwrap();
 
         assert!(peer.is_all_transceiver_sides_in_mute_state(
-            TransceiverKind::Audio,
+            MediaKind::Audio,
             TrackDirection::Send,
             StableMuteState::Muted
         ));
@@ -518,7 +523,7 @@ mod disable_send_tracks {
     ///
     /// 2. Call [`RoomHandle::mute_video`] simultaneous twice.
     ///
-    /// 3. Check that [`PeerConnection`] with [`TransceiverKind::Video`] of
+    /// 3. Check that [`PeerConnection`] with [`MediaKind::Video`] of
     /// [`Room`] is in [`MuteState::Muted`].
     #[wasm_bindgen_test]
     async fn join_two_video_mutes() {
@@ -540,7 +545,7 @@ mod disable_send_tracks {
         second.unwrap();
 
         assert!(peer.is_all_transceiver_sides_in_mute_state(
-            TransceiverKind::Video,
+            MediaKind::Video,
             TrackDirection::Send,
             StableMuteState::Muted
         ));
@@ -557,7 +562,7 @@ mod disable_send_tracks {
     /// 2. Call [`RoomHandle::mute_audio`] and [`RoomHandle::unmute_audio`]
     ///    simultaneous.
     ///
-    /// 3. Check that [`PeerConnection`] with [`TransceiverKind::Audio`] of
+    /// 3. Check that [`PeerConnection`] with [`MediaKind::Audio`] of
     /// [`Room`] is stayed in [`MuteState::Unmuted`].
     #[wasm_bindgen_test]
     async fn join_mute_and_unmute_audio() {
@@ -570,7 +575,7 @@ mod disable_send_tracks {
         .await;
 
         assert!(peer.is_all_transceiver_sides_in_mute_state(
-            TransceiverKind::Audio,
+            MediaKind::Audio,
             TrackDirection::Send,
             StableMuteState::Unmuted
         ));
@@ -585,7 +590,7 @@ mod disable_send_tracks {
         unmute_audio_result.unwrap();
 
         assert!(peer.is_all_transceiver_sides_in_mute_state(
-            TransceiverKind::Audio,
+            MediaKind::Audio,
             TrackDirection::Send,
             StableMuteState::Unmuted
         ));
@@ -602,7 +607,7 @@ mod disable_send_tracks {
     /// 2. Call [`RoomHandle::mute_video`] and [`RoomHandle::unmute_video`]
     ///    simultaneous.
     ///
-    /// 3. Check that [`PeerConnection`] with [`TransceiverKind::Video`] of
+    /// 3. Check that [`PeerConnection`] with [`MediaKind::Video`] of
     /// [`Room`] is stayed in [`MuteState::Unmuted`].
     #[wasm_bindgen_test]
     async fn join_mute_and_unmute_video() {
@@ -615,7 +620,7 @@ mod disable_send_tracks {
         .await;
 
         assert!(peer.is_all_transceiver_sides_in_mute_state(
-            TransceiverKind::Video,
+            MediaKind::Video,
             TrackDirection::Send,
             StableMuteState::Unmuted
         ));
@@ -630,7 +635,7 @@ mod disable_send_tracks {
         unmute_video_result.unwrap();
 
         assert!(peer.is_all_transceiver_sides_in_mute_state(
-            TransceiverKind::Video,
+            MediaKind::Video,
             TrackDirection::Send,
             StableMuteState::Unmuted
         ));
@@ -647,7 +652,7 @@ mod disable_send_tracks {
     /// 2. Call [`RoomHandle::mute_video`] and [`RoomHandle::unmute_video`]
     ///    simultaneous.
     ///
-    /// 3. Check that [`PeerConnection`] with [`TransceiverKind::Video`] of
+    /// 3. Check that [`PeerConnection`] with [`MediaKind::Video`] of
     /// [`Room`] is in [`MuteState::Unmuted`].
     #[wasm_bindgen_test]
     async fn join_unmute_and_mute_audio() {
@@ -660,7 +665,7 @@ mod disable_send_tracks {
         .await;
 
         assert!(peer.is_all_transceiver_sides_in_mute_state(
-            TransceiverKind::Audio,
+            MediaKind::Audio,
             TrackDirection::Send,
             StableMuteState::Unmuted
         ));
@@ -669,7 +674,7 @@ mod disable_send_tracks {
         JsFuture::from(handle.mute_audio()).await.unwrap();
 
         assert!(peer.is_all_transceiver_sides_in_mute_state(
-            TransceiverKind::Audio,
+            MediaKind::Audio,
             TrackDirection::Send,
             StableMuteState::Muted
         ));
@@ -683,7 +688,7 @@ mod disable_send_tracks {
         unmute_audio_result.unwrap();
 
         assert!(peer.is_all_transceiver_sides_in_mute_state(
-            TransceiverKind::Audio,
+            MediaKind::Audio,
             TrackDirection::Send,
             StableMuteState::Unmuted
         ));
@@ -1043,10 +1048,10 @@ mod patches_generation {
             let peer_id = PeerId(i + 1);
 
             let mut local_stream = MediaStreamSettings::default();
-            local_stream.set_track_enabled(false, TransceiverKind::Video);
+            local_stream.set_track_enabled(false, MediaKind::Video);
             local_stream.set_track_enabled(
                 (audio_track_enabled_state_fn)(i),
-                TransceiverKind::Audio,
+                MediaKind::Audio,
             );
             let peer = PeerConnection::new(
                 peer_id,

--- a/jason/tests/media/constraints.rs
+++ b/jason/tests/media/constraints.rs
@@ -8,8 +8,8 @@ use web_sys::{MediaDeviceInfo, MediaDeviceKind};
 use medea_client_api_proto::{MediaSourceKind, VideoSettings};
 use medea_jason::{
     media::{
-        AudioTrackConstraints, DeviceVideoTrackConstraints, MediaManager,
-        MediaStreamSettings, MultiSourceTracksConstraints, TrackKind,
+        AudioTrackConstraints, DeviceVideoTrackConstraints, MediaKind,
+        MediaManager, MediaStreamSettings, MultiSourceTracksConstraints,
         VideoSource,
     },
     utils::{get_property_by_name, window},
@@ -39,7 +39,7 @@ async fn video_constraints_satisfies() {
 
     let track = tracks.pop().unwrap().0;
 
-    assert_eq!(track.kind(), TrackKind::Video);
+    assert_eq!(track.kind(), MediaKind::Video);
     assert!(track_constraints.satisfies(track.as_ref()));
 }
 
@@ -64,7 +64,7 @@ async fn audio_constraints_satisfies() {
 
     let track = tracks.pop().unwrap().0;
 
-    assert_eq!(track.kind(), TrackKind::Audio);
+    assert_eq!(track.kind(), MediaKind::Audio);
     assert!(track_constraints.satisfies(&track));
 }
 
@@ -106,17 +106,17 @@ async fn both_constraints_satisfies() {
     let (mut audio, mut video): (Vec<_>, Vec<_>) = tracks
         .into_iter()
         .partition(|(track, _)| match track.kind() {
-            TrackKind::Audio => true,
-            TrackKind::Video => false,
+            MediaKind::Audio => true,
+            MediaKind::Video => false,
         });
 
     let audio_track = audio.pop().unwrap().0;
     let video_track = video.pop().unwrap().0;
 
-    assert_eq!(audio_track.kind(), TrackKind::Audio);
+    assert_eq!(audio_track.kind(), MediaKind::Audio);
     assert!(audio_constraints.satisfies(&audio_track));
 
-    assert_eq!(video_track.kind(), TrackKind::Video);
+    assert_eq!(video_track.kind(), MediaKind::Video);
     assert!(video_constraints.satisfies(video_track.as_ref()));
 }
 
@@ -143,24 +143,24 @@ async fn equal_constraints_produce_equal_streams() {
 
     let audio_track = &tracks
         .iter()
-        .find(|(track, _)| track.kind() == TrackKind::Audio)
+        .find(|(track, _)| track.kind() == MediaKind::Audio)
         .unwrap()
         .0;
     let some_audio_track = &another_tracks
         .iter()
-        .find(|(track, _)| track.kind() == TrackKind::Audio)
+        .find(|(track, _)| track.kind() == MediaKind::Audio)
         .unwrap()
         .0;
     assert_eq!(audio_track.id(), some_audio_track.id());
 
     let video_track = &tracks
         .iter()
-        .find(|(track, _)| track.kind() == TrackKind::Video)
+        .find(|(track, _)| track.kind() == MediaKind::Video)
         .unwrap()
         .0;
     let some_video_track = &another_tracks
         .iter()
-        .find(|(track, _)| track.kind() == TrackKind::Video)
+        .find(|(track, _)| track.kind() == MediaKind::Video)
         .unwrap()
         .0;
     assert_eq!(video_track.id(), some_video_track.id());
@@ -190,12 +190,12 @@ async fn different_constraints_produce_different_streams() {
 
         let audio_track = &tracks
             .iter()
-            .find(|(track, _)| track.kind() == TrackKind::Audio)
+            .find(|(track, _)| track.kind() == MediaKind::Audio)
             .unwrap()
             .0;
         let another_audio_track = &another_tracks
             .iter()
-            .find(|(track, _)| track.kind() == TrackKind::Audio)
+            .find(|(track, _)| track.kind() == MediaKind::Audio)
             .unwrap()
             .0;
         assert_ne!(audio_track.id(), another_audio_track.id());

--- a/jason/tests/media/manager.rs
+++ b/jason/tests/media/manager.rs
@@ -5,7 +5,7 @@ use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 
 use medea_jason::{
-    media::{MediaManager, TrackKind},
+    media::{MediaKind, MediaManager},
     AudioTrackConstraints, DeviceVideoTrackConstraints,
     DisplayVideoTrackConstraints, MediaStreamSettings,
 };
@@ -136,7 +136,7 @@ async fn same_track_for_same_constraints() {
     let (track1, track1_is_new) = tracks.pop().unwrap();
 
     assert!(track1_is_new);
-    assert_eq!(track1.kind(), TrackKind::Audio);
+    assert_eq!(track1.kind(), MediaKind::Audio);
     assert_eq!(mock_navigator.get_user_media_requests_count(), 1);
 
     // second request, same track, no additional getUserMedia requests
@@ -148,7 +148,7 @@ async fn same_track_for_same_constraints() {
 
     assert!(!track2_is_new);
     assert_eq!(track1.id(), track2.id());
-    assert_eq!(track2.kind(), TrackKind::Audio);
+    assert_eq!(track2.kind(), MediaKind::Audio);
     assert_eq!(mock_navigator.get_user_media_requests_count(), 1);
 }
 
@@ -175,7 +175,7 @@ async fn new_track_if_previous_dropped() {
     assert_eq!(tracks.len(), 1);
     let (track1, track1_is_new) = tracks.pop().unwrap();
 
-    assert_eq!(track1.kind(), TrackKind::Audio);
+    assert_eq!(track1.kind(), MediaKind::Audio);
     assert!(track1_is_new);
     assert_eq!(mock_navigator.get_user_media_requests_count(), 1);
 
@@ -189,7 +189,7 @@ async fn new_track_if_previous_dropped() {
 
     assert!(track2_is_new);
     assert_ne!(track2.id(), track1_id);
-    assert_eq!(track2.kind(), TrackKind::Audio);
+    assert_eq!(track2.kind(), MediaKind::Audio);
     assert_eq!(mock_navigator.get_user_media_requests_count(), 2);
 
     mock_navigator.stop();
@@ -215,7 +215,7 @@ async fn request_audio_video_then_audio_then_video() {
     let tracks = media_manager.get_tracks(constraints).await.unwrap();
     let (mut audio_tracks, mut video_tracks): (Vec<_>, Vec<_>) = tracks
         .into_iter()
-        .partition(|(track, _)| track.kind() == TrackKind::Audio);
+        .partition(|(track, _)| track.kind() == MediaKind::Audio);
     assert_eq!(audio_tracks.len(), 1);
     assert_eq!(video_tracks.len(), 1);
 
@@ -278,7 +278,7 @@ async fn display_track_is_cached() {
 
     let (video_track, video_track_is_new) = tracks
         .into_iter()
-        .find(|(track, _)| track.kind() == TrackKind::Video)
+        .find(|(track, _)| track.kind() == MediaKind::Video)
         .unwrap();
     assert!(video_track_is_new);
 

--- a/jason/tests/web.rs
+++ b/jason/tests/web.rs
@@ -8,7 +8,7 @@
 macro_rules! cb_assert_eq {
     ($a:expr, $b:expr) => {
         if $a != $b {
-            return Err(format!("{} != {}", $a, $b));
+            return Err(format!("{:?} != {:?}", $a, $b));
         }
     };
 }
@@ -87,8 +87,9 @@ use medea_client_api_proto::{
     TrackId, VideoSettings,
 };
 use medea_jason::{
-    media::{LocalTracksConstraints, MediaManager, MediaStreamTrack},
-    peer::TransceiverKind,
+    media::{
+        LocalTracksConstraints, MediaKind, MediaManager, MediaStreamTrack,
+    },
     utils::{window, JasonError},
     AudioTrackConstraints, DeviceVideoTrackConstraints, MediaStreamSettings,
 };
@@ -142,8 +143,8 @@ pub fn get_media_stream_settings(
     video_enabled: bool,
 ) -> MediaStreamSettings {
     let mut settings = MediaStreamSettings::default();
-    settings.set_track_enabled(audio_enabled, TransceiverKind::Audio);
-    settings.set_track_enabled(video_enabled, TransceiverKind::Video);
+    settings.set_track_enabled(audio_enabled, MediaKind::Audio);
+    settings.set_track_enabled(video_enabled, MediaKind::Video);
 
     settings
 }


### PR DESCRIPTION
## Synopsis

Как-то так повелось, что enum'ы в js'ку мы возвращаем в виде строк, так как решили что для js'ки так будет более идиоматично. При этом в функциях которые принимают enum'ы, мы принимаем enum'ы. Хочется достичь консистентности: мы или и принимаем и возвращаем enum'ы, или мы и принимаем и возвращаем стринги. 

Склоняюсь к первому варианту.

## Solution

1. Expose `MediaKind` and `MediaSourceKind` enums. 
2. Change some exported functions return types:
   `InputDeviceInfo.kind -> String => InputDeviceInfo.kind -> MediaKind`
   `MediaTrack.kind -> String => MediaTrack.kind -> MediaKind`
   `MediaTrack.media_source_kind -> String => MediaTrack.media_source_kind -> MediaSourceKind`
3. Internally we use 3 enums with `Audio` and `Video` variants: `InputDeviceKind`, `TransceiverKind` and `MediaTrackKind`. Get rid of those in favor of `MediaKind` enum.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
