### PR TITLE
Wait for OnJoin callback result when accepting RpcConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ All user visible changes to this project will be documented in this file. This p
         - `Create` method for `Room`, `Member`, `Endpoint`;
         - `Get` method for `Room`, `Member`, `Endpoint`;
         - `Delete` method for `Room`, `Member`, `Endpoint`.
-    - gRPC Control API callbacks ([#63]):
-        - `on_join`;
-        - `on_leave`.
+    - gRPC Control API callbacks:
+        - `on_join` ([#63], [#153]);
+        - `on_leave` ([#63]).
     - Configuration of `Member`'s Client API RPC settings ([#95]).
 - Signalling:
     - Dynamic `Peer`s creation when client connects ([#28]);
@@ -81,7 +81,7 @@ All user visible changes to this project will be documented in this file. This p
 [#132]: /../../pull/132
 [#135]: /../../pull/135
 [#138]: /../../pull/138
-
+[#153]: /../../pull/153
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+
 ## [0.1.0] · 2019-08-22
 [0.1.0]: /../../tree/medea-0.1.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
  "pin-project",
  "rand 0.7.3",
  "regex",
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde_json",
  "serde_urlencoded",
  "sha-1",
@@ -149,7 +149,7 @@ dependencies = [
  "http",
  "log",
  "regex",
- "serde 1.0.116",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -288,7 +288,7 @@ dependencies = [
  "mime",
  "pin-project",
  "regex",
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde_json",
  "serde_urlencoded",
  "socket2",
@@ -419,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fefeb39da249f4c33af940b779a56723ce45809ef5c54dad84bb538d4ffb6d9e"
+checksum = "0659b83a146398616883aa5199cdd1b055ec088a83c9a338eab3534f33f0622e"
 dependencies = [
  "async-executor",
  "async-io",
@@ -565,7 +565,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "rand 0.7.3",
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde_json",
  "serde_urlencoded",
 ]
@@ -784,7 +784,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -962,7 +962,7 @@ dependencies = [
  "config",
  "crossbeam-queue",
  "num_cpus",
- "serde 1.0.116",
+ "serde 1.0.117",
  "tokio",
 ]
 
@@ -978,7 +978,7 @@ dependencies = [
  "futures 0.3.6",
  "log",
  "redis",
- "serde 1.0.116",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -1494,7 +1494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
 dependencies = [
  "humantime",
- "serde 1.0.116",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -1755,7 +1755,7 @@ dependencies = [
  "rand 0.7.3",
  "redis",
  "rust-crypto",
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde_json",
  "serde_yaml",
  "serial_test",
@@ -1780,7 +1780,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "medea-macro",
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde_json",
  "serde_with",
 ]
@@ -1799,7 +1799,7 @@ dependencies = [
  "humantime-serde",
  "medea-control-api-proto",
  "protobuf",
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde_json",
  "slog",
  "slog-async",
@@ -1853,7 +1853,7 @@ dependencies = [
  "medea-reactive",
  "mockall",
  "predicates-tree",
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde_json",
  "tracerr",
  "wasm-bindgen",
@@ -2629,9 +2629,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 dependencies = [
  "serde_derive",
 ]
@@ -2651,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2668,7 +2668,7 @@ checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.116",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -2688,7 +2688,7 @@ checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
  "dtoa",
  "itoa",
- "serde 1.0.116",
+ "serde 1.0.117",
  "url",
 ]
 
@@ -2698,7 +2698,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bac272128fb3b1e98872dca27a05c18d8b78b9bd089d3edb7b5871501b50bce"
 dependencies = [
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde_with_macros",
 ]
 
@@ -2722,7 +2722,7 @@ checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
 dependencies = [
  "dtoa",
  "linked-hash-map 0.5.3",
- "serde 1.0.116",
+ "serde 1.0.117",
  "yaml-rust",
 ]
 
@@ -2823,7 +2823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
 dependencies = [
  "chrono",
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde_json",
  "slog",
 ]
@@ -2930,7 +2930,7 @@ checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde_derive",
  "syn 1.0.44",
 ]
@@ -2944,7 +2944,7 @@ dependencies = [
  "base-x",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde_derive",
  "serde_json",
  "sha1",
@@ -3205,7 +3205,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
- "serde 1.0.116",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -3644,7 +3644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if 0.1.10",
- "serde 1.0.116",
+ "serde 1.0.117",
  "serde_json",
  "wasm-bindgen-macro",
 ]

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -358,7 +358,7 @@ pub enum CloseReason {
 /// to Web Client.
 ///
 /// [Close]: https://tools.ietf.org/html/rfc6455#section-5.5.1
-#[derive(Constructor, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Constructor, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CloseDescription {
     /// Reason of why WebSocket connection has been closed.
     pub reason: CloseReason,

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -358,7 +358,7 @@ pub enum CloseReason {
 /// to Web Client.
 ///
 /// [Close]: https://tools.ietf.org/html/rfc6455#section-5.5.1
-#[derive(Constructor, Debug, Deserialize, Serialize)]
+#[derive(Constructor, Debug, Deserialize, PartialEq, Serialize)]
 pub struct CloseDescription {
     /// Reason of why WebSocket connection has been closed.
     pub reason: CloseReason,

--- a/src/api/client/rpc_connection.rs
+++ b/src/api/client/rpc_connection.rs
@@ -42,6 +42,7 @@ pub struct EventMessage(Event);
 /// Abstraction over RPC connection with some remote [`Member`].
 ///
 /// [`Member`]: crate::signalling::elements::member::Member
+#[cfg_attr(test, mockall::automock)]
 pub trait RpcConnection: fmt::Debug + Send {
     /// Closes [`RpcConnection`] and sends [`CloseDescription`] to the client
     /// (in WebSocket implementation description will be sent in a [Close]
@@ -60,6 +61,9 @@ pub trait RpcConnection: fmt::Debug + Send {
     /// [`Member`]: crate::signalling::elements::member::Member
     fn send_event(&self, msg: Event);
 }
+
+#[cfg(test)]
+impl_debug_by_struct_name!(MockRpcConnection);
 
 /// Settings of [`WsSession`].
 #[derive(Clone, Copy, Debug)]

--- a/src/api/control/callback/clients/grpc.rs
+++ b/src/api/control/callback/clients/grpc.rs
@@ -60,3 +60,76 @@ impl fmt::Debug for GrpcCallbackClient {
             .finish()
     }
 }
+
+#[cfg(test)]
+pub mod test {
+    use std::net::ToSocketAddrs;
+
+    use actix::Arbiter;
+    use futures::{channel::oneshot, task, FutureExt as _, TryFutureExt as _};
+    use medea_control_api_proto::grpc::callback::{
+        callback_server::{Callback, CallbackServer as TonicCallbackServer},
+        on_leave::Reason,
+        request::Event,
+        Request, Response,
+    };
+    use tonic::{transport::Server, Status};
+
+    #[mockall::automock]
+    pub trait GrpcCallbackServer {
+        fn on_join(&self, fid: &str) -> Result<(), ()>;
+        fn on_leave(&self, fid: &str, event: Reason) -> Result<(), ()>;
+    }
+
+    #[async_trait::async_trait]
+    impl Callback for MockGrpcCallbackServer {
+        async fn on_event(
+            &self,
+            request: tonic::Request<Request>,
+        ) -> Result<tonic::Response<Response>, Status> {
+            let request = request.into_inner();
+            match request.event.unwrap() {
+                Event::OnJoin(_) => self.on_join(&request.fid),
+                Event::OnLeave(on_leave) => self.on_leave(
+                    &request.fid,
+                    Reason::from_i32(on_leave.reason).unwrap(),
+                ),
+            }
+            .map(|_| tonic::Response::new(Response {}))
+            .map_err(|_| Status::internal(""))
+        }
+    }
+
+    /// Callback gRPC server close handle.
+    pub struct CloseHandle(oneshot::Sender<()>);
+
+    /// Starts [`CallbackServer`] registering provided mock as callback handler.
+    pub async fn start_callback_server<A: ToSocketAddrs>(
+        addr: A,
+        callback: MockGrpcCallbackServer,
+    ) -> CloseHandle {
+        let (close_tx, close_rx) = oneshot::channel();
+        let addr = addr.to_socket_addrs().unwrap().next().unwrap();
+
+        let server = Server::builder()
+            .add_service(TonicCallbackServer::new(callback))
+            .serve_with_shutdown(addr, async move {
+                close_rx.await.ok();
+            })
+            .map_err(|err| err.to_string())
+            .shared();
+
+        // Poll server here to proc socket binding to make sure that server is
+        // ready when this function returns.
+        if let task::Poll::Ready(maybe_err) =
+            futures::poll!(server.clone().boxed())
+        {
+            maybe_err.unwrap();
+        }
+
+        Arbiter::spawn(async move {
+            server.await.unwrap();
+        });
+        CloseHandle(close_tx)
+    }
+}

--- a/src/api/control/callback/clients/mod.rs
+++ b/src/api/control/callback/clients/mod.rs
@@ -5,7 +5,7 @@ pub mod grpc;
 use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
-use derive_more::From;
+use derive_more::{Display, From};
 use futures::future::{FutureExt, LocalBoxFuture};
 
 use crate::{
@@ -16,12 +16,14 @@ use crate::{
 type Result<T> = std::result::Result<T, CallbackClientError>;
 
 /// Error of sending [`CallbackRequest`] by [`CallbackClient`].
-#[derive(Debug, From)]
+#[derive(Debug, Display, From)]
 pub enum CallbackClientError {
     /// [`tonic`] failed to send [`CallbackRequest`].
+    #[display(fmt = "gRPC request failed: {}", _0)]
     Tonic(tonic::Status),
 
     /// Error while creating new [`CallbackClient`].
+    #[display(fmt = "CallbackClientError: {}", _0)]
     TonicTransport(tonic::transport::Error),
 }
 

--- a/src/api/control/callback/mod.rs
+++ b/src/api/control/callback/mod.rs
@@ -13,10 +13,8 @@ use crate::api::control::refs::StatefulFid;
 
 #[doc(inline)]
 pub use self::{
-    service::{
-        CallbackService
-    },
-    clients::{CallbackClientFactoryImpl, CallbackClientError}
+    clients::{CallbackClientError, CallbackClientFactoryImpl},
+    service::CallbackService,
 };
 
 /// Event for `on_leave` `Member` callback.

--- a/src/api/control/callback/mod.rs
+++ b/src/api/control/callback/mod.rs
@@ -6,11 +6,18 @@ pub mod url;
 
 use actix::Message;
 use chrono::{DateTime, Utc};
-use clients::CallbackClientError;
 use derive_more::{Display, From};
 use medea_control_api_proto::grpc::callback as proto;
 
 use crate::api::control::refs::StatefulFid;
+
+#[doc(inline)]
+pub use self::{
+    service::{
+        CallbackService
+    },
+    clients::{CallbackClientFactoryImpl, CallbackClientError}
+};
 
 /// Event for `on_leave` `Member` callback.
 #[derive(Debug)]

--- a/src/api/control/callback/service.rs
+++ b/src/api/control/callback/service.rs
@@ -78,7 +78,7 @@ impl<B: CallbackClientFactory + 'static> CallbackService<B> {
         Ok(())
     }
 
-    /// Sends [`CallbackEvent`] for provided [`StatefulFid`] to
+    /// Asynchronously sends [`CallbackEvent`] for provided [`StatefulFid`] to
     /// [`CallbackClient`] and waits for a response.
     ///
     /// Will use existing [`CallbackClient`] or create new.
@@ -97,7 +97,7 @@ impl<B: CallbackClientFactory + 'static> CallbackService<B> {
             .await
     }
 
-    /// Sends [`CallbackEvent`] for provided [`StatefulFid`] to
+    /// Asynchronously sends [`CallbackEvent`] for provided [`StatefulFid`] to
     /// [`CallbackClient`] ignoring any potential errors.
     ///
     /// Will use existing [`CallbackClient`] or create new.

--- a/src/api/control/callback/service.rs
+++ b/src/api/control/callback/service.rs
@@ -82,13 +82,19 @@ impl<B: CallbackClientFactory + 'static> CallbackService<B> {
     /// [`CallbackClient`] and waits for a response.
     ///
     /// Will use existing [`CallbackClient`] or create new.
+    ///
+    /// ## Errors
+    ///
+    /// With [`CallbackClientError`] if any errors happen during client creation
+    /// or request execution.
     pub async fn send<T: Into<CallbackEvent> + 'static>(
         &self,
         callback_url: CallbackUrl,
         fid: StatefulFid,
         event: T,
     ) -> Result<(), CallbackClientError> {
-        self.inner_send(CallbackRequest::new(fid, event.into()), callback_url).await
+        self.inner_send(CallbackRequest::new(fid, event.into()), callback_url)
+            .await
     }
 
     /// Sends [`CallbackEvent`] for provided [`StatefulFid`] to
@@ -170,9 +176,7 @@ mod tests {
             .map(|_| callback_service.clone())
             .map(|service| {
                 async move {
-                    service
-                        .inner_send(callback_request(), callback_url())
-                        .await
+                    service.inner_send(callback_request(), callback_url()).await
                 }
                 .boxed_local()
             })

--- a/src/api/control/callback/url.rs
+++ b/src/api/control/callback/url.rs
@@ -12,9 +12,8 @@ use url::{ParseError, Url};
 /// without anything else (protocol e.g.).
 ///
 /// In [`Display`] implementation protocol will be added to this address.
-#[derive(Clone, Debug, Display, Eq, PartialEq, Hash, From)]
+#[derive(Clone, Debug, Display, Eq, PartialEq, Hash)]
 #[display(fmt = "grpc://{}", _0)]
-#[from(forward)]
 pub struct GrpcCallbackUrl(String);
 
 impl GrpcCallbackUrl {

--- a/src/api/control/callback/url.rs
+++ b/src/api/control/callback/url.rs
@@ -12,8 +12,9 @@ use url::{ParseError, Url};
 /// without anything else (protocol e.g.).
 ///
 /// In [`Display`] implementation protocol will be added to this address.
-#[derive(Clone, Debug, Display, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Display, Eq, PartialEq, Hash, From)]
 #[display(fmt = "grpc://{}", _0)]
+#[from(forward)]
 pub struct GrpcCallbackUrl(String);
 
 impl GrpcCallbackUrl {

--- a/src/api/control/error_codes.rs
+++ b/src/api/control/error_codes.rs
@@ -425,6 +425,7 @@ impl From<RoomError> for ErrorResponse {
             }
             E::WrongRoomId(_, _)
             | E::PeerNotFound(_)
+            | E::CallbackClientError(_)
             | E::NoTurnCredentials(_)
             | E::ConnectionNotExists(_)
             | E::UnableToSendEvent(_)

--- a/src/signalling/participants.rs
+++ b/src/signalling/participants.rs
@@ -215,7 +215,7 @@ impl ParticipantService {
         )
     }
 
-    /// Saves provided [`RpcConnection`], registers [`IceUser`].
+    /// Saves provided [`RpcConnection`].
     /// If [`Member`] already has any other [`RpcConnection`],
     /// then it will be closed.
     pub fn connection_established(

--- a/src/signalling/participants.rs
+++ b/src/signalling/participants.rs
@@ -115,8 +115,20 @@ impl ParticipantService {
     }
 
     /// Lookups [`Member`] by provided [`MemberId`].
-    pub fn get_member_by_id(&self, id: &MemberId) -> Option<Member> {
-        self.members.get(id).cloned()
+    ///
+    /// ## Errors
+    ///
+    /// With [`ParticipantServiceErr::ParticipantNotFound`] if [`Member`] lookup
+    /// failed.
+    pub fn get_member_by_id(
+        &self,
+        id: &MemberId,
+    ) -> Result<Member, ParticipantServiceErr> {
+        self.members.get(id).cloned().ok_or_else(|| {
+            ParticipantServiceErr::ParticipantNotFound(
+                self.get_fid_to_member(id.clone()),
+            )
+        })
     }
 
     /// Generates [`Fid`] which point to some [`Member`] in this
@@ -167,7 +179,7 @@ impl ParticipantService {
     ) -> Result<Member, AuthorizationError> {
         let member = self
             .get_member_by_id(member_id)
-            .ok_or(AuthorizationError::MemberNotExists)?;
+            .map_err(|_| AuthorizationError::MemberNotExists)?;
         if member.credentials() == credentials {
             Ok(member)
         } else {
@@ -211,14 +223,10 @@ impl ParticipantService {
         conn: Box<dyn RpcConnection>,
     ) -> LocalBoxFuture<'static, Result<Member, ParticipantServiceErr>> {
         let member = match self.get_member_by_id(&member_id) {
-            None => {
-                return Box::pin(future::err(
-                    ParticipantServiceErr::ParticipantNotFound(
-                        self.get_fid_to_member(member_id),
-                    ),
-                ));
+            Err(err) => {
+                return Box::pin(future::err(err));
             }
-            Some(member) => member,
+            Ok(member) => member,
         };
 
         // lookup previous member connection
@@ -271,7 +279,7 @@ impl ParticipantService {
                 //       now.
             }
             ClosedReason::Lost => {
-                if let Some(member) = self.get_member_by_id(&member_id) {
+                if let Ok(member) = self.get_member_by_id(&member_id) {
                     self.drop_connection_tasks.insert(
                         member_id.clone(),
                         ctx.run_later(
@@ -380,7 +388,7 @@ impl ParticipantService {
         id: MemberId,
         spec: &MemberSpec,
     ) -> Result<(), RoomError> {
-        if self.get_member_by_id(&id).is_some() {
+        if self.get_member_by_id(&id).is_ok() {
             return Err(RoomError::MemberAlreadyExists(
                 self.get_fid_to_member(id),
             ));

--- a/src/signalling/room/dynamic_api.rs
+++ b/src/signalling/room/dynamic_api.rs
@@ -40,7 +40,7 @@ impl Room {
             "Deleting Member [id = {}] in Room [id = {}].",
             member_id, self.id
         );
-        if let Some(member) = self.members.get_member_by_id(member_id) {
+        if let Ok(member) = self.members.get_member_by_id(member_id) {
             let peers: HashSet<PeerId> = member
                 .sinks()
                 .values()
@@ -74,7 +74,7 @@ impl Room {
         ctx: &mut Context<Self>,
     ) {
         let endpoint_id =
-            if let Some(member) = self.members.get_member_by_id(member_id) {
+            if let Ok(member) = self.members.get_member_by_id(member_id) {
                 let play_id = endpoint_id.into();
                 if let Some(endpoint) = member.take_sink(&play_id) {
                     if let Some(peer_id) = endpoint.peer_id() {
@@ -84,7 +84,6 @@ impl Room {
                             self.member_peers_removed(
                                 peers.into_iter().map(|p| p.id()).collect(),
                                 member_id,
-                                ctx,
                             )
                             .map(|_, _, _| ())
                             .spawn(ctx);
@@ -271,7 +270,6 @@ impl Room {
                 self.member_peers_removed(
                     peers.into_iter().map(|p| p.id()).collect(),
                     member_id,
-                    ctx,
                 )
                 .map(|_, _, _| ())
                 .spawn(ctx);

--- a/src/signalling/room/mod.rs
+++ b/src/signalling/room/mod.rs
@@ -20,7 +20,7 @@ use medea_client_api_proto::{Event, MemberId, NegotiationRole, PeerId};
 use crate::{
     api::control::{
         callback::{
-            CallbackClientFactoryImpl, CallbackClientError, CallbackService,
+            CallbackClientError, CallbackClientFactoryImpl, CallbackService,
             OnLeaveEvent, OnLeaveReason,
         },
         refs::{Fid, StatefulFid, ToEndpoint, ToMember},
@@ -310,47 +310,41 @@ impl Room {
         &mut self,
         peers_id: Vec<PeerId>,
         member_id: MemberId,
-        ctx: &mut Context<Self>,
     ) -> ActFuture<()> {
         info!(
             "Peers {:?} removed for member [id = {}].",
             peers_id, member_id
         );
-        if let Some(member) = self.members.get_member_by_id(&member_id) {
+        if let Ok(member) = self.members.get_member_by_id(&member_id) {
             member.peers_removed(&peers_id);
-        } else {
-            error!(
-                "Member [id = {}] for which received Event::PeersRemoved not \
-                 found. Closing room.",
-                member_id
-            );
-
-            return self.close_gracefully(ctx);
-        }
-        Box::pin(
-            fut::ready(self.send_peers_removed(member_id, peers_id)).then(
-                |err, this: &mut Room, ctx: &mut Context<Self>| {
-                    if let Err(e) = err {
-                        match e {
-                            RoomError::ConnectionNotExists(_)
-                            | RoomError::UnableToSendEvent(_) => {
-                                Box::pin(actix::fut::ready(()))
+            Box::pin(
+                fut::ready(self.send_peers_removed(member_id, peers_id)).then(
+                    |err, this: &mut Room, ctx: &mut Context<Self>| {
+                        if let Err(e) = err {
+                            match e {
+                                RoomError::ConnectionNotExists(_)
+                                | RoomError::UnableToSendEvent(_) => {
+                                    Box::pin(fut::ready(()))
+                                }
+                                _ => {
+                                    error!(
+                                        "Unexpected failed PeersEvent \
+                                         command, because {}. Room will be \
+                                         stopped.",
+                                        e
+                                    );
+                                    this.close_gracefully(ctx)
+                                }
                             }
-                            _ => {
-                                error!(
-                                    "Unexpected failed PeersEvent command, \
-                                     because {}. Room will be stopped.",
-                                    e
-                                );
-                                this.close_gracefully(ctx)
-                            }
+                        } else {
+                            Box::pin(fut::ready(()))
                         }
-                    } else {
-                        Box::pin(actix::fut::ready(()))
-                    }
-                },
-            ),
-        )
+                    },
+                ),
+            )
+        } else {
+            Box::pin(fut::ready(()))
+        }
     }
 
     /// Sends [`Event::TracksApplied`] with latest [`Peer`] changes to specified

--- a/src/signalling/room/mod.rs
+++ b/src/signalling/room/mod.rs
@@ -109,7 +109,7 @@ pub enum RoomError {
     PeerTrafficWatcherMailbox(MailboxError),
 
     /// Failed to send callback via [`CallbackService`]
-    #[display(fmt = "CallbackClient errored in Room: {}", _0)]
+    #[display(fmt = "CallbackService errored in Room: {}", _0)]
     CallbackClientError(CallbackClientError),
 }
 

--- a/src/signalling/room/rpc_server.rs
+++ b/src/signalling/room/rpc_server.rs
@@ -502,6 +502,7 @@ mod test {
             room
         }
 
+        // TODO: Add on_leave callback tests.
         mod on_join {
 
             use super::*;
@@ -615,50 +616,6 @@ mod test {
                 )
                 .await
                 .unwrap_err();
-            }
-        }
-
-        mod on_leave {
-
-            use super::*;
-
-            // /// Member was normally disconnected.
-            // Disconnected = 0,
-            // /// Connection with Member was lost.
-            // LostConnection = 1,
-            // /// Medea media server is shutting down.
-            // ServerShutdown = 2,
-
-            #[actix_rt::test]
-            #[serial]
-            async fn on_disconnected() {
-                let mut callback_server = MockGrpcCallbackServer::new();
-                callback_server
-                    .expect_on_leave()
-                    .return_once(|fid, reason| {
-                        assert_eq!(fid, "test/member");
-                        assert_eq!(reason, Reason::Disconnected);
-                        Ok(())
-                    });
-                let room = start_room(true, true).await;
-                let _callback_server =
-                    start_callback_server("0.0.0.0:9099", callback_server)
-                        .await;
-
-                room.connection_established(
-                    MemberId::from("member"),
-                    Box::new(MockRpcConnection::new()),
-                )
-                .await
-                .unwrap();
-
-                room.connection_closed(
-                    MemberId::from("member"),
-                    ClosedReason::Closed { normal: true },
-                )
-                .await;
-                drop(_callback_server);
-                tokio::time::delay_for(std::time::Duration::from_secs(4)).await;
             }
         }
     }

--- a/src/signalling/room/rpc_server.rs
+++ b/src/signalling/room/rpc_server.rs
@@ -215,7 +215,8 @@ impl Handler<RpcConnectionEstablished> for Room {
                                             OnJoinEvent,
                                         )
                                         .await
-                                }.err_into()
+                                }
+                                .err_into()
                             })
                         },
                     ))

--- a/src/signalling/room/rpc_server.rs
+++ b/src/signalling/room/rpc_server.rs
@@ -6,7 +6,9 @@ use actix::{
 };
 use derive_more::Display;
 use failure::Fail;
-use futures::future::{self, FutureExt as _, LocalBoxFuture};
+use futures::future::{
+    self, FutureExt as _, LocalBoxFuture, TryFutureExt as _,
+};
 use medea_client_api_proto::{Command, MemberId, PeerId};
 
 use crate::{
@@ -25,7 +27,6 @@ use crate::{
 };
 
 use super::{ActFuture, Room};
-use futures::TryFutureExt;
 
 /// Error of validating received [`Command`].
 #[derive(Debug, Display, Fail, PartialEq)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -111,8 +111,7 @@ macro_rules! actix_try {
         match $e {
             Ok(p) => p,
             Err(e) => {
-                return Box::new(actix::fut::err(e.into()))
-                    as Box<dyn actix::fut::ActorFuture<Actor = _, Output = _>>;
+                return Box::pin(actix::fut::err(e.into()));
             }
         };
     };


### PR DESCRIPTION
## Synopsis

В данный момент все коллбеки стреляют по принципу fire and forget. Для OnLeave это приемлимое поведение, но в случае с OnJoin будет правильнее ожидать ответа, таким образом CallbackServer получит возможность контроллировать процесс подключения пользователя к комнате.



## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
