### PR TITLE
Remove !muted check on media tracks after getUserMedia()/getDisplayMedia() (#27)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
  "actix_derive",
  "bitflags",
  "bytes 0.5.6",
- "crossbeam-channel",
+ "crossbeam-channel 0.4.4",
  "derive_more",
  "futures-channel",
  "futures-util",
@@ -121,7 +121,7 @@ dependencies = [
  "pin-project 1.0.4",
  "rand 0.7.3",
  "regex",
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde_json",
  "serde_urlencoded",
  "sha-1",
@@ -149,7 +149,7 @@ dependencies = [
  "http",
  "log",
  "regex",
- "serde 1.0.118",
+ "serde 1.0.119",
 ]
 
 [[package]]
@@ -288,7 +288,7 @@ dependencies = [
  "mime",
  "pin-project 1.0.4",
  "regex",
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde_json",
  "serde_urlencoded",
  "socket2",
@@ -376,9 +376,9 @@ checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.8"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
+checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
 
 [[package]]
 name = "arrayref"
@@ -578,7 +578,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "rand 0.7.3",
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde_json",
  "serde_urlencoded",
 ]
@@ -792,7 +792,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -861,6 +861,16 @@ checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
  "crossbeam-utils 0.7.2",
  "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -941,7 +951,7 @@ dependencies = [
  "config",
  "crossbeam-queue",
  "num_cpus",
- "serde 1.0.118",
+ "serde 1.0.119",
  "tokio",
 ]
 
@@ -954,10 +964,10 @@ dependencies = [
  "async-trait",
  "config",
  "deadpool",
- "futures 0.3.9",
+ "futures 0.3.10",
  "log",
  "redis",
- "serde 1.0.118",
+ "serde 1.0.119",
 ]
 
 [[package]]
@@ -1230,9 +1240,9 @@ checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
+checksum = "309f13e3f4be6d5917178c84db67c0b9a09177ac16d4f9a7313a767a68adaa77"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1245,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
+checksum = "7a3b03bd32f6ec7885edeb99acd1e47e20e34fd4dfd3c6deed6fcac8a9d28f6a"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1255,15 +1265,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
+checksum = "ed8aeae2b6ab243ebabe6f54cd4cf53054d98883d5d326128af7d57a9ca5cd3d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee9ca2f7eb4475772cf39dd1cd06208dce2670ad38f4d9c7262b3e15f127068"
+checksum = "3f7836b36b7533d16fd5937311d98ba8965ab81030de8b0024c299dd5d51fb9b"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1272,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
+checksum = "d41234e71d5e8ca73d01563974ef6f50e516d71e18f1a2f1184742e31f5d469f"
 
 [[package]]
 name = "futures-lite"
@@ -1293,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8719ca0e1f3c5e34f3efe4570ef2c0610ca6da85ae7990d472e9cbfba13664"
+checksum = "3520e0eb4e704e88d771b92d51273ee212997f0d8282f17f5d8ff1cb39104e42"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
@@ -1305,24 +1315,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
+checksum = "c72d188479368953c6c8c7140e40d7a4401674ab3b98a41e60e515d6cbdbe5de"
 
 [[package]]
 name = "futures-task"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
+checksum = "08944cea9021170d383287169859c0ca8147d9ec285978393109954448f33cc7"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
+checksum = "d3dd206efbe2ca683b2ce138ccdf61e1b0a63f5816dcedc9d8654c500ba0cea6"
 dependencies = [
  "futures 0.1.30",
  "futures-channel",
@@ -1506,7 +1516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
 dependencies = [
  "humantime",
- "serde 1.0.118",
+ "serde 1.0.119",
 ]
 
 [[package]]
@@ -1747,7 +1757,7 @@ dependencies = [
  "dotenv",
  "failure",
  "function_name",
- "futures 0.3.9",
+ "futures 0.3.10",
  "humantime-serde",
  "lazy_static",
  "medea-client-api-proto",
@@ -1755,11 +1765,11 @@ dependencies = [
  "medea-coturn-telnet-client",
  "medea-macro",
  "mockall",
- "rand 0.8.1",
+ "rand 0.8.2",
  "redis",
  "rust-argon2",
  "rust-crypto",
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde_json",
  "serde_yaml",
  "serial_test",
@@ -1785,7 +1795,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "medea-macro",
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde_json",
  "serde_with",
 ]
@@ -1804,7 +1814,7 @@ dependencies = [
  "humantime-serde",
  "medea-control-api-proto",
  "protobuf",
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde_json",
  "slog",
  "slog-async",
@@ -1834,7 +1844,7 @@ dependencies = [
  "bytes 0.5.6",
  "deadpool",
  "derive_more",
- "futures 0.3.9",
+ "futures 0.3.10",
  "once_cell",
  "regex",
  "tokio",
@@ -1853,7 +1863,7 @@ dependencies = [
  "derive_more",
  "downcast",
  "fragile",
- "futures 0.3.9",
+ "futures 0.3.10",
  "js-sys",
  "log",
  "medea-client-api-proto",
@@ -1861,7 +1871,7 @@ dependencies = [
  "medea-reactive",
  "mockall",
  "predicates-tree",
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde_json",
  "tracerr",
  "url",
@@ -1890,7 +1900,7 @@ dependencies = [
 name = "medea-reactive"
 version = "0.1.0-dev"
 dependencies = [
- "futures 0.3.9",
+ "futures 0.3.10",
  "tokio",
 ]
 
@@ -2117,7 +2127,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -2403,9 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
@@ -2530,13 +2540,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom 0.1.16",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rust-argon2",
 ]
 
@@ -2670,9 +2689,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "9bdd36f49e35b61d49efd8aa7fc068fd295961fd2286d0b2ee9a4c7a14e99cc3"
 dependencies = [
  "serde_derive",
 ]
@@ -2692,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "552954ce79a059ddd5fd68c271592374bd15cab2274970380c000118aeffe1cd"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
@@ -2709,7 +2728,7 @@ checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.118",
+ "serde 1.0.119",
 ]
 
 [[package]]
@@ -2730,7 +2749,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.118",
+ "serde 1.0.119",
 ]
 
 [[package]]
@@ -2739,7 +2758,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f6201e064705553ece353a736a64be975680bd244908cf63e8fa71e478a51a"
 dependencies = [
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde_with_macros",
 ]
 
@@ -2763,7 +2782,7 @@ checksum = "971be8f6e4d4a47163b405a3df70d14359186f9ab0f3a3ec37df144ca1ce089f"
 dependencies = [
  "dtoa",
  "linked-hash-map 0.5.4",
- "serde 1.0.118",
+ "serde 1.0.119",
  "yaml-rust",
 ]
 
@@ -2831,11 +2850,11 @@ checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 
 [[package]]
 name = "slog-async"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b3336ce47ce2f96673499fc07eb85e3472727b9a7a2959964b002c2ce8fbbb"
+checksum = "c60813879f820c85dbc4eabf3269befe374591289019775898d56a81a804fbdc"
 dependencies = [
- "crossbeam-channel",
+ "crossbeam-channel 0.5.0",
  "slog",
  "take_mut",
  "thread_local",
@@ -2863,16 +2882,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
 dependencies = [
  "chrono",
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde_json",
  "slog",
 ]
 
 [[package]]
 name = "slog-scope"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c44c89dd8b0ae4537d1ae318353eaf7840b4869c536e31c41e963d1ea523ee6"
+checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
 dependencies = [
  "arc-swap",
  "lazy_static",
@@ -2968,7 +2987,7 @@ checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde_derive",
  "syn 1.0.58",
 ]
@@ -2982,7 +3001,7 @@ dependencies = [
  "base-x",
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde_derive",
  "serde_json",
  "sha1",
@@ -3055,14 +3074,14 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
- "redox_syscall",
+ "rand 0.8.2",
+ "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -3242,7 +3261,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.118",
+ "serde 1.0.119",
 ]
 
 [[package]]
@@ -3532,7 +3551,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "enum-as-inner",
- "futures 0.3.9",
+ "futures 0.3.10",
  "idna",
  "lazy_static",
  "log",
@@ -3551,7 +3570,7 @@ checksum = "6759e8efc40465547b0dfce9500d733c65f969a4cbbfbe3ccf68daaa46ef179e"
 dependencies = [
  "backtrace",
  "cfg-if 0.1.10",
- "futures 0.3.9",
+ "futures 0.3.10",
  "ipconfig",
  "lazy_static",
  "log",
@@ -3682,7 +3701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.118",
+ "serde 1.0.119",
  "serde_json",
  "wasm-bindgen-macro",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,9 +1505,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "humantime-serde"
@@ -2271,9 +2271,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"

--- a/jason/src/media/manager.rs
+++ b/jason/src/media/manager.rs
@@ -65,15 +65,6 @@ pub enum MediaManagerError {
     #[display(fmt = "MediaDevices.enumerateDevices() failed: {}", _0)]
     EnumerateDevicesFailed(JsError),
 
-    /// Occurs when local track is [`muted`][1] right after [getUserMedia()][2]
-    /// or [getDisplayMedia()][3] request.
-    ///
-    /// [1]: https://w3.org/TR/mediacapture-streams#track-muted
-    /// [2]: https://tinyurl.com/rnxcavf
-    /// [3]: https://w3.org/TR/screen-capture#dom-mediadevices-getdisplaymedia
-    #[display(fmt = "{} track is muted", _0)]
-    LocalTrackIsMuted(MediaKind),
-
     /// Occurs when local track is [`ended`][1] right after [getUserMedia()][2]
     /// or [getDisplayMedia()][3] request.
     ///
@@ -328,24 +319,20 @@ impl InnerMediaManager {
     ///
     /// # Errors
     ///
-    /// - [`MediaManagerError::LocalTrackIsEnded`] if at least one track from
-    ///   the provided [`sys::MediaStream`] is in [`ended`][1] state.
-    ///
-    /// - [`MediaManagerError::LocalTrackIsMuted`] if at least one track from
-    ///   the provided [`sys::MediaStream`] is in [`muted`][2] state.
+    /// With [`MediaManagerError::LocalTrackIsEnded`] if at least one track from
+    /// the provided [`sys::MediaStream`] is in [`ended`][1] state.
     ///
     /// In case of error all tracks are stopped and are not saved in
     /// [`MediaManager`]'s tracks storage.
     ///
     /// [1]: https://tinyurl.com/w3-streams#idl-def-MediaStreamTrackState.ended
-    /// [2]: https://w3.org/TR/mediacapture-streams#track-muted
     #[allow(clippy::needless_pass_by_value)]
     fn parse_and_save_tracks(
         &self,
         stream: sys::MediaStream,
         kind: MediaSourceKind,
     ) -> Result<Vec<Rc<local::Track>>> {
-        use MediaManagerError::{LocalTrackIsEnded, LocalTrackIsMuted};
+        use MediaManagerError::LocalTrackIsEnded;
 
         let mut storage = self.tracks.borrow_mut();
         let tracks: Vec<_> = js_sys::try_iter(&stream.get_tracks())
@@ -355,16 +342,13 @@ impl InnerMediaManager {
             .collect();
 
         // Tracks returned by getDisplayMedia()/getUserMedia() request should be
-        // `live` and `!muted`. Otherwise, we should err without caching tracks
-        // in `MediaManager`. Tracks will be stopped on ``Drop`.
+        // `live`. Otherwise, we should err without caching tracks in
+        // `MediaManager`. Tracks will be stopped on `Drop`.
         for track in &tracks {
             if track.sys_track().ready_state()
                 != sys::MediaStreamTrackState::Live
             {
                 return Err(tracerr::new!(LocalTrackIsEnded(track.kind())));
-            }
-            if track.sys_track().muted() {
-                return Err(tracerr::new!(LocalTrackIsMuted(track.kind())));
             }
         }
 


### PR DESCRIPTION
Related to #161

## Synopsis

В #161 были добавлены две проверки состояния треков после их получения:
1. `ready_state == Live`.
2. `muted == false`.

`muted == false` - редкое, но валидное состояние для новых треков.


## Solution

Откатить `muted == false` проверку.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
