### PR TITLE
Refactor with wider type parameter defaults usage

### DIFF
--- a/crates/medea-reactive/src/collections/hash_map.rs
+++ b/crates/medea-reactive/src/collections/hash_map.rs
@@ -123,7 +123,7 @@ where
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    pub fn when_insert_processed(&self) -> Processed<'static, ()> {
+    pub fn when_insert_processed(&self) -> Processed<'static> {
         self.on_insert_subs.when_all_processed()
     }
 
@@ -132,7 +132,7 @@ where
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    pub fn when_remove_processed(&self) -> Processed<'static, ()> {
+    pub fn when_remove_processed(&self) -> Processed<'static> {
         self.on_remove_subs.when_all_processed()
     }
 
@@ -141,7 +141,7 @@ where
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    pub fn when_all_processed(&self) -> AllProcessed<'static, ()> {
+    pub fn when_all_processed(&self) -> AllProcessed<'static> {
         crate::when_all_processed(vec![
             self.when_remove_processed().into(),
             self.when_insert_processed().into(),

--- a/crates/medea-reactive/src/collections/hash_set.rs
+++ b/crates/medea-reactive/src/collections/hash_set.rs
@@ -121,7 +121,7 @@ where
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    pub fn when_insert_processed(&self) -> Processed<'static, ()> {
+    pub fn when_insert_processed(&self) -> Processed<'static> {
         self.on_insert_subs.when_all_processed()
     }
 
@@ -130,7 +130,7 @@ where
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    pub fn when_remove_processed(&self) -> Processed<'static, ()> {
+    pub fn when_remove_processed(&self) -> Processed<'static> {
         self.on_remove_subs.when_all_processed()
     }
 
@@ -139,7 +139,7 @@ where
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    pub fn when_all_processed(&self) -> AllProcessed<'static, ()> {
+    pub fn when_all_processed(&self) -> AllProcessed<'static> {
         crate::when_all_processed(vec![
             self.when_remove_processed().into(),
             self.when_insert_processed().into(),

--- a/crates/medea-reactive/src/collections/vec.rs
+++ b/crates/medea-reactive/src/collections/vec.rs
@@ -104,7 +104,7 @@ where
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    pub fn when_push_processed(&self) -> Processed<'static, ()> {
+    pub fn when_push_processed(&self) -> Processed<'static> {
         self.on_push_subs.when_all_processed()
     }
 
@@ -113,7 +113,7 @@ where
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    pub fn when_remove_processed(&self) -> Processed<'static, ()> {
+    pub fn when_remove_processed(&self) -> Processed<'static> {
         self.on_remove_subs.when_all_processed()
     }
 
@@ -122,7 +122,7 @@ where
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    pub fn when_all_processed(&self) -> AllProcessed<'static, ()> {
+    pub fn when_all_processed(&self) -> AllProcessed<'static> {
         crate::when_all_processed(vec![
             self.when_remove_processed().into(),
             self.when_push_processed().into(),

--- a/crates/medea-reactive/src/field/mod.rs
+++ b/crates/medea-reactive/src/field/mod.rs
@@ -134,7 +134,7 @@ where
     /// subscribers.
     ///
     /// [`Future`]: std::future::Future
-    pub fn when_all_processed(&self) -> Processed<'static, ()> {
+    pub fn when_all_processed(&self) -> Processed<'static> {
         self.subs.when_all_processed()
     }
 }

--- a/crates/medea-reactive/src/field/progressable_cell.rs
+++ b/crates/medea-reactive/src/field/progressable_cell.rs
@@ -66,7 +66,7 @@ where
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    pub fn when_all_processed(&self) -> Processed<'static, ()> {
+    pub fn when_all_processed(&self) -> Processed<'static> {
         self.0.borrow().when_all_processed()
     }
 }

