### PR TITLE
Extend muting and unmuting send video test (#27)

### DIFF
--- a/jason/src/peer/media/mod.rs
+++ b/jason/src/peer/media/mod.rs
@@ -352,10 +352,16 @@ impl MediaConnections {
     /// Returns `true` if all [`Sender`]s with
     /// [`MediaKind::Video`] are enabled or `false` otherwise.
     #[cfg(feature = "mockable")]
-    pub fn is_send_video_enabled(&self) -> bool {
+    pub fn is_send_video_enabled(
+        &self,
+        source_kind: Option<MediaSourceKind>,
+    ) -> bool {
         self.0
             .borrow()
-            .iter_senders_with_kind_and_source_kind(MediaKind::Video, None)
+            .iter_senders_with_kind_and_source_kind(
+                MediaKind::Video,
+                source_kind,
+            )
             .find(|s| s.is_muted())
             .is_none()
     }

--- a/jason/src/peer/mod.rs
+++ b/jason/src/peer/mod.rs
@@ -529,8 +529,11 @@ impl PeerConnection {
 
     /// Returns `true` if all [`Sender`]s video tracks are enabled.
     #[cfg(feature = "mockable")]
-    pub fn is_send_video_enabled(&self) -> bool {
-        self.media_connections.is_send_video_enabled()
+    pub fn is_send_video_enabled(
+        &self,
+        source_kind: Option<MediaSourceKind>,
+    ) -> bool {
+        self.media_connections.is_send_video_enabled(source_kind)
     }
 
     /// Returns `true` if all [`Receiver`]s audio tracks are enabled.

--- a/jason/tests/api/room.rs
+++ b/jason/tests/api/room.rs
@@ -57,8 +57,7 @@ fn get_test_room(
 }
 
 async fn get_test_room_and_exist_peer(
-    audio_track: Track,
-    video_track: Track,
+    tracks: Vec<Track>,
     media_stream_settings: Option<MediaStreamSettings>,
 ) -> (Room, Rc<PeerConnection>) {
     let mut rpc = MockRpcClient::new();
@@ -107,7 +106,7 @@ async fn get_test_room_and_exist_peer(
         .unbounded_send(Event::PeerCreated {
             peer_id: PeerId(1),
             negotiation_role: NegotiationRole::Offerer,
-            tracks: vec![audio_track, video_track],
+            tracks,
             ice_servers: Vec::new(),
             force_relay: false,
         })
@@ -185,7 +184,8 @@ async fn error_inject_invalid_local_stream_into_room_on_exists_peer() {
     });
     let (audio_track, video_track) = get_test_required_tracks();
     let (room, _peer) =
-        get_test_room_and_exist_peer(audio_track, video_track, None).await;
+        get_test_room_and_exist_peer(vec![audio_track, video_track], None)
+            .await;
 
     let mut constraints = MediaStreamSettings::new();
     constraints.audio(AudioTrackConstraints::new());
@@ -213,7 +213,8 @@ async fn no_errors_if_track_not_provided_when_its_optional() {
         let (audio_track, video_track) =
             get_test_tracks(audio_required, video_required);
         let (room, _peer) =
-            get_test_room_and_exist_peer(audio_track, video_track, None).await;
+            get_test_room_and_exist_peer(vec![audio_track, video_track], None)
+                .await;
 
         let mut constraints = MediaStreamSettings::new();
         if add_audio {
@@ -436,8 +437,12 @@ mod disable_recv_tracks {
 
 /// Tests disabling tracks publishing.
 mod disable_send_tracks {
+    use medea_client_api_proto::{
+        AudioSettings, Direction, MediaSourceKind, MediaType, MemberId,
+        VideoSettings,
+    };
     use medea_jason::{
-        media::MediaKind,
+        media::{JsMediaSourceKind, MediaKind},
         peer::{StableMuteState, TrackDirection},
     };
 
@@ -447,8 +452,7 @@ mod disable_send_tracks {
     async fn mute_unmute_audio() {
         let (audio_track, video_track) = get_test_unrequired_tracks();
         let (room, peer) = get_test_room_and_exist_peer(
-            audio_track,
-            video_track,
+            vec![audio_track, video_track],
             Some(media_stream_settings(true, true)),
         )
         .await;
@@ -464,17 +468,107 @@ mod disable_send_tracks {
     async fn mute_unmute_video() {
         let (audio_track, video_track) = get_test_unrequired_tracks();
         let (room, peer) = get_test_room_and_exist_peer(
-            audio_track,
-            video_track,
+            vec![audio_track, video_track],
             Some(media_stream_settings(true, true)),
         )
         .await;
 
         let handle = room.new_handle();
         assert!(JsFuture::from(handle.mute_video(None)).await.is_ok());
-        assert!(!peer.is_send_video_enabled());
+        assert!(!peer.is_send_video_enabled(None));
         assert!(JsFuture::from(handle.unmute_video(None)).await.is_ok());
-        assert!(peer.is_send_video_enabled());
+        assert!(peer.is_send_video_enabled(None));
+    }
+
+    fn audio_track(track_id: TrackId, is_required: bool) -> Track {
+        Track {
+            id: track_id,
+            direction: Direction::Send {
+                receivers: vec![MemberId::from("bob")],
+                mid: None,
+            },
+            media_type: MediaType::Audio(AudioSettings { is_required }),
+        }
+    }
+
+    fn video_track(
+        track_id: TrackId,
+        is_required: bool,
+        source_kind: MediaSourceKind,
+    ) -> Track {
+        Track {
+            id: track_id,
+            direction: Direction::Send {
+                receivers: vec![MemberId::from("bob")],
+                mid: None,
+            },
+            media_type: MediaType::Video(VideoSettings {
+                is_required,
+                source_kind,
+            }),
+        }
+    }
+
+    #[wasm_bindgen_test]
+    async fn mute_unmute_device_video() {
+        let audio_track = audio_track(TrackId(1), false);
+        let device_video_track =
+            video_track(TrackId(2), false, MediaSourceKind::Device);
+        let display_video_track =
+            video_track(TrackId(3), false, MediaSourceKind::Display);
+
+        let (room, peer) = get_test_room_and_exist_peer(
+            vec![audio_track, device_video_track, display_video_track],
+            Some(media_stream_settings(true, true)),
+        )
+        .await;
+
+        let handle = room.new_handle();
+        assert!(JsFuture::from(
+            handle.mute_video(Some(JsMediaSourceKind::Device))
+        )
+        .await
+        .is_ok());
+        assert!(!peer.is_send_video_enabled(Some(MediaSourceKind::Device)));
+        assert!(peer.is_send_video_enabled(Some(MediaSourceKind::Display)));
+        assert!(JsFuture::from(
+            handle.unmute_video(Some(JsMediaSourceKind::Device))
+        )
+        .await
+        .is_ok());
+        assert!(peer.is_send_video_enabled(Some(MediaSourceKind::Device)));
+        assert!(peer.is_send_video_enabled(Some(MediaSourceKind::Display)));
+    }
+
+    #[wasm_bindgen_test]
+    async fn mute_unmute_display_video() {
+        let audio_track = audio_track(TrackId(1), false);
+        let device_video_track =
+            video_track(TrackId(2), false, MediaSourceKind::Device);
+        let display_video_track =
+            video_track(TrackId(3), false, MediaSourceKind::Display);
+
+        let (room, peer) = get_test_room_and_exist_peer(
+            vec![audio_track, device_video_track, display_video_track],
+            Some(media_stream_settings(true, true)),
+        )
+        .await;
+
+        let handle = room.new_handle();
+        assert!(JsFuture::from(
+            handle.mute_video(Some(JsMediaSourceKind::Display))
+        )
+        .await
+        .is_ok());
+        assert!(!peer.is_send_video_enabled(Some(MediaSourceKind::Display)));
+        assert!(peer.is_send_video_enabled(Some(MediaSourceKind::Device)));
+        assert!(JsFuture::from(
+            handle.unmute_video(Some(JsMediaSourceKind::Display))
+        )
+        .await
+        .is_ok());
+        assert!(peer.is_send_video_enabled(Some(MediaSourceKind::Display)));
+        assert!(peer.is_send_video_enabled(Some(MediaSourceKind::Device)));
     }
 
     /// Tests that two simultaneous calls of [`RoomHandle::mute_audio`] method
@@ -492,8 +586,7 @@ mod disable_send_tracks {
     async fn join_two_audio_mutes() {
         let (audio_track, video_track) = get_test_unrequired_tracks();
         let (room, peer) = get_test_room_and_exist_peer(
-            audio_track,
-            video_track,
+            vec![audio_track, video_track],
             Some(media_stream_settings(true, true)),
         )
         .await;
@@ -530,8 +623,7 @@ mod disable_send_tracks {
     async fn join_two_video_mutes() {
         let (audio_track, video_track) = get_test_unrequired_tracks();
         let (room, peer) = get_test_room_and_exist_peer(
-            audio_track,
-            video_track,
+            vec![audio_track, video_track],
             Some(media_stream_settings(true, true)),
         )
         .await;
@@ -570,8 +662,7 @@ mod disable_send_tracks {
     async fn join_mute_and_unmute_audio() {
         let (audio_track, video_track) = get_test_unrequired_tracks();
         let (room, peer) = get_test_room_and_exist_peer(
-            audio_track,
-            video_track,
+            vec![audio_track, video_track],
             Some(media_stream_settings(true, true)),
         )
         .await;
@@ -617,8 +708,7 @@ mod disable_send_tracks {
     async fn join_mute_and_unmute_video() {
         let (audio_track, video_track) = get_test_unrequired_tracks();
         let (room, peer) = get_test_room_and_exist_peer(
-            audio_track,
-            video_track,
+            vec![audio_track, video_track],
             Some(media_stream_settings(true, true)),
         )
         .await;
@@ -664,8 +754,7 @@ mod disable_send_tracks {
     async fn join_unmute_and_mute_audio() {
         let (audio_track, video_track) = get_test_unrequired_tracks();
         let (room, peer) = get_test_room_and_exist_peer(
-            audio_track,
-            video_track,
+            vec![audio_track, video_track],
             Some(media_stream_settings(true, true)),
         )
         .await;
@@ -749,7 +838,7 @@ mod disable_send_tracks {
         }
 
         let peer = room.get_peer_by_id(PeerId(1)).unwrap();
-        assert!(peer.is_send_video_enabled());
+        assert!(peer.is_send_video_enabled(None));
         assert!(!peer.is_send_audio_enabled());
     }
 
@@ -799,7 +888,7 @@ mod disable_send_tracks {
         }
 
         let peer = room.get_peer_by_id(PeerId(1)).unwrap();
-        assert!(!peer.is_send_video_enabled());
+        assert!(!peer.is_send_video_enabled(None));
         assert!(peer.is_send_audio_enabled());
     }
 }
@@ -1008,12 +1097,34 @@ mod patches_generation {
         AudioSettings, Direction, MediaSourceKind, MediaType, Track, TrackId,
         TrackPatchCommand, VideoSettings,
     };
-    use medea_jason::media::RecvConstraints;
+    use medea_jason::{media::RecvConstraints, JsMediaSourceKind};
     use wasm_bindgen_futures::spawn_local;
 
-    use crate::timeout;
+    use crate::{is_firefox, timeout};
 
     use super::*;
+
+    fn audio_and_device_video_tracks_content() -> Vec<(MediaType, Direction)> {
+        vec![
+            (
+                MediaType::Audio(AudioSettings { is_required: false }),
+                Direction::Send {
+                    receivers: Vec::new(),
+                    mid: None,
+                },
+            ),
+            (
+                MediaType::Video(VideoSettings {
+                    is_required: false,
+                    source_kind: MediaSourceKind::Device,
+                }),
+                Direction::Send {
+                    receivers: Vec::new(),
+                    mid: None,
+                },
+            ),
+        ]
+    }
 
     /// Returns [`Room`] with mocked [`PeerRepository`] with provided count of
     /// [`PeerConnection`]s and [`mpsc::UnboundedReceiver`] of [`Command`]s
@@ -1024,40 +1135,28 @@ mod patches_generation {
     async fn get_room_and_commands_receiver(
         peers_count: u32,
         audio_track_enabled_state_fn: impl Fn(u32) -> bool,
+        tracks_content: Vec<(MediaType, Direction)>,
     ) -> (Room, mpsc::UnboundedReceiver<Command>) {
         let mut repo = Box::new(MockPeerRepository::new());
 
         let mut peers = HashMap::new();
         for i in 0..peers_count {
             let (tx, _rx) = mpsc::unbounded();
-            let audio_track_id = TrackId(i + 1);
-            let video_track_id = TrackId(i + 2);
-            let audio_track = Track {
-                id: audio_track_id,
-                media_type: MediaType::Audio(AudioSettings {
-                    is_required: false,
-                }),
-                direction: Direction::Send {
-                    receivers: Vec::new(),
-                    mid: None,
-                },
-            };
-            let video_track = Track {
-                id: video_track_id,
-                media_type: MediaType::Video(VideoSettings {
-                    is_required: false,
-                    source_kind: MediaSourceKind::Device,
-                }),
-                direction: Direction::Send {
-                    receivers: Vec::new(),
-                    mid: None,
-                },
-            };
-            let tracks = vec![audio_track, video_track];
+            let tracks = tracks_content
+                .iter()
+                .enumerate()
+                .map(|(track_i, (media_type, direction))| {
+                    let track_i = (track_i as u32) + i;
+                    Track {
+                        id: TrackId(track_i),
+                        direction: direction.clone(),
+                        media_type: media_type.clone(),
+                    }
+                })
+                .collect();
             let peer_id = PeerId(i + 1);
 
             let mut local_stream = MediaStreamSettings::default();
-            local_stream.set_track_enabled(false, MediaKind::Video, None);
             local_stream.set_track_enabled(
                 (audio_track_enabled_state_fn)(i),
                 MediaKind::Audio,
@@ -1118,8 +1217,12 @@ mod patches_generation {
     ///    one [`TrackPatch`] for audio [`Track`].
     #[wasm_bindgen_test]
     async fn track_patch_for_all_video() {
-        let (room, mut command_rx) =
-            get_room_and_commands_receiver(1, |_| true).await;
+        let (room, mut command_rx) = get_room_and_commands_receiver(
+            1,
+            |_| true,
+            audio_and_device_video_tracks_content(),
+        )
+        .await;
         let room_handle = room.new_handle();
 
         spawn_local(async move {
@@ -1131,7 +1234,7 @@ mod patches_generation {
             Command::UpdateTracks {
                 peer_id: PeerId(1),
                 tracks_patches: vec![TrackPatchCommand {
-                    id: TrackId(1),
+                    id: TrackId(0),
                     is_muted: Some(true),
                 }]
             }
@@ -1153,8 +1256,12 @@ mod patches_generation {
     ///    unmuted [`PeerConnection`]s. [`PeerConnection`]s.
     #[wasm_bindgen_test]
     async fn track_patch_for_many_tracks() {
-        let (room, mut command_rx) =
-            get_room_and_commands_receiver(2, |_| true).await;
+        let (room, mut command_rx) = get_room_and_commands_receiver(
+            2,
+            |_| true,
+            audio_and_device_video_tracks_content(),
+        )
+        .await;
         let room_handle = room.new_handle();
 
         spawn_local(async move {
@@ -1178,7 +1285,7 @@ mod patches_generation {
         assert_eq!(
             commands.remove(&PeerId(1)).unwrap(),
             vec![TrackPatchCommand {
-                id: TrackId(1),
+                id: TrackId(0),
                 is_muted: Some(true),
             }]
         );
@@ -1186,7 +1293,7 @@ mod patches_generation {
         assert_eq!(
             commands.remove(&PeerId(2)).unwrap(),
             vec![TrackPatchCommand {
-                id: TrackId(2),
+                id: TrackId(1),
                 is_muted: Some(true),
             }]
         );
@@ -1206,8 +1313,12 @@ mod patches_generation {
     ///    [`RpcClient`].
     #[wasm_bindgen_test]
     async fn try_to_unmute_unmuted() {
-        let (room, mut command_rx) =
-            get_room_and_commands_receiver(2, |_| true).await;
+        let (room, mut command_rx) = get_room_and_commands_receiver(
+            2,
+            |_| true,
+            audio_and_device_video_tracks_content(),
+        )
+        .await;
         let room_handle = room.new_handle();
 
         spawn_local(async move {
@@ -1231,8 +1342,12 @@ mod patches_generation {
     ///    unmuted [`PeerConnection`].
     #[wasm_bindgen_test]
     async fn mute_room_with_one_muted_track() {
-        let (room, mut command_rx) =
-            get_room_and_commands_receiver(2, |i| i % 2 == 1).await;
+        let (room, mut command_rx) = get_room_and_commands_receiver(
+            2,
+            |i| i % 2 == 1,
+            audio_and_device_video_tracks_content(),
+        )
+        .await;
         let room_handle = room.new_handle();
 
         spawn_local(async move {
@@ -1243,6 +1358,90 @@ mod patches_generation {
             command_rx.next().await.unwrap(),
             Command::UpdateTracks {
                 peer_id: PeerId(2),
+                tracks_patches: vec![TrackPatchCommand {
+                    id: TrackId(1),
+                    is_muted: Some(true),
+                }]
+            }
+        );
+    }
+
+    #[wasm_bindgen_test]
+    async fn mute_device_video() {
+        if is_firefox() {
+            return;
+        }
+
+        let mut tracks = audio_and_device_video_tracks_content();
+        tracks.push((
+            MediaType::Video(VideoSettings {
+                source_kind: MediaSourceKind::Display,
+                is_required: false,
+            }),
+            Direction::Send {
+                mid: None,
+                receivers: vec![],
+            },
+        ));
+        let (room, mut command_rx) =
+            get_room_and_commands_receiver(2, |_| true, tracks).await;
+
+        let room_handle = room.new_handle();
+
+        spawn_local(async move {
+            JsFuture::from(
+                room_handle.mute_video(Some(JsMediaSourceKind::Device)),
+            )
+            .await
+            .unwrap_err();
+        });
+
+        assert_eq!(
+            command_rx.next().await.unwrap(),
+            Command::UpdateTracks {
+                peer_id: PeerId(2),
+                tracks_patches: vec![TrackPatchCommand {
+                    id: TrackId(2),
+                    is_muted: Some(true),
+                }]
+            }
+        );
+    }
+
+    #[wasm_bindgen_test]
+    async fn mute_display_video() {
+        if is_firefox() {
+            return;
+        }
+
+        let mut tracks = audio_and_device_video_tracks_content();
+        tracks.push((
+            MediaType::Video(VideoSettings {
+                source_kind: MediaSourceKind::Display,
+                is_required: false,
+            }),
+            Direction::Send {
+                mid: None,
+                receivers: vec![],
+            },
+        ));
+        let (room, mut command_rx) =
+            get_room_and_commands_receiver(2, |_| true, tracks).await;
+
+        let room_handle = room.new_handle();
+
+        spawn_local(async move {
+            JsFuture::from(
+                room_handle.mute_video(Some(JsMediaSourceKind::Display)),
+            )
+            .await
+            .unwrap_err();
+        });
+
+        assert_eq!(
+            command_rx.next().await.unwrap(),
+            Command::UpdateTracks {
+                peer_id: PeerId(1),
                 tracks_patches: vec![TrackPatchCommand {
                     id: TrackId(2),
                     is_muted: Some(true),
@@ -1257,8 +1456,7 @@ mod patches_generation {
 async fn remote_mute_unmute_audio() {
     let (audio_track, video_track) = get_test_recv_tracks();
     let (room, peer) = get_test_room_and_exist_peer(
-        audio_track,
-        video_track,
+        vec![audio_track, video_track],
         Some(media_stream_settings(true, true)),
     )
     .await;
@@ -1275,8 +1473,7 @@ async fn remote_mute_unmute_audio() {
 async fn remote_mute_unmute_video() {
     let (audio_track, video_track) = get_test_recv_tracks();
     let (room, peer) = get_test_room_and_exist_peer(
-        audio_track,
-        video_track,
+        vec![audio_track, video_track],
         Some(media_stream_settings(true, true)),
     )
     .await;

--- a/jason/tests/api/room.rs
+++ b/jason/tests/api/room.rs
@@ -509,6 +509,9 @@ mod disable_send_tracks {
         }
     }
 
+    /// Tests that when [`JsMediaSouceKind::Device`] is provided to the
+    /// [`RoomHandle::mute_video`] and [`RoomHandle::unmute_video`], the
+    /// only device video will be muted/unmuted.
     #[wasm_bindgen_test]
     async fn mute_unmute_device_video() {
         let audio_track = audio_track(TrackId(1), false);
@@ -540,6 +543,9 @@ mod disable_send_tracks {
         assert!(peer.is_send_video_enabled(Some(MediaSourceKind::Display)));
     }
 
+    /// Tests that when [`JsMediaSouceKind::Display`] is provided to the
+    /// [`RoomHandle::mute_video`] and [`RoomHandle::unmute_video`], the
+    /// only display video will be muted/unmuted.
     #[wasm_bindgen_test]
     async fn mute_unmute_display_video() {
         let audio_track = audio_track(TrackId(1), false);
@@ -1366,6 +1372,10 @@ mod patches_generation {
         );
     }
 
+    /// Checks that on device video muting, correct [`Command::UpdateTracks`]
+    /// will be sent to the `Media Server`.
+    ///
+    /// This test will be ignore in Firefox browser.
     #[wasm_bindgen_test]
     async fn mute_device_video() {
         if is_firefox() {
@@ -1408,6 +1418,10 @@ mod patches_generation {
         );
     }
 
+    /// Checks that on display video muting, correct [`Command::UpdateTracks`]
+    /// will be sent to the `Media Server`.
+    ///
+    /// This test will be ignore in Firefox browser.
     #[wasm_bindgen_test]
     async fn mute_display_video() {
         if is_firefox() {

--- a/jason/tests/peer/mod.rs
+++ b/jason/tests/peer/mod.rs
@@ -71,17 +71,17 @@ async fn mute_unmute_audio() {
         .unwrap();
 
     assert!(peer.is_send_audio_enabled());
-    assert!(peer.is_send_video_enabled());
+    assert!(peer.is_send_video_enabled(None));
 
     peer.patch_tracks(toggle_mute_tracks_updates(&[AUDIO_TRACK_ID], true))
         .unwrap();
     assert!(!peer.is_send_audio_enabled());
-    assert!(peer.is_send_video_enabled());
+    assert!(peer.is_send_video_enabled(None));
 
     peer.patch_tracks(toggle_mute_tracks_updates(&[AUDIO_TRACK_ID], false))
         .unwrap();
     assert!(peer.is_send_audio_enabled());
-    assert!(peer.is_send_video_enabled());
+    assert!(peer.is_send_video_enabled(None));
 }
 
 #[wasm_bindgen_test]
@@ -104,17 +104,17 @@ async fn mute_unmute_video() {
         .unwrap();
 
     assert!(peer.is_send_audio_enabled());
-    assert!(peer.is_send_video_enabled());
+    assert!(peer.is_send_video_enabled(None));
 
     peer.patch_tracks(toggle_mute_tracks_updates(&[VIDEO_TRACK_ID], true))
         .unwrap();
     assert!(peer.is_send_audio_enabled());
-    assert!(!peer.is_send_video_enabled());
+    assert!(!peer.is_send_video_enabled(None));
 
     peer.patch_tracks(toggle_mute_tracks_updates(&[VIDEO_TRACK_ID], false))
         .unwrap();
     assert!(peer.is_send_audio_enabled());
-    assert!(peer.is_send_video_enabled());
+    assert!(peer.is_send_video_enabled(None));
 }
 
 #[wasm_bindgen_test]
@@ -138,7 +138,7 @@ async fn new_with_mute_audio() {
         .unwrap();
     assert!(!peer.is_send_audio_enabled());
 
-    assert!(peer.is_send_video_enabled());
+    assert!(peer.is_send_video_enabled(None));
 }
 
 #[wasm_bindgen_test]
@@ -161,7 +161,7 @@ async fn new_with_mute_video() {
         .unwrap();
 
     assert!(peer.is_send_audio_enabled());
-    assert!(!peer.is_send_video_enabled());
+    assert!(!peer.is_send_video_enabled(None));
 }
 
 #[wasm_bindgen_test]

--- a/jason/tests/web.rs
+++ b/jason/tests/web.rs
@@ -91,7 +91,8 @@ use medea_jason::{
         LocalTracksConstraints, MediaKind, MediaManager, MediaStreamTrack,
     },
     utils::{window, JasonError},
-    AudioTrackConstraints, DeviceVideoTrackConstraints, MediaStreamSettings,
+    AudioTrackConstraints, DeviceVideoTrackConstraints,
+    DisplayVideoTrackConstraints, MediaStreamSettings,
 };
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -229,6 +230,7 @@ fn media_stream_settings(
     }
     if is_video_enabled {
         settings.device_video(DeviceVideoTrackConstraints::default());
+        settings.display_video(DisplayVideoTrackConstraints::default());
     }
 
     settings

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -573,8 +573,9 @@ pub struct IceServer {
 }
 
 /// Direction of [`Track`].
-#[cfg_attr(feature = "medea", derive(Clone, Debug, Eq, PartialEq, Serialize))]
+#[cfg_attr(feature = "medea", derive(Eq, PartialEq, Serialize))]
 #[cfg_attr(feature = "jason", derive(Deserialize))]
+#[derive(Clone, Debug)]
 // TODO: Use different struct without mids in TracksApplied event.
 pub enum Direction {
     Send {
@@ -588,8 +589,9 @@ pub enum Direction {
 }
 
 /// Type of [`Track`].
-#[cfg_attr(feature = "medea", derive(Clone, Debug, Eq, PartialEq, Serialize))]
+#[cfg_attr(feature = "medea", derive(Eq, PartialEq, Serialize))]
 #[cfg_attr(feature = "jason", derive(Deserialize))]
+#[derive(Clone, Debug)]
 pub enum MediaType {
     Audio(AudioSettings),
     Video(VideoSettings),
@@ -606,8 +608,9 @@ impl MediaType {
     }
 }
 
-#[cfg_attr(feature = "medea", derive(Clone, Debug, Eq, PartialEq, Serialize))]
+#[cfg_attr(feature = "medea", derive(Eq, PartialEq, Serialize))]
 #[cfg_attr(feature = "jason", derive(Deserialize))]
+#[derive(Clone, Debug)]
 pub struct AudioSettings {
     /// Importance of the audio media type.
     ///
@@ -615,8 +618,9 @@ pub struct AudioSettings {
     pub is_required: bool,
 }
 
-#[cfg_attr(feature = "medea", derive(Clone, Debug, Eq, PartialEq, Serialize))]
+#[cfg_attr(feature = "medea", derive(Eq, PartialEq, Serialize))]
 #[cfg_attr(feature = "jason", derive(Deserialize))]
+#[derive(Clone, Debug)]
 pub struct VideoSettings {
     /// Importance of the video media type.
     ///


### PR DESCRIPTION
Related to #144




## Synopsis

Tests tests for the device/display muting/unmuting.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
