### PR TITLE
Move RoomId and Credentials to the 'medea-client-api-proto' crate (#27)

### DIFF
--- a/proto/client-api/CHANGELOG.md
+++ b/proto/client-api/CHANGELOG.md
@@ -58,7 +58,7 @@ All user visible changes to this project will be documented in this file. This p
 - `TrackPatchEvent` and `TrackPatchCommand` types ([#127]);
 - `IceRestart` variant to `TrackUpdate` ([#138]);
 - `source_kind` field to `VideoSettings` type ([#145]);
-- `RoomId` and `Credentials` types ([#148]).
+- `RoomId` and `Credential` types ([#148]).
 
 [#28]: /../../pull/28
 [#58]: /../../pull/58

--- a/proto/client-api/CHANGELOG.md
+++ b/proto/client-api/CHANGELOG.md
@@ -57,7 +57,8 @@ All user visible changes to this project will be documented in this file. This p
 - `ConnectionQualityUpdated` event ([#132]);
 - `TrackPatchEvent` and `TrackPatchCommand` types ([#127]);
 - `IceRestart` variant to `TrackUpdate` ([#138]);
-- `source_kind` field to `VideoSettings` type ([#145]).
+- `source_kind` field to `VideoSettings` type ([#145]);
+- `RoomId` and `Credentials` types ([#148]).
 
 [#28]: /../../pull/28
 [#58]: /../../pull/58
@@ -75,6 +76,7 @@ All user visible changes to this project will be documented in this file. This p
 [#127]: /../../pull/127
 [#138]: /../../pull/138
 [#145]: /../../pull/145
+[#148]: /../../pull/148
 
 
 

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -65,12 +65,12 @@ pub struct PeerId(pub u32);
 #[derive(Clone, Copy, Display)]
 pub struct TrackId(pub u32);
 
-/// `Member` credentials.
+/// Credential used for `Member` authentication.
 #[derive(
     Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq, From, Display,
 )]
 #[from(forward)]
-pub struct Credentials(pub String);
+pub struct Credential(pub String);
 
 /// Value that is able to be incremented by `1`.
 #[cfg(feature = "medea")]

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -33,6 +33,13 @@ use serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize};
 
 use self::stats::RtcStat;
 
+/// ID of `Room`.
+#[derive(
+    Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq, From, Display,
+)]
+#[from(forward)]
+pub struct RoomId(pub String);
+
 /// ID of `Member`.
 #[derive(
     Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq, From, Display,
@@ -57,6 +64,13 @@ pub struct PeerId(pub u32);
 #[cfg_attr(feature = "jason", derive(Serialize))]
 #[derive(Clone, Copy, Display)]
 pub struct TrackId(pub u32);
+
+/// `Member` credentials.
+#[derive(
+    Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq, From, Display,
+)]
+#[from(forward)]
+pub struct Credentials(pub String);
 
 /// Value that is able to be incremented by `1`.
 #[cfg(feature = "medea")]

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -67,7 +67,7 @@ pub struct TrackId(pub u32);
 
 /// Credential used for `Member` authentication.
 #[derive(
-    Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq, From, Display,
+    Clone, Debug, Deserialize, Display, Eq, From, Hash, PartialEq, Serialize,
 )]
 #[from(forward)]
 pub struct Credential(pub String);

--- a/src/api/client/rpc_connection.rs
+++ b/src/api/client/rpc_connection.rs
@@ -7,7 +7,9 @@ use std::{fmt, time::Duration};
 use actix::Message;
 use derive_more::{From, Into};
 use futures::future::LocalBoxFuture;
-use medea_client_api_proto::{CloseDescription, Command, Event, MemberId};
+use medea_client_api_proto::{
+    CloseDescription, Command, Credentials, Event, MemberId,
+};
 
 use crate::signalling::room::RoomError;
 
@@ -82,7 +84,7 @@ pub struct Authorize {
     pub member_id: MemberId,
 
     /// Credentials to authorize [`RpcConnection`] with.
-    pub credentials: String, // TODO: &str when futures will allow references
+    pub credentials: Credentials,
 }
 
 /// Error of authorization [`RpcConnection`] in [`Room`].

--- a/src/api/client/rpc_connection.rs
+++ b/src/api/client/rpc_connection.rs
@@ -8,7 +8,7 @@ use actix::Message;
 use derive_more::{From, Into};
 use futures::future::LocalBoxFuture;
 use medea_client_api_proto::{
-    CloseDescription, Command, Credentials, Event, MemberId,
+    CloseDescription, Command, Credential, Event, MemberId,
 };
 
 use crate::signalling::room::RoomError;
@@ -84,7 +84,7 @@ pub struct Authorize {
     pub member_id: MemberId,
 
     /// Credentials to authorize [`RpcConnection`] with.
-    pub credentials: Credentials,
+    pub credentials: Credential,
 }
 
 /// Error of authorization [`RpcConnection`] in [`Room`].

--- a/src/api/client/server.rs
+++ b/src/api/client/server.rs
@@ -11,16 +11,13 @@ use actix_web::{
 };
 use actix_web_actors::ws;
 use futures::FutureExt as _;
-use medea_client_api_proto::MemberId;
+use medea_client_api_proto::{Credentials, MemberId, RoomId};
 use serde::Deserialize;
 
 use crate::{
-    api::{
-        client::{
-            rpc_connection::{AuthorizationError, Authorize},
-            session::WsSession,
-        },
-        control::RoomId,
+    api::client::{
+        rpc_connection::{AuthorizationError, Authorize},
+        session::WsSession,
     },
     conf::{Conf, Rpc},
     log::prelude::*,
@@ -38,7 +35,7 @@ struct RequestParams {
     member_id: MemberId,
 
     /// Credential of [`Member`] to authorize WebSocket connection with.
-    credentials: String,
+    credentials: Credentials,
 }
 
 /// Handles all HTTP requests, performs WebSocket handshake (upgrade) and starts

--- a/src/api/client/server.rs
+++ b/src/api/client/server.rs
@@ -11,7 +11,7 @@ use actix_web::{
 };
 use actix_web_actors::ws;
 use futures::FutureExt as _;
-use medea_client_api_proto::{Credentials, MemberId, RoomId};
+use medea_client_api_proto::{Credential, MemberId, RoomId};
 use serde::Deserialize;
 
 use crate::{
@@ -35,7 +35,7 @@ struct RequestParams {
     member_id: MemberId,
 
     /// Credential of [`Member`] to authorize WebSocket connection with.
-    credentials: Credentials,
+    credentials: Credential,
 }
 
 /// Handles all HTTP requests, performs WebSocket handshake (upgrade) and starts

--- a/src/api/client/session.rs
+++ b/src/api/client/session.rs
@@ -17,14 +17,13 @@ use actix_web_actors::ws::{self, CloseCode};
 use bytes::{Buf, BytesMut};
 use futures::future::{FutureExt as _, LocalBoxFuture};
 use medea_client_api_proto::{
-    ClientMsg, CloseDescription, CloseReason, Event, MemberId, RpcSettings,
-    ServerMsg,
+    ClientMsg, CloseDescription, CloseReason, Event, MemberId, RoomId,
+    RpcSettings, ServerMsg,
 };
 
 use crate::{
     api::{
         client::rpc_connection::{ClosedReason, EventMessage, RpcConnection},
-        control::RoomId,
         RpcServer,
     },
     log::prelude::*,
@@ -479,12 +478,6 @@ mod test {
     use actix_web::{test::TestServer, web, App, HttpRequest};
     use actix_web_actors::ws::{start, CloseCode, CloseReason, Frame, Message};
     use bytes::{Buf, Bytes};
-    use medea_client_api_proto::{
-        CloseDescription, CloseReason as ProtoCloseReason, Command, Event,
-        MemberId, PeerId,
-    };
-    use tokio::time::timeout;
-
     use futures::{
         channel::{
             mpsc::{self, UnboundedReceiver, UnboundedSender},
@@ -492,10 +485,14 @@ mod test {
         },
         future, FutureExt as _, SinkExt as _, StreamExt as _,
     };
+    use medea_client_api_proto::{
+        CloseDescription, CloseReason as ProtoCloseReason, Command, Event,
+        MemberId, PeerId, RoomId,
+    };
+    use tokio::time::timeout;
 
     use crate::api::{
         client::rpc_connection::{ClosedReason, RpcConnection},
-        control::RoomId,
         MockRpcServer,
     };
 

--- a/src/api/client/session.rs
+++ b/src/api/client/session.rs
@@ -484,10 +484,9 @@ mod test {
         },
         future, FutureExt as _, SinkExt as _, StreamExt as _,
     };
-    }
     use medea_client_api_proto::{
         ClientMsg, CloseDescription, CloseReason as ProtoCloseReason, Command,
-        Event, IceCandidate, MemberId, PeerId, RpcSettings, ServerMsg,
+        Event, IceCandidate, MemberId, PeerId, RoomId, RpcSettings, ServerMsg,
     };
     use tokio::time::timeout;
 
@@ -528,7 +527,7 @@ mod test {
     #[actix_rt::test]
     async fn close_if_rpc_established_failed() {
         fn factory() -> WsSession {
-            let member_id = MemberId::from(String::from("test_member"));
+            let member_id = MemberId::from("test_member");
             let mut rpc_server = MockRpcServer::new();
 
             let expected_member_id = member_id.clone();
@@ -566,7 +565,7 @@ mod test {
     #[actix_rt::test]
     async fn sends_rpc_settings_and_pings() {
         let mut serv = test_server(|| -> WsSession {
-            let member_id = MemberId::from(String::from("test_member"));
+            let member_id = MemberId::from("test_member");
             let mut rpc_server = MockRpcServer::new();
 
             rpc_server
@@ -607,7 +606,7 @@ mod test {
     #[actix_rt::test]
     async fn dropped_if_idle() {
         let mut serv = test_server(|| -> WsSession {
-            let member_id = MemberId::from(String::from("test_member"));
+            let member_id = MemberId::from("test_member");
             let mut rpc_server = MockRpcServer::new();
 
             rpc_server
@@ -661,7 +660,7 @@ mod test {
         }
 
         let mut serv = test_server(|| -> WsSession {
-            let member_id = MemberId::from(String::from("test_member"));
+            let member_id = MemberId::from("test_member");
             let mut rpc_server = MockRpcServer::new();
 
             rpc_server
@@ -756,7 +755,7 @@ mod test {
         }
 
         let mut serv = test_server(|| -> WsSession {
-            let member_id = MemberId::from(String::from("test_member"));
+            let member_id = MemberId::from("test_member");
             let mut rpc_server = MockRpcServer::new();
 
             rpc_server.expect_connection_established().return_once(
@@ -812,7 +811,7 @@ mod test {
         }
 
         let mut serv = test_server(|| -> WsSession {
-            let member_id = MemberId::from(String::from("test_member"));
+            let member_id = MemberId::from("test_member");
             let mut rpc_server = MockRpcServer::new();
 
             rpc_server.expect_connection_established().return_once(

--- a/src/api/control/member.rs
+++ b/src/api/control/member.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use medea_client_api_proto::MemberId as Id;
+use medea_client_api_proto::{Credentials, MemberId as Id};
 use medea_control_api_proto::grpc::api as proto;
 use rand::{distributions::Alphanumeric, Rng};
 use serde::Deserialize;
@@ -53,7 +53,7 @@ pub struct MemberSpec {
     pipeline: Pipeline<EndpointId, MemberElement>,
 
     /// Credentials to authorize `Member` with.
-    credentials: String,
+    credentials: Credentials,
 
     /// URL to which `OnJoin` Control API callback will be sent.
     on_join: Option<CallbackUrl>,
@@ -95,7 +95,7 @@ impl MemberSpec {
     #[inline]
     pub fn new(
         pipeline: Pipeline<EndpointId, MemberElement>,
-        credentials: String,
+        credentials: Credentials,
         on_join: Option<CallbackUrl>,
         on_leave: Option<CallbackUrl>,
         idle_timeout: Option<Duration>,
@@ -151,7 +151,7 @@ impl MemberSpec {
     }
 
     /// Returns credentials from this [`MemberSpec`].
-    pub fn credentials(&self) -> &str {
+    pub fn credentials(&self) -> &Credentials {
         &self.credentials
     }
 
@@ -194,11 +194,12 @@ impl MemberSpec {
 /// [`MemberProto`] implemented for [`MemberSpec`].
 ///
 /// [Control API]: https://tinyurl.com/yxsqplq7
-fn generate_member_credentials() -> String {
+fn generate_member_credentials() -> Credentials {
     rand::thread_rng()
         .sample_iter(&Alphanumeric)
         .take(CREDENTIALS_LEN)
-        .collect()
+        .collect::<String>()
+        .into()
 }
 
 impl TryFrom<proto::Member> for MemberSpec {
@@ -226,8 +227,8 @@ impl TryFrom<proto::Member> for MemberSpec {
             }
         }
 
-        let mut credentials = member.credentials;
-        if credentials.is_empty() {
+        let mut credentials = Credentials::from(member.credentials);
+        if credentials.0.is_empty() {
             credentials = generate_member_credentials();
         }
 

--- a/src/api/control/member.rs
+++ b/src/api/control/member.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use medea_client_api_proto::{Credentials, MemberId as Id};
+use medea_client_api_proto::{Credential, MemberId as Id};
 use medea_control_api_proto::grpc::api as proto;
 use rand::{distributions::Alphanumeric, Rng};
 use serde::Deserialize;
@@ -53,7 +53,7 @@ pub struct MemberSpec {
     pipeline: Pipeline<EndpointId, MemberElement>,
 
     /// Credentials to authorize `Member` with.
-    credentials: Credentials,
+    credentials: Credential,
 
     /// URL to which `OnJoin` Control API callback will be sent.
     on_join: Option<CallbackUrl>,
@@ -95,7 +95,7 @@ impl MemberSpec {
     #[inline]
     pub fn new(
         pipeline: Pipeline<EndpointId, MemberElement>,
-        credentials: Credentials,
+        credentials: Credential,
         on_join: Option<CallbackUrl>,
         on_leave: Option<CallbackUrl>,
         idle_timeout: Option<Duration>,
@@ -151,7 +151,7 @@ impl MemberSpec {
     }
 
     /// Returns credentials from this [`MemberSpec`].
-    pub fn credentials(&self) -> &Credentials {
+    pub fn credentials(&self) -> &Credential {
         &self.credentials
     }
 
@@ -194,7 +194,7 @@ impl MemberSpec {
 /// [`MemberProto`] implemented for [`MemberSpec`].
 ///
 /// [Control API]: https://tinyurl.com/yxsqplq7
-fn generate_member_credentials() -> Credentials {
+fn generate_member_credentials() -> Credential {
     rand::thread_rng()
         .sample_iter(&Alphanumeric)
         .take(CREDENTIALS_LEN)
@@ -227,7 +227,7 @@ impl TryFrom<proto::Member> for MemberSpec {
             }
         }
 
-        let mut credentials = Credentials::from(member.credentials);
+        let mut credentials = Credential::from(member.credentials);
         if credentials.0.is_empty() {
             credentials = generate_member_credentials();
         }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -16,7 +16,7 @@ use std::{convert::TryFrom as _, fs::File, io::Read as _, path::Path};
 use actix::Addr;
 use derive_more::Display;
 use failure::{Error, Fail};
-use medea_client_api_proto::MemberId;
+use medea_client_api_proto::{MemberId, RoomId};
 use serde::Deserialize;
 
 use crate::{
@@ -37,7 +37,7 @@ pub use self::{
         Id as EndpointId,
     },
     member::MemberSpec,
-    room::{Id as RoomId, RoomElement, RoomSpec},
+    room::{RoomElement, RoomSpec},
 };
 
 /// Errors which may occur while deserializing protobuf spec.

--- a/src/api/control/refs/fid.rs
+++ b/src/api/control/refs/fid.rs
@@ -7,8 +7,9 @@ use std::{
 
 use derive_more::{Display, From};
 use failure::Fail;
+use medea_client_api_proto::RoomId;
 
-use crate::{api::control::RoomId, impls_for_stateful_refs};
+use crate::impls_for_stateful_refs;
 
 use super::{ToEndpoint, ToMember, ToRoom};
 

--- a/src/api/control/refs/local_uri.rs
+++ b/src/api/control/refs/local_uri.rs
@@ -7,10 +7,10 @@ use std::{convert::TryFrom, fmt, string::ToString};
 
 use derive_more::{Display, From};
 use failure::Fail;
-use medea_client_api_proto::MemberId;
+use medea_client_api_proto::{MemberId, RoomId};
 use url::Url;
 
-use crate::{api::control::RoomId, impls_for_stateful_refs};
+use crate::impls_for_stateful_refs;
 
 use super::{SrcUri, ToEndpoint, ToMember, ToRoom};
 

--- a/src/api/control/refs/mod.rs
+++ b/src/api/control/refs/mod.rs
@@ -7,9 +7,9 @@ pub mod fid;
 pub mod local_uri;
 pub mod src_uri;
 
-use medea_client_api_proto::MemberId;
+use medea_client_api_proto::{MemberId, RoomId};
 
-use super::{EndpointId, RoomId};
+use super::EndpointId;
 
 #[doc(inline)]
 pub use self::{

--- a/src/api/control/refs/src_uri.rs
+++ b/src/api/control/refs/src_uri.rs
@@ -9,7 +9,7 @@ use std::{convert::TryFrom, fmt};
 
 use derive_more::Display;
 use failure::Fail;
-use medea_client_api_proto::MemberId;
+use medea_client_api_proto::{MemberId, RoomId};
 use serde::{
     de::{self, Deserializer, Error, Visitor},
     Deserialize,
@@ -21,7 +21,6 @@ use crate::api::control::{
         local_uri::{LocalUriParseError, StatefulLocalUri},
         LocalUri, ToEndpoint,
     },
-    RoomId,
 };
 
 /// Errors which can happen while parsing [`SrcUri`] from [Control API] specs.

--- a/src/api/control/room.rs
+++ b/src/api/control/room.rs
@@ -4,8 +4,7 @@
 
 use std::{collections::HashMap, convert::TryFrom, time::Duration};
 
-use derive_more::{Display, From};
-use medea_client_api_proto::MemberId;
+use medea_client_api_proto::{Credentials, MemberId, RoomId as Id};
 use medea_control_api_proto::grpc::api as proto;
 use serde::Deserialize;
 
@@ -19,13 +18,6 @@ use super::{
     RootElement, TryFromElementError,
 };
 
-/// ID of [`Room`].
-///
-/// [`Room`]: crate::signalling::room::Room
-#[derive(Clone, Debug, Deserialize, Display, Eq, From, Hash, PartialEq)]
-#[from(forward)]
-pub struct Id(String);
-
 /// Element of [`Room`]'s [`Pipeline`].
 ///
 /// [`Room`]: crate::signalling::room::Room
@@ -36,7 +28,7 @@ pub enum RoomElement {
     /// Can transform into [`MemberSpec`] by `MemberSpec::try_from`.
     Member {
         spec: Pipeline<EndpointId, MemberElement>,
-        credentials: String,
+        credentials: Credentials,
         on_leave: Option<CallbackUrl>,
         on_join: Option<CallbackUrl>,
         #[serde(default, with = "humantime_serde")]

--- a/src/api/control/room.rs
+++ b/src/api/control/room.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::HashMap, convert::TryFrom, time::Duration};
 
-use medea_client_api_proto::{Credentials, MemberId, RoomId as Id};
+use medea_client_api_proto::{Credential, MemberId, RoomId as Id};
 use medea_control_api_proto::grpc::api as proto;
 use serde::Deserialize;
 
@@ -28,7 +28,7 @@ pub enum RoomElement {
     /// Can transform into [`MemberSpec`] by `MemberSpec::try_from`.
     Member {
         spec: Pipeline<EndpointId, MemberElement>,
-        credentials: Credentials,
+        credentials: Credential,
         on_leave: Option<CallbackUrl>,
         on_join: Option<CallbackUrl>,
         #[serde(default, with = "humantime_serde")]

--- a/src/media/ice_user.rs
+++ b/src/media/ice_user.rs
@@ -3,9 +3,7 @@
 //! [Coturn]: https://github.com/coturn/coturn
 
 use derive_more::{AsRef, Display, From, Into};
-use medea_client_api_proto::{IceServer, PeerId};
-
-use crate::api::control::RoomId;
+use medea_client_api_proto::{IceServer, PeerId, RoomId};
 
 /// Username for authorization on [Coturn] server.
 ///

--- a/src/signalling/elements/member.rs
+++ b/src/signalling/elements/member.rs
@@ -12,7 +12,7 @@ use std::{
 
 use derive_more::Display;
 use failure::Fail;
-use medea_client_api_proto::{Credentials, MemberId, PeerId, RoomId};
+use medea_client_api_proto::{Credential, MemberId, PeerId, RoomId};
 use medea_control_api_proto::grpc::api as proto;
 
 use crate::{
@@ -81,7 +81,7 @@ struct MemberInner {
     sinks: HashMap<WebRtcPlayId, WebRtcPlayEndpoint>,
 
     /// Credentials for this [`Member`].
-    credentials: Credentials,
+    credentials: Credential,
 
     /// URL to which `on_join` Control API callback will be sent.
     on_join: Option<CallbackUrl>,
@@ -111,7 +111,7 @@ impl Member {
     /// function.
     pub fn new(
         id: MemberId,
-        credentials: Credentials,
+        credentials: Credential,
         room_id: RoomId,
         idle_timeout: Duration,
         reconnect_timeout: Duration,
@@ -301,7 +301,7 @@ impl Member {
     }
 
     /// Returns credentials of this [`Member`].
-    pub fn credentials(&self) -> Credentials {
+    pub fn credentials(&self) -> Credential {
         self.0.borrow().credentials.clone()
     }
 

--- a/src/signalling/elements/member.rs
+++ b/src/signalling/elements/member.rs
@@ -12,7 +12,7 @@ use std::{
 
 use derive_more::Display;
 use failure::Fail;
-use medea_client_api_proto::{MemberId, PeerId};
+use medea_client_api_proto::{Credentials, MemberId, PeerId, RoomId};
 use medea_control_api_proto::grpc::api as proto;
 
 use crate::{
@@ -20,8 +20,8 @@ use crate::{
         callback::url::CallbackUrl,
         endpoints::WebRtcPlayEndpoint as WebRtcPlayEndpointSpec,
         refs::{Fid, StatefulFid, ToEndpoint, ToMember, ToRoom},
-        EndpointId, MemberSpec, RoomId, RoomSpec, TryFromElementError,
-        WebRtcPlayId, WebRtcPublishId,
+        EndpointId, MemberSpec, RoomSpec, TryFromElementError, WebRtcPlayId,
+        WebRtcPublishId,
     },
     conf::Rpc as RpcConf,
     log::prelude::*,
@@ -81,7 +81,7 @@ struct MemberInner {
     sinks: HashMap<WebRtcPlayId, WebRtcPlayEndpoint>,
 
     /// Credentials for this [`Member`].
-    credentials: String,
+    credentials: Credentials,
 
     /// URL to which `on_join` Control API callback will be sent.
     on_join: Option<CallbackUrl>,
@@ -111,7 +111,7 @@ impl Member {
     /// function.
     pub fn new(
         id: MemberId,
-        credentials: String,
+        credentials: Credentials,
         room_id: RoomId,
         idle_timeout: Duration,
         reconnect_timeout: Duration,
@@ -301,7 +301,7 @@ impl Member {
     }
 
     /// Returns credentials of this [`Member`].
-    pub fn credentials(&self) -> String {
+    pub fn credentials(&self) -> Credentials {
         self.0.borrow().credentials.clone()
     }
 
@@ -529,7 +529,7 @@ pub fn parse_members(
         .map(|(id, member)| {
             let new_member = Member::new(
                 id.clone(),
-                member.credentials().to_string(),
+                member.credentials().clone(),
                 room_spec.id.clone(),
                 member.idle_timeout().unwrap_or(rpc_conf.idle_timeout),
                 member
@@ -584,7 +584,7 @@ impl Into<proto::Member> for Member {
 
         proto::Member {
             id: self.id().to_string(),
-            credentials: self.credentials(),
+            credentials: self.credentials().to_string(),
             on_leave: self
                 .get_on_leave()
                 .map(|c| c.to_string())

--- a/src/signalling/participants.rs
+++ b/src/signalling/participants.rs
@@ -17,7 +17,7 @@ use derive_more::Display;
 use failure::Fail;
 use futures::future::{self, FutureExt as _, LocalBoxFuture};
 use medea_client_api_proto::{
-    CloseDescription, CloseReason, Credentials, Event, MemberId, RoomId,
+    CloseDescription, CloseReason, Credential, Event, MemberId, RoomId,
 };
 
 use crate::{
@@ -165,7 +165,7 @@ impl ParticipantService {
     pub fn get_member_by_id_and_credentials(
         &self,
         member_id: &MemberId,
-        credentials: &Credentials,
+        credentials: &Credential,
     ) -> Result<Member, AuthorizationError> {
         let member = self
             .get_member_by_id(member_id)

--- a/src/signalling/participants.rs
+++ b/src/signalling/participants.rs
@@ -16,7 +16,9 @@ use actix::{
 use derive_more::Display;
 use failure::Fail;
 use futures::future::{self, FutureExt as _, LocalBoxFuture};
-use medea_client_api_proto::{CloseDescription, CloseReason, Event, MemberId};
+use medea_client_api_proto::{
+    CloseDescription, CloseReason, Credentials, Event, MemberId, RoomId,
+};
 
 use crate::{
     api::{
@@ -26,7 +28,7 @@ use crate::{
         },
         control::{
             refs::{Fid, ToEndpoint, ToMember},
-            MemberSpec, RoomId, RoomSpec,
+            MemberSpec, RoomSpec,
         },
     },
     conf::Rpc as RpcConf,
@@ -163,12 +165,12 @@ impl ParticipantService {
     pub fn get_member_by_id_and_credentials(
         &self,
         member_id: &MemberId,
-        credentials: &str,
+        credentials: &Credentials,
     ) -> Result<Member, AuthorizationError> {
         let member = self
             .get_member_by_id(member_id)
             .ok_or(AuthorizationError::MemberNotExists)?;
-        if member.credentials() == credentials {
+        if &member.credentials() == credentials {
             Ok(member)
         } else {
             Err(AuthorizationError::InvalidCredentials)
@@ -386,7 +388,7 @@ impl ParticipantService {
         }
         let signalling_member = Member::new(
             id.clone(),
-            spec.credentials().to_string(),
+            spec.credentials().clone(),
             self.room_id.clone(),
             spec.idle_timeout().unwrap_or(self.rpc_conf.idle_timeout),
             spec.reconnect_timeout()
@@ -472,7 +474,7 @@ mod test {
 
         let test_member_spec = MemberSpec::new(
             Pipeline::new(HashMap::new()),
-            String::from("w/e"),
+            "w/e".into(),
             None,
             None,
             None,
@@ -514,7 +516,7 @@ mod test {
 
         let test_member_spec = MemberSpec::new(
             Pipeline::new(HashMap::new()),
-            String::from("w/e"),
+            "w/e".into(),
             None,
             None,
             Some(idle_timeout),

--- a/src/signalling/peers/metrics/flowing_detector.rs
+++ b/src/signalling/peers/metrics/flowing_detector.rs
@@ -20,14 +20,11 @@ use medea_client_api_proto::{
         RtcOutboundRtpStreamMediaType, RtcOutboundRtpStreamStats, RtcStat,
         RtcStatsType, StatId,
     },
-    MediaType as MediaTypeProto, MemberId, PeerConnectionState, PeerId,
+    MediaType as MediaTypeProto, MemberId, PeerConnectionState, PeerId, RoomId,
 };
 
 use crate::{
-    api::control::{
-        callback::{MediaDirection, MediaType},
-        RoomId,
-    },
+    api::control::callback::{MediaDirection, MediaType},
     log::prelude::*,
     media::{PeerStateMachine as Peer, PeerStateMachine},
     signalling::peers::{

--- a/src/signalling/peers/metrics/mod.rs
+++ b/src/signalling/peers/metrics/mod.rs
@@ -22,15 +22,12 @@ use futures::{
 };
 use medea_client_api_proto::{
     stats::RtcStat, ConnectionQualityScore, MemberId, PeerConnectionState,
-    PeerId,
+    PeerId, RoomId,
 };
 use medea_macro::dispatchable;
 
 use crate::{
-    api::control::{
-        callback::{MediaDirection, MediaType},
-        RoomId,
-    },
+    api::control::callback::{MediaDirection, MediaType},
     media::PeerStateMachine,
     signalling::peers::{
         metrics::{

--- a/src/signalling/peers/mod.rs
+++ b/src/signalling/peers/mod.rs
@@ -16,11 +16,10 @@ use derive_more::Display;
 use futures::{future, Stream};
 use medea_client_api_proto::{
     stats::RtcStat, Incrementable, MemberId, PeerConnectionState, PeerId,
-    TrackId,
+    RoomId, TrackId,
 };
 
 use crate::{
-    api::control::RoomId,
     conf,
     log::prelude::*,
     media::{peer::PeerUpdatesSubscriber, Peer, PeerError, PeerStateMachine},
@@ -890,7 +889,7 @@ mod tests {
 
         let publisher = Member::new(
             "publisher".into(),
-            "test".to_string(),
+            "test".into(),
             "test".into(),
             Duration::from_secs(10),
             Duration::from_secs(10),
@@ -898,7 +897,7 @@ mod tests {
         );
         let receiver = Member::new(
             "receiver".into(),
-            "test".to_string(),
+            "test".into(),
             "test".into(),
             Duration::from_secs(10),
             Duration::from_secs(10),
@@ -995,7 +994,7 @@ mod tests {
 
         let publisher = Member::new(
             "publisher".into(),
-            "test".to_string(),
+            "test".into(),
             "test".into(),
             Duration::from_secs(10),
             Duration::from_secs(10),
@@ -1003,7 +1002,7 @@ mod tests {
         );
         let receiver = Member::new(
             "receiver".into(),
-            "test".to_string(),
+            "test".into(),
             "test".into(),
             Duration::from_secs(10),
             Duration::from_secs(10),

--- a/src/signalling/peers/traffic_watcher.rs
+++ b/src/signalling/peers/traffic_watcher.rs
@@ -37,11 +37,9 @@ use actix::{
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use medea_client_api_proto::PeerId;
+use medea_client_api_proto::{PeerId, RoomId};
 
-use crate::{
-    api::control::RoomId, conf, log::prelude::*, utils::instant_into_utc,
-};
+use crate::{conf, log::prelude::*, utils::instant_into_utc};
 
 /// Subscriber of `Peer` traffic flowing changes.
 #[cfg_attr(test, mockall::automock)]

--- a/src/signalling/room/mod.rs
+++ b/src/signalling/room/mod.rs
@@ -15,7 +15,9 @@ use actix::{
 use derive_more::{Display, From};
 use failure::Fail;
 use futures::future;
-use medea_client_api_proto::{Event, MemberId, NegotiationRole, PeerId};
+use medea_client_api_proto::{
+    Event, MemberId, NegotiationRole, PeerId, RoomId,
+};
 
 use crate::{
     api::control::{
@@ -25,7 +27,6 @@ use crate::{
         },
         refs::{Fid, StatefulFid, ToEndpoint, ToMember},
         room::RoomSpec,
-        RoomId,
     },
     log::prelude::*,
     media::{peer::PeerUpdatesSubscriber, Peer, PeerError, Stable},

--- a/src/signalling/room/rpc_server.rs
+++ b/src/signalling/room/rpc_server.rs
@@ -292,10 +292,12 @@ impl Handler<RpcConnectionClosed> for Room {
 mod test {
     use std::collections::HashMap;
 
+    use medea_client_api_proto::RoomId;
+
     use super::*;
 
     use crate::{
-        api::control::{pipeline::Pipeline, MemberSpec, RoomId, RoomSpec},
+        api::control::{pipeline::Pipeline, MemberSpec, RoomSpec},
         conf::{self, Conf},
         media::peer::tests::dummy_negotiation_sub_mock,
         signalling::{
@@ -339,7 +341,7 @@ mod test {
 
         let member1 = MemberSpec::new(
             Pipeline::new(HashMap::new()),
-            String::from("w/e"),
+            "w/e".into(),
             None,
             None,
             None,
@@ -377,7 +379,7 @@ mod test {
 
         let member1 = MemberSpec::new(
             Pipeline::new(HashMap::new()),
-            String::from("w/e"),
+            "w/e".into(),
             None,
             None,
             None,

--- a/src/signalling/room_repo.rs
+++ b/src/signalling/room_repo.rs
@@ -6,8 +6,9 @@ use std::{
 };
 
 use actix::Addr;
+use medea_client_api_proto::RoomId;
 
-use crate::{api::control::RoomId, signalling::Room};
+use crate::signalling::Room;
 
 /// Repository that stores [`Room`]s addresses.
 #[derive(Clone, Debug, Default)]

--- a/src/signalling/room_service.rs
+++ b/src/signalling/room_service.rs
@@ -10,7 +10,7 @@ use failure::Fail;
 use futures::future::{
     self, FutureExt as _, LocalBoxFuture, TryFutureExt as _,
 };
-use medea_client_api_proto::{Credentials, MemberId, RoomId};
+use medea_client_api_proto::{Credential, MemberId, RoomId};
 use medea_control_api_proto::grpc::api as proto;
 use redis::RedisError;
 
@@ -190,7 +190,7 @@ impl RoomService {
         &self,
         room_id: &RoomId,
         member_id: &MemberId,
-        credentials: &Credentials,
+        credentials: &Credential,
     ) -> String {
         format!(
             "{}/{}/{}/{}",

--- a/src/signalling/room_service.rs
+++ b/src/signalling/room_service.rs
@@ -10,7 +10,7 @@ use failure::Fail;
 use futures::future::{
     self, FutureExt as _, LocalBoxFuture, TryFutureExt as _,
 };
-use medea_client_api_proto::MemberId;
+use medea_client_api_proto::{Credentials, MemberId, RoomId};
 use medea_control_api_proto::grpc::api as proto;
 use redis::RedisError;
 
@@ -19,7 +19,7 @@ use crate::{
         endpoints::EndpointSpec,
         load_static_specs_from_dir,
         refs::{Fid, StatefulFid, ToMember, ToRoom},
-        EndpointId, LoadStaticControlSpecsError, MemberSpec, RoomId, RoomSpec,
+        EndpointId, LoadStaticControlSpecsError, MemberSpec, RoomSpec,
         TryFromElementError,
     },
     log::prelude::*,
@@ -196,7 +196,7 @@ impl RoomService {
         &self,
         room_id: &RoomId,
         member_id: &MemberId,
-        credentials: &str,
+        credentials: &Credentials,
     ) -> String {
         format!(
             "{}/{}/{}/{}",

--- a/src/turn/allocation_event.rs
+++ b/src/turn/allocation_event.rs
@@ -3,9 +3,7 @@
 use std::{borrow::Cow, collections::HashMap, time::Duration};
 
 use derive_more::Display;
-use medea_client_api_proto::PeerId;
-
-use crate::api::control::RoomId;
+use medea_client_api_proto::{PeerId, RoomId};
 
 /// Errors of [`CoturnEvent`] parsing.
 #[derive(Debug, Display)]

--- a/src/turn/mod.rs
+++ b/src/turn/mod.rs
@@ -9,9 +9,7 @@ pub mod repo;
 pub mod service;
 
 use derive_more::Display;
-use medea_client_api_proto::PeerId;
-
-use crate::api::control::RoomId;
+use medea_client_api_proto::{PeerId, RoomId};
 
 #[doc(inline)]
 pub use self::service::{

--- a/src/turn/service.rs
+++ b/src/turn/service.rs
@@ -8,12 +8,11 @@ use std::{fmt, sync::Arc};
 use async_trait::async_trait;
 use derive_more::{Display, From};
 use failure::Fail;
-use medea_client_api_proto::PeerId;
+use medea_client_api_proto::{PeerId, RoomId};
 use rand::{distributions::Alphanumeric, Rng};
 use redis::ConnectionInfo;
 
 use crate::{
-    api::control::RoomId,
     conf,
     media::IceUser,
     turn::{


### PR DESCRIPTION
Part of #27

Required for #147




## Synopsis

In #147 we need to use `RoomId` and `Credentials` on the Jason side, so it was decided to move this newtypes from `medea` crate to the `medea-client-api-proto`.




## Solution

Move `RoomId` to the `medea-client-api-proto` and use this newtype instead of old newtype.

Add `Credentials` newtype to the `medea-client-api-proto` and use it.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