--- a/crates/medea-reactive/src/subscribers_store/progressable/mod.rs
+++ b/crates/medea-reactive/src/subscribers_store/progressable/mod.rs
@@ -46,7 +46,7 @@ impl<T> SubStore<T> {
     /// Returns [`Future`] resolving when all subscribers processes update.
     ///
     /// [`Future`]: std::future::Future
-    pub fn when_all_processed(&self) -> Processed<'static, ()> {
+    pub fn when_all_processed(&self) -> Processed<'static> {
         let counter = Rc::clone(&self.counter);
         Processed::new(Box::new(move || {
             let counter = Rc::clone(&counter);

--- a/crates/medea-reactive/src/subscribers_store/progressable/processed.rs
+++ b/crates/medea-reactive/src/subscribers_store/progressable/processed.rs
@@ -19,7 +19,7 @@ pub type Factory<'a, T> = Box<dyn Fn() -> LocalBoxFuture<'a, T> + 'static>;
 
 /// Creates [`AllProcessed`] [`Future`] from the provided [`Iterator`] of
 /// [`Factory`]s.
-pub fn when_all_processed<I, T>(futures: I) -> AllProcessed<'static, ()>
+pub fn when_all_processed<I, T>(futures: I) -> AllProcessed<'static>
 where
     I: IntoIterator<Item = Factory<'static, T>>,
     T: 'static,
@@ -34,7 +34,7 @@ where
 /// [`Future`] with inner factory. [`Factory`] can be unwrapped using [`Into`]
 /// implementation.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct Processed<'a, T> {
+pub struct Processed<'a, T = ()> {
     /// Factory creating the underlying [`Future`].
     factory: Factory<'a, T>,
 
@@ -86,7 +86,7 @@ impl<'a, T> fmt::Debug for Processed<'a, T> {
 ///
 /// Inner [`Factory`] can be unwrapped using [`Into`] implementation.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct AllProcessed<'a, T> {
+pub struct AllProcessed<'a, T = ()> {
     /// Factory creating the underlying [`Future`] and recreating it to recheck
     /// the [`Future`] during polling.
     factory: Factory<'a, T>,

--- a/jason/src/peer/component.rs
+++ b/jason/src/peer/component.rs
@@ -169,7 +169,7 @@ impl State {
     /// be applied.
     ///
     /// [`Future`]: std::future::Future
-    fn when_all_senders_updated(&self) -> AllProcessed<'static, ()> {
+    fn when_all_senders_updated(&self) -> AllProcessed<'static> {
         let when_futs: Vec<_> = self
             .senders
             .borrow()
@@ -183,7 +183,7 @@ impl State {
     /// be applied.
     ///
     /// [`Future`]: std::future::Future
-    fn when_all_receivers_updated(&self) -> AllProcessed<'static, ()> {
+    fn when_all_receivers_updated(&self) -> AllProcessed<'static> {
         let when_futs: Vec<_> = self
             .receivers
             .borrow()
@@ -198,7 +198,7 @@ impl State {
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    pub fn when_all_updated(&self) -> AllProcessed<'static, ()> {
+    pub fn when_all_updated(&self) -> AllProcessed<'static> {
         medea_reactive::when_all_processed(vec![
             self.when_all_receivers_updated().into(),
             self.when_all_senders_updated().into(),
@@ -283,7 +283,7 @@ impl State {
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    fn when_all_senders_processed(&self) -> AllProcessed<'static, ()> {
+    fn when_all_senders_processed(&self) -> AllProcessed<'static> {
         self.senders.borrow().when_all_processed()
     }
 
@@ -292,7 +292,7 @@ impl State {
     ///
     /// [`Future`]: std::future::Future
     #[inline]
-    fn when_all_receivers_processed(&self) -> AllProcessed<'static, ()> {
+    fn when_all_receivers_processed(&self) -> AllProcessed<'static> {
         self.receivers.borrow().when_all_processed()
     }
 

--- a/jason/src/peer/media/receiver/component.rs
+++ b/jason/src/peer/media/receiver/component.rs
@@ -114,7 +114,7 @@ impl State {
     /// [`Receiver`].
     ///
     /// [`Future`]: std::future::Future
-    pub fn when_updated(&self) -> AllProcessed<'static, ()> {
+    pub fn when_updated(&self) -> AllProcessed<'static> {
         medea_reactive::when_all_processed(vec![
             self.enabled_general.when_all_processed().into(),
             self.enabled_individual.when_all_processed().into(),

--- a/jason/src/peer/media/sender/component.rs
+++ b/jason/src/peer/media/sender/component.rs
@@ -139,7 +139,7 @@ impl State {
     /// [`Sender`].
     ///
     /// [`Future`]: std::future::Future
-    pub fn when_updated(&self) -> AllProcessed<'static, ()> {
+    pub fn when_updated(&self) -> AllProcessed<'static> {
         medea_reactive::when_all_processed(vec![
             self.enabled_general.when_all_processed().into(),
             self.enabled_individual.when_all_processed().into(),

--- a/src/api/control/callback/clients/mod.rs
+++ b/src/api/control/callback/clients/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     log::prelude::*,
 };
 
-type Result<T> = std::result::Result<T, CallbackClientError>;
+type Result<T = ()> = std::result::Result<T, CallbackClientError>;
 
 /// Error of sending [`CallbackRequest`] by [`CallbackClient`].
 #[derive(Debug, Display, From)]
@@ -31,7 +31,7 @@ pub enum CallbackClientError {
 #[cfg_attr(test, mockall::automock)]
 pub trait CallbackClient: fmt::Debug + Send + Sync {
     /// Sends provided [`CallbackRequest`].
-    async fn send(&self, request: CallbackRequest) -> Result<()>;
+    async fn send(&self, request: CallbackRequest) -> Result;
 }
 
 #[cfg(test)]

--- a/src/api/control/callback/clients/mod.rs
+++ b/src/api/control/callback/clients/mod.rs
@@ -13,7 +13,8 @@ use crate::{
     log::prelude::*,
 };
 
-type Result<T = ()> = std::result::Result<T, CallbackClientError>;
+/// Shortcut for [`Result`] of methods in this module.
+type CallbackResult<T = ()> = Result<T, CallbackClientError>;
 
 /// Error of sending [`CallbackRequest`] by [`CallbackClient`].
 #[derive(Debug, Display, From)]
@@ -31,7 +32,7 @@ pub enum CallbackClientError {
 #[cfg_attr(test, mockall::automock)]
 pub trait CallbackClient: fmt::Debug + Send + Sync {
     /// Sends provided [`CallbackRequest`].
-    async fn send(&self, request: CallbackRequest) -> Result;
+    async fn send(&self, request: CallbackRequest) -> CallbackResult;
 }
 
 #[cfg(test)]
@@ -43,7 +44,7 @@ pub trait CallbackClientFactory {
     /// Creates [`CallbackClient`] basing on provided [`CallbackUrl`].
     fn build(
         url: CallbackUrl,
-    ) -> LocalBoxFuture<'static, Result<Arc<dyn CallbackClient>>>;
+    ) -> LocalBoxFuture<'static, CallbackResult<Arc<dyn CallbackClient>>>;
 }
 
 #[cfg(test)]
@@ -57,7 +58,7 @@ impl CallbackClientFactory for CallbackClientFactoryImpl {
     #[inline]
     fn build(
         url: CallbackUrl,
-    ) -> LocalBoxFuture<'static, Result<Arc<dyn CallbackClient>>> {
+    ) -> LocalBoxFuture<'static, CallbackResult<Arc<dyn CallbackClient>>> {
         info!("Creating CallbackClient for URL: {}", url);
         match url {
             CallbackUrl::Grpc(grpc_url) => async move {

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -105,11 +105,7 @@ struct OsSignal(i32);
 impl Handler<OsSignal> for GracefulShutdown {
     type Result = ResponseFuture<()>;
 
-    fn handle(
-        &mut self,
-        sig: OsSignal,
-        _: &mut Context<Self>,
-    ) -> ResponseFuture<()> {
+    fn handle(&mut self, sig: OsSignal, _: &mut Context<Self>) -> Self::Result {
         info!("OS signal '{}' received", sig.0);
 
         match self.state {

--- a/src/signalling/room/mod.rs
+++ b/src/signalling/room/mod.rs
@@ -46,7 +46,8 @@ pub use dynamic_api::{
 };
 
 /// Ergonomic type alias for using [`ActorFuture`] for [`Room`].
-pub type ActFuture<O> = Pin<Box<dyn ActorFuture<Actor = Room, Output = O>>>;
+pub type ActFuture<O = ()> =
+    Pin<Box<dyn ActorFuture<Actor = Room, Output = O>>>;
 
 #[derive(Debug, Display, Fail, From)]
 pub enum RoomError {
@@ -282,7 +283,7 @@ impl Room {
 
     /// Closes [`Room`] gracefully, by dropping all the connections and moving
     /// into [`State::Stopped`].
-    fn close_gracefully(&mut self, ctx: &mut Context<Self>) -> ActFuture<()> {
+    fn close_gracefully(&mut self, ctx: &mut Context<Self>) -> ActFuture {
         info!("Closing Room [id = {}]", self.id);
         self.state = State::Stopping;
 
@@ -316,7 +317,7 @@ impl Room {
         &mut self,
         peers_id: Vec<PeerId>,
         member_id: MemberId,
-    ) -> ActFuture<()> {
+    ) -> ActFuture {
         info!(
             "Peers {:?} removed for member [id = {}].",
             peers_id, member_id
@@ -403,7 +404,7 @@ impl Actor for Room {
 }
 
 impl Handler<ShutdownGracefully> for Room {
-    type Result = ActFuture<()>;
+    type Result = ActFuture;
 
     fn handle(
         &mut self,

--- a/src/signalling/room/rpc_server.rs
+++ b/src/signalling/room/rpc_server.rs
@@ -134,7 +134,7 @@ impl RpcServer for Addr<Room> {
 }
 
 impl Handler<CommandMessage> for Room {
-    type Result = ActFuture<()>;
+    type Result = ActFuture;
 
     /// Receives [`Command`] from Web client and passes it to corresponding
     /// handlers. Will emit `CloseRoom` on any error.

--- a/src/turn/coturn_metrics.rs
+++ b/src/turn/coturn_metrics.rs
@@ -30,7 +30,7 @@ use super::{
 const ALLOCATIONS_CHANNEL_PATTERN: &str = "turn/realm/*/user/*/allocation/*";
 
 /// Ergonomic type alias for using [`ActorFuture`] by [`CoturnMetricsService`].
-pub type ActFuture<O> =
+pub type ActFuture<O = ()> =
     Pin<Box<dyn ActorFuture<Actor = CoturnMetricsService, Output = O>>>;
 
 /// Service responsible for processing [`Peer`]'s metrics received
@@ -107,7 +107,7 @@ impl CoturnMetricsService {
     }
 
     /// Connects Redis until succeeds.
-    fn connect_until_success(&mut self) -> ActFuture<()> {
+    fn connect_until_success(&mut self) -> ActFuture {
         Box::pin(self.connect_and_subscribe().then(|res, this, _| {
             if let Err(err) = res {
                 warn!(


### PR DESCRIPTION
## Synopsis

Minor refactor to wider default type parameters usage to lower unnecessary verbosity.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
