### PR TITLE
Derive (de)serialization in medea-client-api-proto (#27)

### DIFF
--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -88,7 +88,7 @@ impl_incrementable!(PeerId);
 impl_incrementable!(TrackId);
 
 // TODO: should be properly shared between medea and jason
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "msg", content = "data")]
 /// Message sent by `Media Server` to `Client`.
 pub enum ServerMsg {
@@ -121,7 +121,7 @@ pub struct RpcSettings {
 }
 
 #[cfg_attr(test, derive(PartialEq))]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "msg", content = "data")]
 /// Message from 'Client' to 'Media Server'.
 pub enum ClientMsg {

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -25,11 +25,11 @@
 
 pub mod stats;
 
-use std::{collections::HashMap, convert::TryInto as _};
+use std::collections::HashMap;
 
 use derive_more::{Constructor, Display, From};
 use medea_macro::dispatchable;
-use serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use self::stats::RtcStat;
 
@@ -648,87 +648,6 @@ pub enum ConnectionQualityScore {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn command() {
-        let mut mids = HashMap::new();
-        mids.insert(TrackId(0), String::from("1"));
-
-        let command = ClientMsg::Command(Command::MakeSdpOffer {
-            peer_id: PeerId(77),
-            sdp_offer: "offer".to_owned(),
-            mids,
-            transceivers_statuses: HashMap::new(),
-        });
-        #[cfg_attr(nightly, rustfmt::skip)]
-            let command_str =
-            "{\
-                \"command\":\"MakeSdpOffer\",\
-                \"data\":{\
-                    \"peer_id\":77,\
-                    \"sdp_offer\":\"offer\",\
-                    \"mids\":{\"0\":\"1\"},\
-                    \"transceivers_statuses\":{}\
-                }\
-            }";
-
-        assert_eq!(command_str, serde_json::to_string(&command).unwrap());
-        assert_eq!(
-            command,
-            serde_json::from_str(&serde_json::to_string(&command).unwrap())
-                .unwrap()
-        );
-    }
-
-    #[test]
-    fn ping() {
-        let ping = ServerMsg::Ping(15);
-        let ping_str = "{\"ping\":15}";
-
-        assert_eq!(ping_str, serde_json::to_string(&ping).unwrap());
-        assert_eq!(
-            ping,
-            serde_json::from_str(&serde_json::to_string(&ping).unwrap())
-                .unwrap()
-        )
-    }
-
-    #[test]
-    fn event() {
-        let event = ServerMsg::Event(Event::SdpAnswerMade {
-            peer_id: PeerId(45),
-            sdp_answer: "answer".to_owned(),
-        });
-        #[cfg_attr(nightly, rustfmt::skip)]
-            let event_str =
-            "{\
-                \"event\":\"SdpAnswerMade\",\
-                \"data\":{\
-                    \"peer_id\":45,\
-                    \"sdp_answer\":\"answer\"\
-                }\
-            }";
-
-        assert_eq!(event_str, serde_json::to_string(&event).unwrap());
-        assert_eq!(
-            event,
-            serde_json::from_str(&serde_json::to_string(&event).unwrap())
-                .unwrap()
-        );
-    }
-
-    #[test]
-    fn pong() {
-        let pong = ClientMsg::Pong(5);
-        let pong_str = "{\"pong\":5}";
-
-        assert_eq!(pong_str, serde_json::to_string(&pong).unwrap());
-        assert_eq!(
-            pong,
-            serde_json::from_str(&serde_json::to_string(&pong).unwrap())
-                .unwrap()
-        )
-    }
 
     #[test]
     fn track_patch_merge() {

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -87,8 +87,9 @@ impl_incrementable!(PeerId);
 #[cfg(feature = "medea")]
 impl_incrementable!(TrackId);
 
-// TODO: should be properly shared between medea and jason
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "medea", derive(Serialize))]
+#[cfg_attr(feature = "jason", derive(Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[serde(tag = "msg", content = "data")]
 /// Message sent by `Media Server` to `Client`.
 pub enum ServerMsg {
@@ -120,8 +121,10 @@ pub struct RpcSettings {
     pub ping_interval_ms: u32,
 }
 
+#[cfg_attr(feature = "medea", derive(Deserialize))]
+#[cfg_attr(feature = "jason", derive(Serialize))]
 #[cfg_attr(test, derive(PartialEq))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 #[serde(tag = "msg", content = "data")]
 /// Message from 'Client' to 'Media Server'.
 pub enum ClientMsg {

--- a/src/api/client/session.rs
+++ b/src/api/client/session.rs
@@ -291,7 +291,7 @@ impl Actor for WsSession {
                     Ok(_) => {
                         // send RpcSettings
                         let rpc_settings_message =
-                            serde_json::to_string(&this.get_rpc_settings())
+                            serde_json::to_string(&ServerMsg::RpcSettings(this.get_rpc_settings()))
                                 .unwrap();
                         ctx.text(rpc_settings_message);
 


### PR DESCRIPTION
Part of #27

Required for #147




## Synopsis

In #147 we extend `SeverMsg` and `ClientMsg` structs and custom (de)serializers starts to be complicated, so it was decided to start using `#[derive(Serialize, Deserialize)]`.

### Comparing previous (de)serialization version with new

#### `ServerMsg::RpcSettings`

##### Before

```json
{
    "idle_timeout_ms": 10000,
    "ping_interval_ms": 3000
}
```

##### After

```json
{
    "msg": "RpcSettings",
    "data": {
        "idle_timeout_ms": 10000,
        "ping_interval_ms": 3000
    }
}
```

#### `ServerMsg::Ping`

##### Before

```json
{
    "ping": 0
}
```

##### After

```json
{
    "msg": "Ping",
    "data": 0
}
```

#### `ServerMsg::Event`

##### Before

```json
{
    "event": "ConnectionQualityUpdated",
    "data": {
        "partner_member_id": "Velda",
        "quality_score": "High"
    }
}
```

##### After

```json
{
    "msg": "Event",
    "data": {
        "event": "ConnectionQualityUpdated",
        "data": {
            "partner_member_id": "Henri",
            "quality_score": "High"
        }
    }
}
```




## Solution

Remove `Serialize` and `Deserialize` implementations for the `ServerMsg` and `ClientMsg`.

Add `#[derive(Serialize, Deserialize)]` for the `ServerMsg` and `ClientMsg`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
