### PR TITLE
Upgrade stable Rust to 1.51 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
  "log",
  "once_cell",
  "parking_lot",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "smallvec",
  "tokio 0.2.25",
  "tokio-util 0.3.1",
@@ -46,7 +46,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio 0.2.25",
  "tokio-util 0.3.1",
 ]
@@ -120,10 +120,10 @@ dependencies = [
  "log",
  "mime",
  "percent-encoding",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "rand 0.7.3",
  "regex",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "serde_urlencoded 0.7.0",
  "sha-1",
@@ -138,7 +138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ca8ce00b267af8ccebbd647de0d61e0674b6e61185cc7a592ff88772bed655"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -151,7 +151,7 @@ dependencies = [
  "http",
  "log",
  "regex",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -196,7 +196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0052435d581b5be835d11f4eb3bce417c8af18d87ddf8ace99f8e67e595882bb"
 dependencies = [
  "futures-util",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
 ]
 
 [[package]]
@@ -256,7 +256,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "log",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "slab",
 ]
 
@@ -288,9 +288,9 @@ dependencies = [
  "fxhash",
  "log",
  "mime",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "regex",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "serde_urlencoded 0.7.0",
  "socket2 0.3.19",
@@ -312,7 +312,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures-channel",
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
 ]
 
 [[package]]
@@ -323,7 +323,7 @@ checksum = "ad26f77093333e0e7c6ffe54ebe3582d908a104e448723eec6d43d08b07143fb"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -334,7 +334,7 @@ checksum = "b95aceadaf327f18f0df5962fedc1bde2f870566a0b9f65c89508a3b1f79334c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cddc5f91628367664cc7c69714ff08deee8a3efc54623011c772544d7b2767"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "arc-swap"
@@ -481,7 +481,7 @@ checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -539,7 +539,7 @@ checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -567,7 +567,7 @@ checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -612,7 +612,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "rand 0.7.3",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "serde_urlencoded 0.7.0",
 ]
@@ -835,7 +835,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+checksum = "076a6803b0dacd6a88cfe64deba628b01533ff5ef265687e6938280c1afd0a28"
 
 [[package]]
 name = "constant_time_eq"
@@ -982,12 +982,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1025,7 +1025,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "regex",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1035,7 +1035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed431abf442833fd62ad7cc527a3833d969155c803f0dcf7f8a68db8adddc4c5"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1069,7 +1069,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "strsim 0.9.3",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1083,7 +1083,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "strsim 0.10.0",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1094,7 +1094,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1105,7 +1105,7 @@ checksum = "c0220073ce504f12a70efc4e7cdaea9e9b1b324872e7ad96a208056d7a638b81"
 dependencies = [
  "darling_core 0.12.2",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1118,7 +1118,7 @@ dependencies = [
  "config",
  "crossbeam-queue",
  "num_cpus",
- "serde 1.0.124",
+ "serde 1.0.125",
  "tokio 0.2.25",
 ]
 
@@ -1134,7 +1134,7 @@ dependencies = [
  "futures 0.3.13",
  "log",
  "redis",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -1145,7 +1145,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1158,7 +1158,7 @@ dependencies = [
  "derive_builder_core",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1170,7 +1170,7 @@ dependencies = [
  "darling 0.10.2",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1182,7 +1182,7 @@ dependencies = [
  "convert_case",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1269,7 +1269,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1296,7 +1296,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
  "synstructure",
 ]
 
@@ -1311,10 +1311,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "hyper 0.14.4",
+ "hyper 0.14.5",
  "hyper-tls",
  "mime",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "tokio 1.4.0",
  "url",
@@ -1514,7 +1514,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1612,9 +1612,9 @@ dependencies = [
  "heck",
  "peg",
  "quote 1.0.9",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
- "syn 1.0.64",
+ "syn 1.0.65",
  "textwrap 0.12.1",
  "thiserror",
  "typed-builder",
@@ -1628,7 +1628,7 @@ checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -1696,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
+checksum = "fc018e188373e2777d0ef2467ebff62a08e66c3f5857b23c8fbec3018210dc00"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -1830,7 +1830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
 dependencies = [
  "humantime",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -1849,7 +1849,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "socket2 0.3.19",
  "tokio 0.2.25",
  "tower-service",
@@ -1859,22 +1859,22 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.1",
+ "h2 0.3.2",
  "http",
  "http-body 0.4.1",
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
- "socket2 0.3.19",
+ "pin-project 1.0.6",
+ "socket2 0.4.0",
  "tokio 1.4.0",
  "tower-service",
  "tracing",
@@ -1888,7 +1888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.0.1",
- "hyper 0.14.4",
+ "hyper 0.14.5",
  "native-tls",
  "tokio 1.4.0",
  "tokio-native-tls",
@@ -1973,7 +1973,7 @@ checksum = "75c094e94816723ab936484666968f5b58060492e880f3c8d00489a1e244fa51"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -2082,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
+checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "linked-hash-map"
@@ -2175,7 +2175,7 @@ dependencies = [
  "function_name",
  "futures 0.3.13",
  "humantime-serde",
- "hyper 0.14.4",
+ "hyper 0.14.5",
  "lazy_static",
  "medea-client-api-proto",
  "medea-control-api-mock",
@@ -2189,7 +2189,7 @@ dependencies = [
  "reqwest",
  "rust-argon2",
  "rust-crypto",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "serde_yaml",
  "serial_test",
@@ -2219,7 +2219,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "medea-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "serde_with",
 ]
@@ -2238,7 +2238,7 @@ dependencies = [
  "humantime-serde",
  "medea-control-api-proto 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "slog",
  "slog-async",
@@ -2324,7 +2324,7 @@ dependencies = [
  "medea-reactive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockall",
  "predicates-tree",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "tracerr",
  "url",
@@ -2345,7 +2345,7 @@ dependencies = [
  "medea-jason",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
  "synstructure",
 ]
 
@@ -2358,7 +2358,7 @@ dependencies = [
  "Inflector",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
  "synstructure",
 ]
 
@@ -2438,13 +2438,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2182a122f3b7f3f5329cb1972cee089ba2459a0a80a56935e6e674f096f8d839"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.6",
+ "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
 ]
@@ -2474,11 +2474,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2 0.3.19",
  "winapi 0.3.9",
 ]
 
@@ -2506,7 +2505,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -2751,42 +2750,42 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
 dependencies = [
- "pin-project-internal 0.4.27",
+ "pin-project-internal 0.4.28",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
+checksum = "bc174859768806e91ae575187ada95c91a29e96a98dc5d2cd9a1fed039501ba6"
 dependencies = [
- "pin-project-internal 1.0.5",
+ "pin-project-internal 1.0.6",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
+checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -2938,7 +2937,7 @@ dependencies = [
  "itertools 0.8.2",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -3198,7 +3197,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body 0.4.1",
- "hyper 0.14.4",
+ "hyper 0.14.5",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3208,7 +3207,7 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.6",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "serde_urlencoded 0.7.0",
  "tokio 1.4.0",
@@ -3326,9 +3325,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3339,9 +3338,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3370,9 +3369,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
@@ -3392,13 +3391,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -3409,7 +3408,7 @@ checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -3429,7 +3428,7 @@ checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
  "dtoa",
  "itoa",
- "serde 1.0.124",
+ "serde 1.0.125",
  "url",
 ]
 
@@ -3442,16 +3441,17 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
 name = "serde_with"
-version = "1.6.4"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44be9227e214a0420707c9ca74c2d4991d9955bae9415a8f93f05cebf561be5"
+checksum = "7f23bb4df023db259e4423c8a5c248d75d83c0e20c8f0063254f41b859a65ab3"
 dependencies = [
- "serde 1.0.124",
+ "rustversion",
+ "serde 1.0.125",
  "serde_with_macros",
 ]
 
@@ -3464,7 +3464,7 @@ dependencies = [
  "darling 0.12.2",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -3475,7 +3475,7 @@ checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
 dependencies = [
  "dtoa",
  "linked-hash-map 0.5.4",
- "serde 1.0.124",
+ "serde 1.0.125",
  "yaml-rust",
 ]
 
@@ -3498,7 +3498,7 @@ checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -3585,7 +3585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
 dependencies = [
  "chrono",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "slog",
 ]
@@ -3639,7 +3639,7 @@ checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -3700,9 +3700,9 @@ checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_derive",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -3714,11 +3714,11 @@ dependencies = [
  "base-x",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -3764,9 +3764,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
+checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -3781,7 +3781,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
  "unicode-xid 0.2.1",
 ]
 
@@ -3871,7 +3871,7 @@ checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -3937,7 +3937,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "standback",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -3988,7 +3988,7 @@ dependencies = [
  "bytes 1.0.1",
  "libc",
  "memchr",
- "mio 0.7.10",
+ "mio 0.7.11",
  "num_cpus",
  "pin-project-lite 0.2.6",
  "tokio-macros 1.1.0",
@@ -4002,7 +4002,7 @@ checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -4013,7 +4013,7 @@ checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -4061,7 +4061,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -4080,7 +4080,7 @@ dependencies = [
  "http-body 0.3.1",
  "hyper 0.13.10",
  "percent-encoding",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "prost",
  "prost-derive",
  "tokio 0.2.25",
@@ -4103,7 +4103,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "prost-build",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -4133,7 +4133,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "rand 0.7.3",
  "slab",
  "tokio 0.2.25",
@@ -4153,7 +4153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio 0.2.25",
  "tower-layer",
  "tower-service",
@@ -4167,7 +4167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f6b5000c3c54d269cc695dff28136bb33d08cbf1df2c48129e143ab65bf3c2a"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tower-service",
 ]
 
@@ -4184,7 +4184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio 0.2.25",
  "tower-layer",
  "tower-load",
@@ -4199,7 +4199,7 @@ checksum = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
 dependencies = [
  "futures-core",
  "log",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio 0.2.25",
  "tower-discover",
  "tower-service",
@@ -4212,7 +4212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f021e23900173dc315feb4b6922510dae3e79c689b74c089112066c11f0ae4e"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tower-layer",
  "tower-service",
 ]
@@ -4248,7 +4248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio 0.2.25",
  "tower-layer",
  "tower-service",
@@ -4266,7 +4266,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
 dependencies = [
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio 0.2.25",
  "tower-layer",
  "tower-service",
@@ -4280,7 +4280,7 @@ checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tower-service",
 ]
 
@@ -4314,7 +4314,7 @@ checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -4332,7 +4332,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.5",
+ "pin-project 1.0.6",
  "tracing",
 ]
 
@@ -4395,7 +4395,7 @@ checksum = "f85f4270f4f449a3f2c0cf2aecc8415e388a597aeacc7d55fc749c5c968c8533"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
 ]
 
 [[package]]
@@ -4523,9 +4523,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
  "winapi 0.3.9",
@@ -4556,9 +4556,9 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "scoped-tls",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "serde_urlencoded 0.6.1",
  "tokio 0.2.25",
@@ -4587,7 +4587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_json",
  "wasm-bindgen-macro",
 ]
@@ -4603,7 +4603,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
  "wasm-bindgen-shared",
 ]
 
@@ -4637,7 +4637,7 @@ checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.65",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4704,7 +4704,7 @@ dependencies = [
  "cookie 0.12.0",
  "http",
  "log",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_derive",
  "serde_json",
  "time 0.1.43",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
 
 [[package]]
 name = "linked-hash-map"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ca8ce00b267af8ccebbd647de0d61e0674b6e61185cc7a592ff88772bed655"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -323,7 +323,7 @@ checksum = "ad26f77093333e0e7c6ffe54ebe3582d908a104e448723eec6d43d08b07143fb"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -334,7 +334,7 @@ checksum = "b95aceadaf327f18f0df5962fedc1bde2f870566a0b9f65c89508a3b1f79334c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -481,7 +481,7 @@ checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -539,7 +539,7 @@ checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -567,7 +567,7 @@ checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -987,7 +987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1025,7 +1025,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "regex",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1035,7 +1035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed431abf442833fd62ad7cc527a3833d969155c803f0dcf7f8a68db8adddc4c5"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1069,7 +1069,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "strsim 0.9.3",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1083,7 +1083,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "strsim 0.10.0",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1094,7 +1094,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1105,7 +1105,7 @@ checksum = "c0220073ce504f12a70efc4e7cdaea9e9b1b324872e7ad96a208056d7a638b81"
 dependencies = [
  "darling_core 0.12.2",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1145,7 +1145,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1158,7 +1158,7 @@ dependencies = [
  "derive_builder_core",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1170,7 +1170,7 @@ dependencies = [
  "darling 0.10.2",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1182,7 +1182,7 @@ dependencies = [
  "convert_case",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1241,9 +1241,9 @@ checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "dtoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
@@ -1269,7 +1269,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1296,7 +1296,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
  "synstructure",
 ]
 
@@ -1514,7 +1514,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1614,7 +1614,7 @@ dependencies = [
  "quote 1.0.9",
  "serde 1.0.125",
  "serde_json",
- "syn 1.0.65",
+ "syn 1.0.67",
  "textwrap 0.12.1",
  "thiserror",
  "typed-builder",
@@ -1628,7 +1628,7 @@ checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1973,7 +1973,7 @@ checksum = "75c094e94816723ab936484666968f5b58060492e880f3c8d00489a1e244fa51"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -2029,9 +2029,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2345,7 +2345,7 @@ dependencies = [
  "medea-jason",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
  "synstructure",
 ]
 
@@ -2358,7 +2358,7 @@ dependencies = [
  "Inflector",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
  "synstructure",
 ]
 
@@ -2505,7 +2505,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -2774,7 +2774,7 @@ checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -2785,7 +2785,7 @@ checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -2937,7 +2937,7 @@ dependencies = [
  "itertools 0.8.2",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -3397,7 +3397,7 @@ checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -3464,7 +3464,7 @@ dependencies = [
  "darling 0.12.2",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -3498,7 +3498,7 @@ checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -3639,7 +3639,7 @@ checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -3702,7 +3702,7 @@ dependencies = [
  "quote 1.0.9",
  "serde 1.0.125",
  "serde_derive",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -3718,7 +3718,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -3764,9 +3764,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.65"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
+checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -3781,7 +3781,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
  "unicode-xid 0.2.1",
 ]
 
@@ -3871,7 +3871,7 @@ checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -3937,7 +3937,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "standback",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -4002,7 +4002,7 @@ checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -4013,7 +4013,7 @@ checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -4103,7 +4103,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "prost-build",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -4314,7 +4314,7 @@ checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -4395,7 +4395,7 @@ checksum = "f85f4270f4f449a3f2c0cf2aecc8415e388a597aeacc7d55fc749c5c968c8533"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -4582,9 +4582,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if 1.0.0",
  "serde 1.0.125",
@@ -4594,24 +4594,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73157efb9af26fb564bb59a009afd1c7c334a44db171d280690d0c3faaec3468"
+checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4621,9 +4621,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
  "quote 1.0.9",
  "wasm-bindgen-macro-support",
@@ -4631,28 +4631,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.67",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f002ea97b5abdb19aafd48cbb5a0a7f6931cf36ea05a0a46ccc95d9f4c2cf43"
+checksum = "e972e914de63aa53bd84865e54f5c761bd274d48e5be3a6329a662c0386aa67a"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -4664,9 +4664,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a6c0bd3933daf64c78fc25a7452530f79fa7e21f77fa03d608d1e988a66735"
+checksum = "ea6153a8f9bf24588e9f25c87223414fff124049f68d3a442a0f0eab4768a8b6"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -4685,9 +4685,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "medea"
 version = "0.2.0-rc.1"
 edition = "2018"
+resolver = "2"
 description = "Medea media server"
 authors = ["Instrumentisto Team <developer@instrumentisto.com>"]
 license = "MPL-2.0"
@@ -30,6 +31,9 @@ codegen-units = 1
 
 [profile.release.package.medea-jason]
 opt-level = "s"  # Tell rustc to optimize for small code size.
+
+[profile.dev]
+split-debuginfo = "unpacked"
 
 [dependencies]
 actix = "0.10"

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ IMAGE_NAME := $(strip \
 	$(if $(call eq,$(image),medea-demo-edge),medea-demo,\
 	$(image))))
 
-RUST_VER := 1.50
-CHROME_VERSION := 88.0
+RUST_VER := 1.51
+CHROME_VERSION := 89.0
 FIREFOX_VERSION := 86.0.1
 
 crate-dir = .

--- a/crates/medea-coturn-telnet-client/Cargo.toml
+++ b/crates/medea-coturn-telnet-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "medea-coturn-telnet-client"
 version = "0.1.0"
 edition = "2018"
+resolver = "2"
 description = "Coturn TURN server telnet client"
 authors = ["Instrumentisto Team <developer@instrumentisto.com>"]
 license = "BlueOak-1.0.0"

--- a/crates/medea-macro/Cargo.toml
+++ b/crates/medea-macro/Cargo.toml
@@ -2,6 +2,7 @@
 name = "medea-macro"
 version = "0.2.0"
 edition = "2018"
+resolver = "2"
 description = "Internal macros and codegen for Medea media server project"
 authors = ["Instrumentisto Team <developer@instrumentisto.com>"]
 license = "BlueOak-1.0.0"

--- a/crates/medea-reactive/Cargo.toml
+++ b/crates/medea-reactive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "medea-reactive"
 version = "0.1.0"
 edition = "2018"
+resolver = "2"
 description = "Reactive mutable data containers"
 authors = ["Instrumentisto Team <developer@instrumentisto.com>"]
 license = "BlueOak-1.0.0"

--- a/crates/medea-reactive/src/subscribers_store/progressable/processed.rs
+++ b/crates/medea-reactive/src/subscribers_store/progressable/processed.rs
@@ -65,10 +65,10 @@ impl<'a, T> Future for Processed<'a, T> {
     }
 }
 
-impl<'a, T> Into<Factory<'a, T>> for Processed<'a, T> {
+impl<'a, T> From<Processed<'a, T>> for Factory<'a, T> {
     #[inline]
-    fn into(self) -> Factory<'a, T> {
-        self.factory
+    fn from(processed: Processed<'a, T>) -> Self {
+        processed.factory
     }
 }
 
@@ -95,10 +95,10 @@ pub struct AllProcessed<'a, T = ()> {
     fut: LocalBoxFuture<'a, T>,
 }
 
-impl<'a, T> Into<Factory<'a, T>> for AllProcessed<'a, T> {
+impl<'a, T> From<AllProcessed<'a, T>> for Factory<'a, T> {
     #[inline]
-    fn into(self) -> Box<dyn Fn() -> LocalBoxFuture<'a, T>> {
-        self.factory
+    fn from(processed: AllProcessed<'a, T>) -> Self {
+        processed.factory
     }
 }
 

--- a/crates/medea-reactive/src/subscribers_store/progressable/processed.rs
+++ b/crates/medea-reactive/src/subscribers_store/progressable/processed.rs
@@ -67,8 +67,8 @@ impl<'a, T> Future for Processed<'a, T> {
 
 impl<'a, T> From<Processed<'a, T>> for Factory<'a, T> {
     #[inline]
-    fn from(processed: Processed<'a, T>) -> Self {
-        processed.factory
+    fn from(p: Processed<'a, T>) -> Self {
+        p.factory
     }
 }
 
@@ -97,8 +97,8 @@ pub struct AllProcessed<'a, T = ()> {
 
 impl<'a, T> From<AllProcessed<'a, T>> for Factory<'a, T> {
     #[inline]
-    fn from(processed: AllProcessed<'a, T>) -> Self {
-        processed.factory
+    fn from(p: AllProcessed<'a, T>) -> Self {
+        p.factory
     }
 }
 

--- a/jason/Cargo.toml
+++ b/jason/Cargo.toml
@@ -2,6 +2,7 @@
 name = "medea-jason"
 version = "0.2.0-rc.1"
 edition = "2018"
+resolver = "2"
 description = "Client library for Medea media server"
 authors = ["Instrumentisto Team <developer@instrumentisto.com>"]
 license = "MPL-2.0"

--- a/jason/src/media/track/local.rs
+++ b/jason/src/media/track/local.rs
@@ -43,6 +43,10 @@ pub struct Track {
 impl Track {
     /// Builds new [`Track`] from the provided [`sys::MediaStreamTrack`] and
     /// [`MediaSourceKind`].
+    ///
+    /// # Panics
+    ///
+    /// If inner [`sys::MediaStreamTrack`] type is not `audio` or `video`.
     #[must_use]
     pub fn new(
         track: sys::MediaStreamTrack,

--- a/jason/src/media/track/local.rs
+++ b/jason/src/media/track/local.rs
@@ -41,12 +41,12 @@ pub struct Track {
 }
 
 impl Track {
-    /// Builds new [`Track`] from the provided [`sys::MediaStreamTrack`] and
+    /// Builds a new [`Track`] from the provided [`sys::MediaStreamTrack`] and
     /// [`MediaSourceKind`].
     ///
     /// # Panics
     ///
-    /// If inner [`sys::MediaStreamTrack`] type is not `audio` or `video`.
+    /// If the given [`sys::MediaStreamTrack`]'s kind is not `audio` or `video`.
     #[must_use]
     pub fn new(
         track: sys::MediaStreamTrack,

--- a/jason/src/media/track/remote.rs
+++ b/jason/src/media/track/remote.rs
@@ -46,6 +46,10 @@ impl Track {
     /// Creates new [`Track`] spawning a listener for its [`enabled`][1]
     /// property changes.
     ///
+    /// # Panics
+    ///
+    /// If provided [`sys::MediaStreamTrack`] kind is not `audio` or `video`.
+    ///
     /// [1]: https://tinyurl.com/w3-streams#dom-mediastreamtrack-enabled
     #[must_use]
     pub fn new<T>(track: T, media_source_kind: MediaSourceKind) -> Self

--- a/jason/src/media/track/remote.rs
+++ b/jason/src/media/track/remote.rs
@@ -43,7 +43,7 @@ struct Inner {
 pub struct Track(Rc<Inner>);
 
 impl Track {
-    /// Creates new [`Track`] spawning a listener for its [`enabled`][1]
+    /// Creates a new [`Track`] spawning a listener for its [`enabled`][1]
     /// property changes.
     ///
     /// # Panics

--- a/jason/src/peer/conn.rs
+++ b/jason/src/peer/conn.rs
@@ -676,8 +676,8 @@ impl RtcPeerConnection {
     ///
     /// # Panics
     ///
-    /// If any unexpected error happens while iterating over inner
-    /// [`SysRtcPeerConnection`]'s transceivers. Not supposed to ever happen.
+    /// If fails to [iterate over transceivers on JS side](js_sys::try_iter).
+    /// Not supposed to ever happen.
     ///
     /// [1]: https://w3.org/TR/webrtc/#dom-rtcrtptransceiver
     /// [2]: https://w3.org/TR/webrtc/#transceivers-set

--- a/jason/src/peer/conn.rs
+++ b/jason/src/peer/conn.rs
@@ -203,7 +203,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// Errors with [`RTCPeerConnectionError::PeerCreationError`] if
+    /// Errors with [`RtcPeerConnectionError::PeerCreationError`] if
     /// [`SysRtcPeerConnection`] creation fails.
     pub fn new<I>(ice_servers: I, is_force_relayed: bool) -> Result<Self>
     where
@@ -237,10 +237,10 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// Errors with [`RTCPeerConnectionError::RtcStatsError`] if getting or
+    /// Errors with [`RtcPeerConnectionError::RtcStatsError`] if getting or
     /// parsing of [`RtcStats`] fails.
     ///
-    /// Errors with [`RTCPeerConnectionError::GetStatsException`] when
+    /// Errors with [`RtcPeerConnectionError::GetStatsException`] when
     /// [PeerConnection.getStats][1] promise throws exception.
     ///
     /// [`PeerConnection`]: super::PeerConnection
@@ -261,7 +261,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// Errors with [`RTCPeerConnectionError::PeerConnectionEventBindFailed`] if
+    /// Errors with [`RtcPeerConnectionError::PeerConnectionEventBindFailed`] if
     /// [`EventListener`] binding fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#rtctrackevent
@@ -296,7 +296,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// Errors with [`RTCPeerConnectionError::PeerConnectionEventBindFailed`] if
+    /// Errors with [`RtcPeerConnectionError::PeerConnectionEventBindFailed`] if
     /// [`EventListener`] binding fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#dom-rtcpeerconnectioniceevent
@@ -356,7 +356,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// Will return [`RTCPeerConnectionError::PeerConnectionEventBindFailed`] if
+    /// Will return [`RtcPeerConnectionError::PeerConnectionEventBindFailed`] if
     /// [`EventListener`] binding fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#event-iceconnectionstatechange
@@ -391,7 +391,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// Will return [`RTCPeerConnectionError::PeerConnectionEventBindFailed`] if
+    /// Will return [`RtcPeerConnectionError::PeerConnectionEventBindFailed`] if
     /// [`EventListener`] binding fails.
     /// This error can be ignored, since this event is currently implemented
     /// only in Chrome and Safari.
@@ -450,7 +450,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// With [`RTCPeerConnectionError::AddIceCandidateFailed`] if
+    /// With [`RtcPeerConnectionError::AddIceCandidateFailed`] if
     /// [RtcPeerConnection.addIceCandidate()][3] fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#rtcpeerconnection-interface
@@ -491,7 +491,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// With [`RTCPeerConnectionError::SetLocalDescriptionFailed`] if
+    /// With [`RtcPeerConnectionError::SetLocalDescriptionFailed`] if
     /// [RtcPeerConnection.setLocalDescription()][1] fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#dom-peerconnection-setlocaldescription
@@ -518,7 +518,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// With [`RTCPeerConnectionError::SetLocalDescriptionFailed`] if
+    /// With [`RtcPeerConnectionError::SetLocalDescriptionFailed`] if
     /// [RtcPeerConnection.setLocalDescription()][1] fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#dom-peerconnection-setlocaldescription
@@ -532,7 +532,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// With [`RTCPeerConnectionError::SetLocalDescriptionFailed`] if
+    /// With [`RtcPeerConnectionError::SetLocalDescriptionFailed`] if
     /// [RtcPeerConnection.setLocalDescription()][1] fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#dom-peerconnection-setlocaldescription
@@ -549,7 +549,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// With [`RTCPeerConnectionError::CreateAnswerFailed`] if
+    /// With [`RtcPeerConnectionError::CreateAnswerFailed`] if
     /// [RtcPeerConnection.createAnswer()][1] fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#dom-rtcpeerconnection-createanswer
@@ -569,7 +569,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// With [`RTCPeerConnectionError::SetLocalDescriptionFailed`] if
+    /// With [`RtcPeerConnectionError::SetLocalDescriptionFailed`] if
     /// [RtcPeerConnection.setLocalDescription()][1] fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#dom-peerconnection-setlocaldescription
@@ -595,7 +595,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// With [`RTCPeerConnectionError::CreateOfferFailed`] if
+    /// With [`RtcPeerConnectionError::CreateOfferFailed`] if
     /// [RtcPeerConnection.createOffer()][1] fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#dom-rtcpeerconnection-createoffer
@@ -626,7 +626,7 @@ impl RtcPeerConnection {
     ///
     /// # Errors
     ///
-    /// With [`RTCPeerConnectionError::SetRemoteDescriptionFailed`] if
+    /// With [`RtcPeerConnectionError::SetRemoteDescriptionFailed`] if
     /// [RTCPeerConnection.setRemoteDescription()][1] fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#dom-peerconnection-setremotedescription

--- a/jason/src/peer/media/mod.rs
+++ b/jason/src/peer/media/mod.rs
@@ -657,9 +657,9 @@ impl MediaConnections {
     ///
     /// # Panics
     ///
-    /// If [`Transceiver`] from provided [`RtcTrackEvent`] does not have
-    /// [`mid`]. Not supposed to happen, since [`RtcTrackEvent`] is only
-    /// fired when [`Transceiver`] is negotiated thus have [`mid`].
+    /// If [`Transceiver`] from the provided [`RtcTrackEvent`] doesn't have a
+    /// [`mid`]. Not supposed to happen, since [`RtcTrackEvent`] is only fired
+    /// when a [`Transceiver`] is negotiated, thus have a [`mid`].
     ///
     /// [`Sender`]: self::sender::Sender
     /// [`Receiver`]: self::receiver::Receiver

--- a/jason/src/peer/media/mod.rs
+++ b/jason/src/peer/media/mod.rs
@@ -655,8 +655,15 @@ impl MediaConnections {
     /// Errors with [`MediaConnectionsError::CouldNotInsertRemoteTrack`] if
     /// could not find [`Receiver`] by transceivers `mid`.
     ///
+    /// # Panics
+    ///
+    /// If [`Transceiver`] from provided [`RtcTrackEvent`] does not have
+    /// [`mid`]. Not supposed to happen, since [`RtcTrackEvent`] is only
+    /// fired when [`Transceiver`] is negotiated thus have [`mid`].
+    ///
     /// [`Sender`]: self::sender::Sender
     /// [`Receiver`]: self::receiver::Receiver
+    /// [`mid`]: https://w3.org/TR/webrtc/#dom-rtptransceiver-mid
     pub fn add_remote_track(&self, track_event: &RtcTrackEvent) -> Result<()> {
         let inner = self.0.borrow();
         let transceiver = Transceiver::from(track_event.transceiver());

--- a/jason/src/peer/media/sender/mod.rs
+++ b/jason/src/peer/media/sender/mod.rs
@@ -136,15 +136,14 @@ impl Sender {
     ///
     /// # Panics
     ///
-    /// If [`replaceTrack`][1] call fails. This might happen if underlying
-    /// [`RTCRtpSender`][1] is stopped. [`replaceTrack`][1] with `null` track
+    /// If [replaceTrack()][2] call fails. This might happen if an underlying
+    /// [RTCRtpSender][1] is stopped. [replaceTrack()][2] with `null` track
     /// should never fail for any other reason.
     ///
     /// [1]: https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender
     /// [2]: https://w3.org/TR/webrtc/#dom-rtcrtpsender-replacetrack
     #[inline]
     pub async fn remove_track(&self) {
-        // cannot fail
         self.transceiver.set_send_track(None).await.unwrap();
     }
 

--- a/jason/src/peer/media/sender/mod.rs
+++ b/jason/src/peer/media/sender/mod.rs
@@ -133,6 +133,15 @@ impl Sender {
 
     /// Drops [`local::Track`] used by this [`Sender`]. Sets track used by
     /// sending side of inner transceiver to [`None`].
+    ///
+    /// # Panics
+    ///
+    /// If [`replaceTrack`][1] call fails. This might happen if underlying
+    /// [`RTCRtpSender`][1] is stopped. [`replaceTrack`][1] with `null` track
+    /// should never fail for any other reason.
+    ///
+    /// [1]: https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender
+    /// [2]: https://w3.org/TR/webrtc/#dom-rtcrtpsender-replacetrack
     #[inline]
     pub async fn remove_track(&self) {
         // cannot fail

--- a/jason/src/peer/mod.rs
+++ b/jason/src/peer/mod.rs
@@ -45,7 +45,7 @@ use crate::{
 #[doc(inline)]
 pub use self::{
     component::{Component, State},
-    conn::{IceCandidate, RTCPeerConnectionError, RtcPeerConnection, SdpType},
+    conn::{IceCandidate, RtcPeerConnection, RtcPeerConnectionError, SdpType},
     media::{
         media_exchange_state, mute_state, receiver, sender, MediaConnections,
         MediaConnectionsError, MediaExchangeState,
@@ -77,7 +77,7 @@ pub enum PeerError {
     ///
     /// [1]: https://w3.org/TR/webrtc/#dom-rtcpeerconnection
     #[display(fmt = "{}", _0)]
-    RtcPeerConnection(#[js(cause)] RTCPeerConnectionError),
+    RtcPeerConnection(#[js(cause)] RtcPeerConnectionError),
 
     /// Errors that may occur when validating [`TracksRequest`] or parsing
     /// [`local::Track`]s.

--- a/jason/src/peer/mod.rs
+++ b/jason/src/peer/mod.rs
@@ -846,7 +846,7 @@ impl PeerConnection {
     ///
     /// # Errors
     ///
-    /// With [`RTCPeerConnectionError::SetRemoteDescriptionFailed`] if
+    /// With [`RtcPeerConnectionError::SetRemoteDescriptionFailed`] if
     /// [RTCPeerConnection.setRemoteDescription()][2] fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#rtcpeerconnection-interface
@@ -861,7 +861,7 @@ impl PeerConnection {
     ///
     /// # Errors
     ///
-    /// With [`RTCPeerConnectionError::SetRemoteDescriptionFailed`] if
+    /// With [`RtcPeerConnectionError::SetRemoteDescriptionFailed`] if
     /// [RTCPeerConnection.setRemoteDescription()][2] fails.
     ///
     /// [1]: https://w3.org/TR/webrtc/#rtcpeerconnection-interface
@@ -877,10 +877,10 @@ impl PeerConnection {
     ///
     /// # Errors
     ///
-    /// With [`RTCPeerConnectionError::SetRemoteDescriptionFailed`] if
+    /// With [`RtcPeerConnectionError::SetRemoteDescriptionFailed`] if
     /// [RTCPeerConnection.setRemoteDescription()][2] fails.
     ///
-    /// With [`RTCPeerConnectionError::AddIceCandidateFailed`] if
+    /// With [`RtcPeerConnectionError::AddIceCandidateFailed`] if
     /// [RtcPeerConnection.addIceCandidate()][3] fails when adding buffered ICE
     /// candidates.
     ///
@@ -921,7 +921,7 @@ impl PeerConnection {
     ///
     /// # Errors
     ///
-    /// With [`RTCPeerConnectionError::AddIceCandidateFailed`] if
+    /// With [`RtcPeerConnectionError::AddIceCandidateFailed`] if
     /// [RtcPeerConnection.addIceCandidate()][2] fails to add buffered
     /// [ICE candidates][1].
     ///

--- a/jason/src/utils/mod.rs
+++ b/jason/src/utils/mod.rs
@@ -151,6 +151,10 @@ where
 
 /// [`Future`] which resolves after the provided [`JsDuration`].
 ///
+/// # Panics
+///
+/// If fails to interact with JS side.
+///
 /// [`Future`]: std::future::Future
 ///
 /// # Panics

--- a/jason/src/utils/mod.rs
+++ b/jason/src/utils/mod.rs
@@ -8,10 +8,10 @@ pub mod component;
 mod event_listener;
 mod resettable_delay;
 
-use std::{convert::TryInto as _, future::Future, ops::Mul, time::Duration};
+use std::{convert::TryInto as _, ops::Mul, time::Duration};
 
 use derive_more::{From, Sub};
-use futures::future::{self, AbortHandle};
+use futures::future::{self, AbortHandle, Future};
 use js_sys::{Promise, Reflect};
 use medea_reactive::Guarded;
 use wasm_bindgen::prelude::*;
@@ -152,6 +152,11 @@ where
 /// [`Future`] which resolves after the provided [`JsDuration`].
 ///
 /// [`Future`]: std::future::Future
+///
+/// # Panics
+///
+/// If call to UA's `setTimeout()` returns error or [`Promise`] to [`Future`]
+/// conversion fails.
 pub async fn delay_for(delay_ms: JsDuration) {
     JsFuture::from(Promise::new(&mut |yes, _| {
         window()

--- a/mock/control-api/Cargo.toml
+++ b/mock/control-api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "medea-control-api-mock"
 version = "0.1.0"
 edition = "2018"
+resolver = "2"
 description = "Mock server for Medea's Control API."
 authors = ["Instrumentisto Team <developer@instrumentisto.com>"]
 license = "BlueOak-1.0.0"

--- a/mock/control-api/src/api/endpoint.rs
+++ b/mock/control-api/src/api/endpoint.rs
@@ -12,14 +12,13 @@ pub enum P2pMode {
     IfPossible,
 }
 
-impl Into<proto::web_rtc_publish_endpoint::P2p> for P2pMode {
-    fn into(self) -> proto::web_rtc_publish_endpoint::P2p {
-        use proto::web_rtc_publish_endpoint::P2p;
-
-        match self {
-            Self::Always => P2p::Always,
-            Self::IfPossible => P2p::IfPossible,
-            Self::Never => P2p::Never,
+impl From<P2pMode> for proto::web_rtc_publish_endpoint::P2p {
+    #[inline]
+    fn from(mode: P2pMode) -> Self {
+        match mode {
+            P2pMode::Always => Self::Always,
+            P2pMode::IfPossible => Self::IfPossible,
+            P2pMode::Never => Self::Never,
         }
     }
 }

--- a/mock/control-api/src/api/mod.rs
+++ b/mock/control-api/src/api/mod.rs
@@ -58,6 +58,10 @@ pub struct AppContext {
 
 /// Run REST [Control API] server mock.
 ///
+/// # Panics
+///
+/// If the given `args` don't contain an expected `medea_addr` value.
+///
 /// [Control API]: https://tinyurl.com/yxsqplq7
 pub async fn run(
     args: &ArgMatches<'static>,
@@ -149,7 +153,7 @@ macro_rules! gen_request_macro {
 /// # Errors
 ///
 /// Errors if unable to send message to [`GrpcCallbackServer`] actor.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::missing_panics_doc, clippy::needless_pass_by_value)]
 pub async fn get_callbacks(
     state: Data<AppContext>,
 ) -> Result<HttpResponse, ()> {
@@ -258,11 +262,11 @@ pub struct ErrorResponse {
 
 impl From<proto::Error> for ErrorResponse {
     #[inline]
-    fn from(err: proto::Error) -> Self {
-        ErrorResponse {
-            code: err.code,
-            text: err.text,
-            element: err.element,
+    fn from(e: proto::Error) -> Self {
+        Self {
+            code: e.code,
+            text: e.text,
+            element: e.element,
         }
     }
 }
@@ -308,9 +312,9 @@ macro_rules! impl_from_for_http_response {
         impl From<$resp> for HttpResponse {
             fn from(resp: $resp) -> Self {
                 if resp.error.is_some() {
-                    HttpResponse::BadRequest().json(resp)
+                    Self::BadRequest().json(resp)
                 } else {
-                    HttpResponse::Ok().json(resp)
+                    Self::Ok().json(resp)
                 }
             }
         }
@@ -357,6 +361,11 @@ pub enum Element {
 }
 
 impl Element {
+    /// Converts this [`Element`] into an appropriate [`proto::room::Element`].
+    ///
+    /// # Panics
+    ///
+    /// If a conversion for such an [`Element`] isn't implemented yet.
     #[must_use]
     pub fn into_proto(self, id: String) -> proto::room::Element {
         let el = match self {

--- a/mock/control-api/src/api/mod.rs
+++ b/mock/control-api/src/api/mod.rs
@@ -256,12 +256,13 @@ pub struct ErrorResponse {
     pub element: String,
 }
 
-impl Into<ErrorResponse> for proto::Error {
-    fn into(self) -> ErrorResponse {
+impl From<proto::Error> for ErrorResponse {
+    #[inline]
+    fn from(err: proto::Error) -> Self {
         ErrorResponse {
-            code: self.code,
-            text: self.text,
-            element: self.element,
+            code: err.code,
+            text: err.text,
+            element: err.element,
         }
     }
 }
@@ -296,29 +297,29 @@ pub struct Response {
     pub error: Option<ErrorResponse>,
 }
 
-/// Macro which implements [`Into`] [`HttpResponse`] for all
-/// `control-api-mock` responses.
+/// Macro that implements [`From`] `control-api-mock` responses for
+/// [`HttpResponse`].
 ///
 /// Implementation will check existence of `error` and if it exists then
 /// [`HttpResponse`] will be `BadRequest` with this struct as response in
 /// otherwise `Ok` with this struct as response.
-macro_rules! impl_into_http_response {
+macro_rules! impl_from_for_http_response {
     ($resp:tt) => {
-        impl Into<HttpResponse> for $resp {
-            fn into(self) -> HttpResponse {
-                if self.error.is_some() {
-                    HttpResponse::BadRequest().json(self)
+        impl From<$resp> for HttpResponse {
+            fn from(resp: $resp) -> Self {
+                if resp.error.is_some() {
+                    HttpResponse::BadRequest().json(resp)
                 } else {
-                    HttpResponse::Ok().json(self)
+                    HttpResponse::Ok().json(resp)
                 }
             }
         }
     };
 }
 
-impl_into_http_response!(CreateResponse);
-impl_into_http_response!(Response);
-impl_into_http_response!(SingleGetResponse);
+impl_from_for_http_response!(CreateResponse);
+impl_from_for_http_response!(Response);
+impl_from_for_http_response!(SingleGetResponse);
 
 impl From<proto::Response> for Response {
     fn from(resp: proto::Response) -> Self {

--- a/mock/control-api/src/api/ws.rs
+++ b/mock/control-api/src/api/ws.rs
@@ -63,6 +63,7 @@ enum NotificationVariants<'a> {
 
 impl Notification {
     /// Builds `method: Created` [`Notification`].
+    #[allow(clippy::missing_panics_doc)]
     #[must_use]
     pub fn created(fid: &Fid, element: &Element) -> Notification {
         Self(
@@ -75,6 +76,7 @@ impl Notification {
     }
 
     /// Builds `method: Deleted` [`Notification`].
+    #[allow(clippy::missing_panics_doc)]
     #[must_use]
     pub fn deleted(fid: &Fid) -> Notification {
         Self(
@@ -86,6 +88,7 @@ impl Notification {
     }
 
     /// Builds `method: Broadcast` [`Notification`].
+    #[allow(clippy::missing_panics_doc)]
     #[must_use]
     pub fn broadcast(payload: Value) -> Notification {
         Self(

--- a/mock/control-api/src/callback/server.rs
+++ b/mock/control-api/src/callback/server.rs
@@ -2,7 +2,10 @@
 //!
 //! [Callback service]: https://tinyurl.com/y5fajesq
 
-use std::sync::{Arc, Mutex};
+use std::{
+    convert::Infallible,
+    sync::{Arc, Mutex},
+};
 
 use actix::{Actor, Addr, Arbiter, Context, Handler, Message};
 use clap::ArgMatches;
@@ -63,11 +66,11 @@ impl CallbackService for GrpcCallbackService {
 /// [`Message`] which returns all [`CallbackItem`]s received by this
 /// [`GrpcCallbackServer`].
 #[derive(Message)]
-#[rtype(result = "Result<Vec<CallbackItem>, ()>")]
+#[rtype(result = "Result<Vec<CallbackItem>, Infallible>")]
 pub struct GetCallbackItems;
 
 impl Handler<GetCallbackItems> for GrpcCallbackServer {
-    type Result = Result<Vec<CallbackItem>, ()>;
+    type Result = Result<Vec<CallbackItem>, Infallible>;
 
     fn handle(
         &mut self,
@@ -79,6 +82,11 @@ impl Handler<GetCallbackItems> for GrpcCallbackServer {
 }
 
 /// Run [`GrpcCallbackServer`].
+///
+/// # Panics
+///
+/// If the given `args` don't contain expected `callback_host` and
+/// `callback_port` values.
 pub async fn run(args: &ArgMatches<'static>) -> Addr<GrpcCallbackServer> {
     let host = args.value_of("callback_host").unwrap();
     let port: u32 = args.value_of("callback_port").unwrap().parse().unwrap();

--- a/mock/control-api/src/client.rs
+++ b/mock/control-api/src/client.rs
@@ -99,6 +99,7 @@ impl ControlClient {
     /// # Errors
     ///
     /// Errors if gRPC request fails.
+    #[allow(clippy::missing_panics_doc)]
     pub async fn create(
         &self,
         id: String,
@@ -160,6 +161,7 @@ impl ControlClient {
     /// # Errors
     ///
     /// Errors if gRPC request fails.
+    #[allow(clippy::missing_panics_doc)]
     pub async fn delete(&self, fid: Fid) -> Result<proto::Response, Status> {
         let req = id_request(vec![fid.clone().into()]);
         let response = self.get_client().delete(tonic::Request::new(req)).await;

--- a/mock/control-api/src/lib.rs
+++ b/mock/control-api/src/lib.rs
@@ -3,7 +3,7 @@
 //! [Medea]: https://github.com/instrumentisto/medea
 //! [Control API]: https://tinyurl.com/yxsqplq7
 
-#![allow(clippy::module_name_repetitions, clippy::missing_panics_doc)]
+#![allow(clippy::module_name_repetitions)]
 
 pub mod api;
 pub mod callback;
@@ -27,6 +27,10 @@ pub mod proto {
 
 /// Initializes [`slog`] logger outputting logs with a [`slog_term`]'s
 /// decorator.
+///
+/// # Panics
+///
+/// If [`slog_stdlog`] fails to [initialize](slog_stdlog::init).
 pub fn init_logger() -> GlobalLoggerGuard {
     let decorator = slog_term::TermDecorator::new().build();
     let drain = slog_term::FullFormat::new(decorator).build().fuse();

--- a/mock/control-api/src/lib.rs
+++ b/mock/control-api/src/lib.rs
@@ -3,7 +3,7 @@
 //! [Medea]: https://github.com/instrumentisto/medea
 //! [Control API]: https://tinyurl.com/yxsqplq7
 
-#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::module_name_repetitions, clippy::missing_panics_doc)]
 
 pub mod api;
 pub mod callback;

--- a/proto/client-api/Cargo.toml
+++ b/proto/client-api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "medea-client-api-proto"
 version = "0.2.0"
 edition = "2018"
+resolver = "2"
 description = "Client API protocol implementation for Medea media server"
 authors = ["Instrumentisto Team <developer@instrumentisto.com>"]
 license = "BlueOak-1.0.0"

--- a/proto/control-api/Cargo.toml
+++ b/proto/control-api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "medea-control-api-proto"
 version = "0.1.0"
 edition = "2018"
+resolver = "2"
 description = "Control API protocol implementation for Medea media server"
 authors = ["Instrumentisto Team <developer@instrumentisto.com>"]
 license = "BlueOak-1.0.0"

--- a/src/api/control/callback/mod.rs
+++ b/src/api/control/callback/mod.rs
@@ -35,9 +35,9 @@ impl OnLeaveEvent {
 
 impl From<OnLeaveEvent> for proto::OnLeave {
     #[inline]
-    fn from(event: OnLeaveEvent) -> Self {
-        proto::OnLeave {
-            reason: proto::on_leave::Reason::from(event.reason) as i32,
+    fn from(ev: OnLeaveEvent) -> Self {
+        Self {
+            reason: proto::on_leave::Reason::from(ev.reason) as i32,
         }
     }
 }
@@ -60,8 +60,8 @@ pub enum OnLeaveReason {
 
 impl From<OnLeaveReason> for proto::on_leave::Reason {
     #[inline]
-    fn from(reason: OnLeaveReason) -> Self {
-        match reason {
+    fn from(rsn: OnLeaveReason) -> Self {
+        match rsn {
             OnLeaveReason::LostConnection => Self::LostConnection,
             OnLeaveReason::ServerShutdown => Self::ServerShutdown,
             OnLeaveReason::Disconnected => Self::Disconnected,
@@ -77,7 +77,7 @@ pub struct OnJoinEvent;
 impl From<OnJoinEvent> for proto::OnJoin {
     #[inline]
     fn from(_: OnJoinEvent) -> Self {
-        proto::OnJoin {}
+        Self {}
     }
 }
 
@@ -90,8 +90,8 @@ pub enum CallbackEvent {
 
 impl From<CallbackEvent> for proto::request::Event {
     #[inline]
-    fn from(event: CallbackEvent) -> Self {
-        match event {
+    fn from(ev: CallbackEvent) -> Self {
+        match ev {
             CallbackEvent::OnJoin(on_join) => Self::OnJoin(on_join.into()),
             CallbackEvent::OnLeave(on_leave) => Self::OnLeave(on_leave.into()),
         }
@@ -196,12 +196,11 @@ impl CallbackRequest {
 }
 
 impl From<CallbackRequest> for proto::Request {
-    #[inline]
-    fn from(request: CallbackRequest) -> Self {
+    fn from(req: CallbackRequest) -> Self {
         Self {
-            event: Some(request.event.into()),
-            fid: request.fid.to_string(),
-            at: request.at.to_rfc3339(),
+            event: Some(req.event.into()),
+            fid: req.fid.to_string(),
+            at: req.at.to_rfc3339(),
         }
     }
 }

--- a/src/api/control/callback/mod.rs
+++ b/src/api/control/callback/mod.rs
@@ -33,11 +33,11 @@ impl OnLeaveEvent {
     }
 }
 
-impl Into<proto::OnLeave> for OnLeaveEvent {
-    fn into(self) -> proto::OnLeave {
-        let on_leave: proto::on_leave::Reason = self.reason.into();
+impl From<OnLeaveEvent> for proto::OnLeave {
+    #[inline]
+    fn from(event: OnLeaveEvent) -> Self {
         proto::OnLeave {
-            reason: on_leave as i32,
+            reason: proto::on_leave::Reason::from(event.reason) as i32,
         }
     }
 }
@@ -58,13 +58,14 @@ pub enum OnLeaveReason {
     ServerShutdown,
 }
 
-impl Into<proto::on_leave::Reason> for OnLeaveReason {
-    fn into(self) -> proto::on_leave::Reason {
-        match self {
-            Self::LostConnection => proto::on_leave::Reason::LostConnection,
-            Self::ServerShutdown => proto::on_leave::Reason::ServerShutdown,
-            Self::Disconnected => proto::on_leave::Reason::Disconnected,
-            Self::Kicked => proto::on_leave::Reason::Kicked,
+impl From<OnLeaveReason> for proto::on_leave::Reason {
+    #[inline]
+    fn from(reason: OnLeaveReason) -> Self {
+        match reason {
+            OnLeaveReason::LostConnection => Self::LostConnection,
+            OnLeaveReason::ServerShutdown => Self::ServerShutdown,
+            OnLeaveReason::Disconnected => Self::Disconnected,
+            OnLeaveReason::Kicked => Self::Kicked,
         }
     }
 }
@@ -73,8 +74,9 @@ impl Into<proto::on_leave::Reason> for OnLeaveReason {
 #[derive(Debug)]
 pub struct OnJoinEvent;
 
-impl Into<proto::OnJoin> for OnJoinEvent {
-    fn into(self) -> proto::OnJoin {
+impl From<OnJoinEvent> for proto::OnJoin {
+    #[inline]
+    fn from(_: OnJoinEvent) -> Self {
         proto::OnJoin {}
     }
 }
@@ -86,15 +88,12 @@ pub enum CallbackEvent {
     OnLeave(OnLeaveEvent),
 }
 
-impl Into<proto::request::Event> for CallbackEvent {
-    fn into(self) -> proto::request::Event {
-        match self {
-            Self::OnJoin(on_join) => {
-                proto::request::Event::OnJoin(on_join.into())
-            }
-            Self::OnLeave(on_leave) => {
-                proto::request::Event::OnLeave(on_leave.into())
-            }
+impl From<CallbackEvent> for proto::request::Event {
+    #[inline]
+    fn from(event: CallbackEvent) -> Self {
+        match event {
+            CallbackEvent::OnJoin(on_join) => Self::OnJoin(on_join.into()),
+            CallbackEvent::OnLeave(on_leave) => Self::OnLeave(on_leave.into()),
         }
     }
 }
@@ -196,12 +195,13 @@ impl CallbackRequest {
     }
 }
 
-impl Into<proto::Request> for CallbackRequest {
-    fn into(self) -> proto::Request {
-        proto::Request {
-            event: Some(self.event.into()),
-            fid: self.fid.to_string(),
-            at: self.at.to_rfc3339(),
+impl From<CallbackRequest> for proto::Request {
+    #[inline]
+    fn from(request: CallbackRequest) -> Self {
+        Self {
+            event: Some(request.event.into()),
+            fid: request.fid.to_string(),
+            at: request.at.to_rfc3339(),
         }
     }
 }

--- a/src/api/control/endpoints/mod.rs
+++ b/src/api/control/endpoints/mod.rs
@@ -53,15 +53,14 @@ pub enum EndpointSpec {
     WebRtcPlay(WebRtcPlayEndpoint),
 }
 
-impl Into<MemberElement> for EndpointSpec {
-    fn into(self) -> MemberElement {
-        match self {
-            Self::WebRtcPublish(e) => {
-                MemberElement::WebRtcPublishEndpoint { spec: e }
+impl From<EndpointSpec> for MemberElement {
+    #[inline]
+    fn from(spec: EndpointSpec) -> Self {
+        match spec {
+            EndpointSpec::WebRtcPublish(e) => {
+                Self::WebRtcPublishEndpoint { spec: e }
             }
-            Self::WebRtcPlay(e) => {
-                MemberElement::WebRtcPlayEndpoint { spec: e }
-            }
+            EndpointSpec::WebRtcPlay(e) => Self::WebRtcPlayEndpoint { spec: e },
         }
     }
 }

--- a/src/api/control/endpoints/webrtc_publish_endpoint.rs
+++ b/src/api/control/endpoints/webrtc_publish_endpoint.rs
@@ -39,14 +39,13 @@ impl From<proto::web_rtc_publish_endpoint::P2p> for P2pMode {
     }
 }
 
-impl Into<proto::web_rtc_publish_endpoint::P2p> for P2pMode {
-    fn into(self) -> proto::web_rtc_publish_endpoint::P2p {
-        use proto::web_rtc_publish_endpoint::P2p;
-
-        match self {
-            Self::Always => P2p::Always,
-            Self::IfPossible => P2p::IfPossible,
-            Self::Never => P2p::Never,
+impl From<P2pMode> for proto::web_rtc_publish_endpoint::P2p {
+    #[inline]
+    fn from(mode: P2pMode) -> Self {
+        match mode {
+            P2pMode::Always => Self::Always,
+            P2pMode::IfPossible => Self::IfPossible,
+            P2pMode::Never => Self::Never,
         }
     }
 }

--- a/src/api/control/error_codes.rs
+++ b/src/api/control/error_codes.rs
@@ -105,18 +105,18 @@ impl ErrorResponse {
     }
 }
 
-impl Into<proto::Error> for ErrorResponse {
-    fn into(self) -> proto::Error {
-        let text = if let Some(additional_text) = &self.explanation {
-            format!("{} {}", self.error_code.to_string(), additional_text)
+impl From<ErrorResponse> for proto::Error {
+    fn from(resp: ErrorResponse) -> Self {
+        let text = if let Some(additional_text) = &resp.explanation {
+            format!("{} {}", resp.error_code.to_string(), additional_text)
         } else {
-            self.error_code.to_string()
+            resp.error_code.to_string()
         };
-        proto::Error {
+        Self {
             doc: String::new(),
             text,
-            element: self.element_id.unwrap_or_default(),
-            code: self.error_code as u32,
+            element: resp.element_id.unwrap_or_default(),
+            code: resp.error_code as u32,
         }
     }
 }

--- a/src/api/control/grpc/server.rs
+++ b/src/api/control/grpc/server.rs
@@ -295,7 +295,9 @@ impl Handler<ShutdownGracefully> for GrpcServer {
     }
 }
 
-/// Run gRPC [Control API] server in actix actor.
+/// Run gRPC [Control API] server in actix actor. Returns [`Addr`] of
+/// [`GrpcServer`] [`Actor`] and [`oneshot::Receiver`] for [`transport::Error`]
+/// that may fire when initializing [`GrpcServer`].
 ///
 /// [Control API]: https://tinyurl.com/yxsqplq7
 pub fn run(

--- a/src/api/control/grpc/server.rs
+++ b/src/api/control/grpc/server.rs
@@ -5,12 +5,14 @@
 use std::{
     collections::HashMap,
     convert::{From, TryFrom},
+    net::SocketAddr,
 };
 
-use actix::{Actor, Addr, Arbiter, Context, Handler, MailboxError};
+use actix::{Actor, Addr, Arbiter, Context, Handler, MailboxError, System};
 use async_trait::async_trait;
 use derive_more::{Display, From};
 use failure::Fail;
+use futures::channel::oneshot;
 use medea_client_api_proto::MemberId;
 use medea_control_api_proto::grpc::{
     api as proto,
@@ -18,7 +20,10 @@ use medea_control_api_proto::grpc::{
         ControlApi, ControlApiServer as TonicControlApiServer,
     },
 };
-use tonic::{transport::Server, Status};
+use tonic::{
+    transport::{self, Server},
+    Status,
+};
 
 use crate::{
     api::control::{
@@ -293,32 +298,45 @@ impl Handler<ShutdownGracefully> for GrpcServer {
 /// Run gRPC [Control API] server in actix actor.
 ///
 /// [Control API]: https://tinyurl.com/yxsqplq7
-pub async fn run(
+pub fn run(
     room_service: Addr<RoomService>,
     app: &AppContext,
-) -> Addr<GrpcServer> {
-    let bind_ip = app.config.server.control.grpc.bind_ip.to_string();
+) -> (
+    Addr<GrpcServer>,
+    oneshot::Receiver<Result<(), transport::Error>>,
+) {
+    let bind_ip = app.config.server.control.grpc.bind_ip;
     let bind_port = app.config.server.control.grpc.bind_port;
 
     info!("Starting gRPC server on {}:{}", bind_ip, bind_port);
 
-    let (grpc_shutdown_tx, grpc_shutdown_rx) =
-        futures::channel::oneshot::channel();
+    let bind_addr = SocketAddr::from((bind_ip, bind_port));
+    let (grpc_shutdown_tx, grpc_shutdown_rx) = oneshot::channel();
+    let (tonic_server_tx, tonic_server_rx) = oneshot::channel();
+    let grpc_actor_addr =
+        GrpcServer::start_in_arbiter(&Arbiter::new(), move |_| {
+            Arbiter::spawn(async move {
+                let result = Server::builder()
+                    .add_service(TonicControlApiServer::new(ControlApiService(
+                        room_service,
+                    )))
+                    .serve_with_shutdown(bind_addr, async move {
+                        let _ = grpc_shutdown_rx.await;
+                    })
+                    .await;
 
-    let addr = format!("{}:{}", bind_ip, bind_port).parse().unwrap();
-    Arbiter::spawn(async move {
-        Server::builder()
-            .add_service(TonicControlApiServer::new(ControlApiService(
-                room_service,
-            )))
-            .serve_with_shutdown(addr, async move {
-                grpc_shutdown_rx.await.ok();
-            })
-            .await
-            .unwrap();
-    });
+                if let Err(err) = tonic_server_tx.send(result) {
+                    error!(
+                        "gRPC server failed to start, and error could not \
+                        be propagated. Error details: {:?}",
+                        err
+                    );
+                    System::current().stop();
+                };
+            });
 
-    GrpcServer::start_in_arbiter(&Arbiter::new(), move |_| {
-        GrpcServer(Some(grpc_shutdown_tx))
-    })
+            GrpcServer(Some(grpc_shutdown_tx))
+        });
+
+    (grpc_actor_addr, tonic_server_rx)
 }

--- a/src/api/control/member.rs
+++ b/src/api/control/member.rs
@@ -137,16 +137,17 @@ pub struct MemberSpec {
     ping_interval: Option<Duration>,
 }
 
-impl Into<RoomElement> for MemberSpec {
-    fn into(self) -> RoomElement {
-        RoomElement::Member {
-            spec: self.pipeline,
-            credentials: self.credentials,
-            on_join: self.on_join,
-            on_leave: self.on_leave,
-            idle_timeout: self.idle_timeout,
-            reconnect_timeout: self.reconnect_timeout,
-            ping_interval: self.ping_interval,
+impl From<MemberSpec> for RoomElement {
+    #[inline]
+    fn from(spec: MemberSpec) -> Self {
+        Self::Member {
+            spec: spec.pipeline,
+            credentials: spec.credentials,
+            on_join: spec.on_join,
+            on_leave: spec.on_leave,
+            idle_timeout: spec.idle_timeout,
+            reconnect_timeout: spec.reconnect_timeout,
+            ping_interval: spec.ping_interval,
         }
     }
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -239,6 +239,10 @@ pub fn load_static_specs_from_dir<P: AsRef<Path>>(
 ///
 /// Errors if unable to send message to [`RoomService`] actor.
 ///
+/// # Panics
+///
+/// If the [`RoomService`] fails to start all static [`Room`]s.
+///
 /// [Control API]: https://tinyurl.com/yxsqplq7
 /// [`Room`]: crate::signalling::room::Room
 pub async fn start_static_rooms(

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -252,7 +252,7 @@ pub async fn start_static_rooms(
              specs not loaded. {}",
             e,
         ),
-        Err(e) => panic!("{}", e),
+        Err(e) => return Err(Error::from(e)),
         Ok(_) => {}
     };
     Ok(())

--- a/src/conf/server.rs
+++ b/src/conf/server.rs
@@ -1,6 +1,6 @@
 //! Settings for application servers.
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs as _};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use serde::{Deserialize, Serialize};
 use smart_default::SmartDefault;
@@ -55,11 +55,7 @@ impl ClientApiHttpServer {
     #[inline]
     #[must_use]
     pub fn bind_addr(&self) -> SocketAddr {
-        (self.bind_ip, self.bind_port)
-            .to_socket_addrs()
-            .unwrap()
-            .next()
-            .unwrap()
+        (self.bind_ip, self.bind_port).into()
     }
 }
 

--- a/src/conf/server.rs
+++ b/src/conf/server.rs
@@ -51,7 +51,7 @@ pub struct ClientApiHttpServer {
 }
 
 impl ClientApiHttpServer {
-    /// Builds [`SocketAddr`] from `bind_ip` and `bind_port`.
+    /// Builds a [`SocketAddr`] from `bind_ip` and `bind_port`.
     #[inline]
     #[must_use]
     pub fn bind_addr(&self) -> SocketAddr {

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -260,7 +260,7 @@ impl PeerStateMachine {
     ///
     /// # Panics
     ///
-    /// If this [`Peer`] does not have [`IceUser`].
+    /// If this [`Peer`] doesn't have an [`IceUser`].
     #[must_use]
     pub fn get_state(&self) -> state::Peer {
         state::Peer {

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -257,6 +257,10 @@ impl PeerStateMachine {
     }
 
     /// Returns a [`state::Peer`] of this [`PeerStateMachine`].
+    ///
+    /// # Panics
+    ///
+    /// If this [`Peer`] does not have [`IceUser`].
     #[must_use]
     pub fn get_state(&self) -> state::Peer {
         state::Peer {

--- a/src/signalling/elements/endpoints/mod.rs
+++ b/src/signalling/elements/endpoints/mod.rs
@@ -40,8 +40,8 @@ impl From<Endpoint> for proto::Element {
     #[inline]
     fn from(endpoint: Endpoint) -> Self {
         match endpoint {
-            Endpoint::WebRtcPublishEndpoint(play) => Self::from(play),
-            Endpoint::WebRtcPlayEndpoint(publish) => Self::from(publish),
+            Endpoint::WebRtcPublishEndpoint(play) => play.into(),
+            Endpoint::WebRtcPlayEndpoint(publish) => publish.into(),
         }
     }
 }

--- a/src/signalling/elements/endpoints/mod.rs
+++ b/src/signalling/elements/endpoints/mod.rs
@@ -36,12 +36,12 @@ impl Endpoint {
     }
 }
 
-impl Into<proto::Element> for Endpoint {
+impl From<Endpoint> for proto::Element {
     #[inline]
-    fn into(self) -> proto::Element {
-        match self {
-            Self::WebRtcPublishEndpoint(play) => play.into(),
-            Self::WebRtcPlayEndpoint(publish) => publish.into(),
+    fn from(endpoint: Endpoint) -> Self {
+        match endpoint {
+            Endpoint::WebRtcPublishEndpoint(play) => Self::from(play),
+            Endpoint::WebRtcPlayEndpoint(publish) => Self::from(publish),
         }
     }
 }

--- a/src/signalling/elements/endpoints/webrtc/play_endpoint.rs
+++ b/src/signalling/elements/endpoints/webrtc/play_endpoint.rs
@@ -250,7 +250,6 @@ impl From<WebRtcPlayEndpoint> for proto::member::Element {
 }
 
 impl From<WebRtcPlayEndpoint> for proto::WebRtcPlayEndpoint {
-    #[inline]
     fn from(endpoint: WebRtcPlayEndpoint) -> Self {
         Self {
             on_start: String::new(),

--- a/src/signalling/elements/endpoints/webrtc/play_endpoint.rs
+++ b/src/signalling/elements/endpoints/webrtc/play_endpoint.rs
@@ -240,30 +240,33 @@ impl WeakWebRtcPlayEndpoint {
     }
 }
 
-impl Into<proto::member::Element> for WebRtcPlayEndpoint {
-    fn into(self) -> proto::member::Element {
-        proto::member::Element {
-            el: Some(proto::member::element::El::WebrtcPlay(self.into())),
+impl From<WebRtcPlayEndpoint> for proto::member::Element {
+    #[inline]
+    fn from(endpoint: WebRtcPlayEndpoint) -> Self {
+        Self {
+            el: Some(proto::member::element::El::WebrtcPlay(endpoint.into())),
         }
     }
 }
 
-impl Into<proto::WebRtcPlayEndpoint> for WebRtcPlayEndpoint {
-    fn into(self) -> proto::WebRtcPlayEndpoint {
-        proto::WebRtcPlayEndpoint {
+impl From<WebRtcPlayEndpoint> for proto::WebRtcPlayEndpoint {
+    #[inline]
+    fn from(endpoint: WebRtcPlayEndpoint) -> Self {
+        Self {
             on_start: String::new(),
             on_stop: String::new(),
-            src: self.src_uri().to_string(),
-            id: self.id().to_string(),
-            force_relay: self.is_force_relayed(),
+            src: endpoint.src_uri().to_string(),
+            id: endpoint.id().to_string(),
+            force_relay: endpoint.is_force_relayed(),
         }
     }
 }
 
-impl Into<proto::Element> for WebRtcPlayEndpoint {
-    fn into(self) -> proto::Element {
-        proto::Element {
-            el: Some(proto::element::El::WebrtcPlay(self.into())),
+impl From<WebRtcPlayEndpoint> for proto::Element {
+    #[inline]
+    fn from(endpoint: WebRtcPlayEndpoint) -> Self {
+        Self {
+            el: Some(proto::element::El::WebrtcPlay(endpoint.into())),
         }
     }
 }

--- a/src/signalling/elements/endpoints/webrtc/publish_endpoint.rs
+++ b/src/signalling/elements/endpoints/webrtc/publish_endpoint.rs
@@ -304,8 +304,8 @@ impl WeakWebRtcPublishEndpoint {
 
 impl From<WebRtcPublishEndpoint> for proto::WebRtcPublishEndpoint {
     fn from(endpoint: WebRtcPublishEndpoint) -> Self {
-        let p2p = proto::web_rtc_publish_endpoint::P2p::from(endpoint.p2p());
-        proto::WebRtcPublishEndpoint {
+        let p2p: proto::web_rtc_publish_endpoint::P2p = endpoint.p2p().into();
+        Self {
             p2p: p2p as i32,
             id: endpoint.id().to_string(),
             force_relay: endpoint.is_force_relayed(),

--- a/src/signalling/elements/endpoints/webrtc/publish_endpoint.rs
+++ b/src/signalling/elements/endpoints/webrtc/publish_endpoint.rs
@@ -63,7 +63,7 @@ impl Drop for WebRtcPublishEndpointInner {
             .filter_map(WeakWebRtcPlayEndpoint::safe_upgrade)
         {
             if let Some(receiver_owner) = receiver.weak_owner().safe_upgrade() {
-                receiver_owner.remove_sink(&receiver.id())
+                drop(receiver_owner.take_sink(&receiver.id()))
             }
         }
     }
@@ -302,33 +302,35 @@ impl WeakWebRtcPublishEndpoint {
     }
 }
 
-impl Into<proto::WebRtcPublishEndpoint> for WebRtcPublishEndpoint {
-    fn into(self) -> proto::WebRtcPublishEndpoint {
-        let p2p: proto::web_rtc_publish_endpoint::P2p = self.p2p().into();
+impl From<WebRtcPublishEndpoint> for proto::WebRtcPublishEndpoint {
+    fn from(endpoint: WebRtcPublishEndpoint) -> Self {
+        let p2p = proto::web_rtc_publish_endpoint::P2p::from(endpoint.p2p());
         proto::WebRtcPublishEndpoint {
             p2p: p2p as i32,
-            id: self.id().to_string(),
-            force_relay: self.is_force_relayed(),
-            audio_settings: Some(self.audio_settings().into()),
-            video_settings: Some(self.video_settings().into()),
+            id: endpoint.id().to_string(),
+            force_relay: endpoint.is_force_relayed(),
+            audio_settings: Some(endpoint.audio_settings().into()),
+            video_settings: Some(endpoint.video_settings().into()),
             on_stop: String::new(),
             on_start: String::new(),
         }
     }
 }
 
-impl Into<proto::member::Element> for WebRtcPublishEndpoint {
-    fn into(self) -> proto::member::Element {
-        proto::member::Element {
-            el: Some(proto::member::element::El::WebrtcPub(self.into())),
+impl From<WebRtcPublishEndpoint> for proto::member::Element {
+    #[inline]
+    fn from(endpoint: WebRtcPublishEndpoint) -> Self {
+        Self {
+            el: Some(proto::member::element::El::WebrtcPub(endpoint.into())),
         }
     }
 }
 
-impl Into<proto::Element> for WebRtcPublishEndpoint {
-    fn into(self) -> proto::Element {
-        proto::Element {
-            el: Some(proto::element::El::WebrtcPub(self.into())),
+impl From<WebRtcPublishEndpoint> for proto::Element {
+    #[inline]
+    fn from(endpoint: WebRtcPublishEndpoint) -> Self {
+        Self {
+            el: Some(proto::element::El::WebrtcPub(endpoint.into())),
         }
     }
 }

--- a/src/signalling/elements/endpoints/webrtc/publish_endpoint.rs
+++ b/src/signalling/elements/endpoints/webrtc/publish_endpoint.rs
@@ -63,7 +63,7 @@ impl Drop for WebRtcPublishEndpointInner {
             .filter_map(WeakWebRtcPlayEndpoint::safe_upgrade)
         {
             if let Some(receiver_owner) = receiver.weak_owner().safe_upgrade() {
-                drop(receiver_owner.take_sink(&receiver.id()))
+                drop(receiver_owner.remove_sink(&receiver.id()))
             }
         }
     }

--- a/src/signalling/elements/member.rs
+++ b/src/signalling/elements/member.rs
@@ -389,14 +389,14 @@ impl Member {
     /// Takes sink from [`Member`]'s `sinks`.
     #[inline]
     #[must_use]
-    pub fn take_sink(&self, id: &WebRtcPlayId) -> Option<WebRtcPlayEndpoint> {
+    pub fn remove_sink(&self, id: &WebRtcPlayId) -> Option<WebRtcPlayEndpoint> {
         self.0.borrow_mut().sinks.remove(id)
     }
 
     /// Takes src from [`Member`]'s `srsc`.
     #[inline]
     #[must_use]
-    pub fn take_src(
+    pub fn remove_src(
         &self,
         id: &WebRtcPublishId,
     ) -> Option<WebRtcPublishEndpoint> {
@@ -753,10 +753,10 @@ mod tests {
         let some_member = store.get(&id("some-member")).unwrap();
         let responder = store.get(&id("responder")).unwrap();
 
-        drop(caller.take_src(&id("publish")));
+        drop(caller.remove_src(&id("publish")));
         assert_eq!(responder.sinks().len(), 1);
 
-        drop(some_member.take_src(&id("publish")));
+        drop(some_member.remove_src(&id("publish")));
         assert_eq!(responder.sinks().len(), 0);
     }
 
@@ -772,11 +772,11 @@ mod tests {
         let some_member_publisher =
             some_member.get_src_by_id(&id("publish")).unwrap();
 
-        drop(responder.take_sink(&id("play")));
+        drop(responder.remove_sink(&id("play")));
         assert_eq!(caller_publisher.sinks().len(), 0);
         assert_eq!(some_member_publisher.sinks().len(), 1);
 
-        drop(responder.take_sink(&id("play2")));
+        drop(responder.remove_sink(&id("play2")));
         assert_eq!(caller_publisher.sinks().len(), 0);
         assert_eq!(some_member_publisher.sinks().len(), 0);
     }

--- a/src/signalling/elements/member.rs
+++ b/src/signalling/elements/member.rs
@@ -509,7 +509,7 @@ impl WeakMember {
     ///
     /// # Panics
     ///
-    /// If inner [`Weak`] pointer upgrade fails.
+    /// If an inner [`Weak`] pointer upgrade fails.
     #[inline]
     #[must_use]
     pub fn upgrade(&self) -> Member {
@@ -592,33 +592,29 @@ pub fn parse_members(
 }
 
 impl From<Member> for proto::Member {
-    fn from(member: Member) -> Self {
-        let member_pipeline = member
+    fn from(m: Member) -> Self {
+        let member_pipeline = m
             .sinks()
             .into_iter()
             .map(|(id, play)| (id.to_string(), play.into()))
             .chain(
-                member
-                    .srcs()
+                m.srcs()
                     .into_iter()
                     .map(|(id, publish)| (id.to_string(), publish.into())),
             )
             .collect();
 
         Self {
-            id: member.id().to_string(),
-            credentials: Some(member.credentials().into()),
-            on_leave: member
+            id: m.id().to_string(),
+            credentials: Some(m.credentials().into()),
+            on_leave: m
                 .get_on_leave()
                 .map(|c| c.to_string())
                 .unwrap_or_default(),
-            on_join: member
-                .get_on_join()
-                .map(|c| c.to_string())
-                .unwrap_or_default(),
-            reconnect_timeout: Some(member.get_reconnect_timeout().into()),
-            idle_timeout: Some(member.get_idle_timeout().into()),
-            ping_interval: Some(member.get_ping_interval().into()),
+            on_join: m.get_on_join().map(|c| c.to_string()).unwrap_or_default(),
+            reconnect_timeout: Some(m.get_reconnect_timeout().into()),
+            idle_timeout: Some(m.get_idle_timeout().into()),
+            ping_interval: Some(m.get_ping_interval().into()),
             pipeline: member_pipeline,
         }
     }
@@ -626,18 +622,18 @@ impl From<Member> for proto::Member {
 
 impl From<Member> for proto::room::Element {
     #[inline]
-    fn from(member: Member) -> Self {
+    fn from(m: Member) -> Self {
         Self {
-            el: Some(proto::room::element::El::Member(member.into())),
+            el: Some(proto::room::element::El::Member(m.into())),
         }
     }
 }
 
 impl From<Member> for proto::Element {
     #[inline]
-    fn from(member: Member) -> Self {
+    fn from(m: Member) -> Self {
         Self {
-            el: Some(proto::element::El::Member(member.into())),
+            el: Some(proto::element::El::Member(m.into())),
         }
     }
 }

--- a/src/signalling/room/dynamic_api.rs
+++ b/src/signalling/room/dynamic_api.rs
@@ -277,25 +277,26 @@ impl Room {
     }
 }
 
-impl Into<proto::Room> for &Room {
-    fn into(self) -> proto::Room {
-        let pipeline = self
+impl From<&Room> for proto::Room {
+    fn from(room: &Room) -> Self {
+        let pipeline = room
             .members
             .members()
             .into_iter()
             .map(|(id, member)| (id.to_string(), member.into()))
             .collect();
-        proto::Room {
-            id: self.id().to_string(),
+        Self {
+            id: room.id().to_string(),
             pipeline,
         }
     }
 }
 
-impl Into<proto::Element> for &Room {
-    fn into(self) -> proto::Element {
-        proto::Element {
-            el: Some(proto::element::El::Room(self.into())),
+impl From<&Room> for proto::Element {
+    #[inline]
+    fn from(room: &Room) -> Self {
+        Self {
+            el: Some(proto::element::El::Room(room.into())),
         }
     }
 }

--- a/src/signalling/room/dynamic_api.rs
+++ b/src/signalling/room/dynamic_api.rs
@@ -68,7 +68,7 @@ impl Room {
         let endpoint_id =
             if let Ok(member) = self.members.get_member_by_id(member_id) {
                 let play_id = endpoint_id.into();
-                if let Some(endpoint) = member.take_sink(&play_id) {
+                if let Some(endpoint) = member.remove_sink(&play_id) {
                     if let Some(peer_id) = endpoint.peer_id() {
                         let removed_peers =
                             self.peers.remove_peers(member_id, &[peer_id]);
@@ -82,7 +82,7 @@ impl Room {
                 }
 
                 let publish_id = String::from(play_id).into();
-                if let Some(endpoint) = member.take_src(&publish_id) {
+                if let Some(endpoint) = member.remove_src(&publish_id) {
                     let peer_ids = endpoint.peer_ids();
                     self.remove_peers(member_id, &peer_ids);
                 }

--- a/src/signalling/room_repo.rs
+++ b/src/signalling/room_repo.rs
@@ -43,6 +43,10 @@ impl RoomRepository {
     }
 
     /// Returns [`Room`] by its ID.
+    ///
+    /// # Panics
+    ///
+    /// If inner [`Mutex`] is poisoned.
     #[inline]
     #[must_use]
     pub fn get(&self, id: &RoomId) -> Option<Addr<Room>> {
@@ -51,17 +55,29 @@ impl RoomRepository {
     }
 
     /// Removes [`Room`] from [`RoomRepository`] by [`RoomId`].
+    ///
+    /// # Panics
+    ///
+    /// If inner [`Mutex`] is poisoned.
     pub fn remove(&self, id: &RoomId) {
         self.rooms.lock().unwrap().remove(id);
     }
 
     /// Adds new [`Room`] into [`RoomRepository`].
+    ///
+    /// # Panics
+    ///
+    /// If inner [`Mutex`] is poisoned.
     pub fn add(&self, id: RoomId, room: Addr<Room>) {
         self.rooms.lock().unwrap().insert(id, room);
     }
 
     /// Checks existence of [`Room`] in [`RoomRepository`] by provided
     /// [`RoomId`].
+    ///
+    /// # Panics
+    ///
+    /// If inner [`Mutex`] is poisoned.
     #[inline]
     #[must_use]
     pub fn contains_room_with_id(&self, id: &RoomId) -> bool {

--- a/src/signalling/room_repo.rs
+++ b/src/signalling/room_repo.rs
@@ -43,10 +43,7 @@ impl RoomRepository {
     }
 
     /// Returns [`Room`] by its ID.
-    ///
-    /// # Panics
-    ///
-    /// If inner [`Mutex`] is poisoned.
+    #[allow(clippy::missing_panics_doc)]
     #[inline]
     #[must_use]
     pub fn get(&self, id: &RoomId) -> Option<Addr<Room>> {
@@ -55,29 +52,20 @@ impl RoomRepository {
     }
 
     /// Removes [`Room`] from [`RoomRepository`] by [`RoomId`].
-    ///
-    /// # Panics
-    ///
-    /// If inner [`Mutex`] is poisoned.
+    #[allow(clippy::missing_panics_doc)]
     pub fn remove(&self, id: &RoomId) {
         self.rooms.lock().unwrap().remove(id);
     }
 
     /// Adds new [`Room`] into [`RoomRepository`].
-    ///
-    /// # Panics
-    ///
-    /// If inner [`Mutex`] is poisoned.
+    #[allow(clippy::missing_panics_doc)]
     pub fn add(&self, id: RoomId, room: Addr<Room>) {
         self.rooms.lock().unwrap().insert(id, room);
     }
 
     /// Checks existence of [`Room`] in [`RoomRepository`] by provided
     /// [`RoomId`].
-    ///
-    /// # Panics
-    ///
-    /// If inner [`Mutex`] is poisoned.
+    #[allow(clippy::missing_panics_doc)]
     #[inline]
     #[must_use]
     pub fn contains_room_with_id(&self, id: &RoomId) -> bool {

--- a/tests/integration/signalling/track_disable.rs
+++ b/tests/integration/signalling/track_disable.rs
@@ -108,7 +108,7 @@ async fn helper(
                 }
             }
         }
-    };
+    }
     wait_tracks_applied(enabled, publisher_rx, PeerId(0)).await;
     wait_tracks_applied(enabled, subscriber_rx, PeerId(1)).await;
 }


### PR DESCRIPTION
## Synopsis

Rust [v1.51 is out](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1510-2021-03-25), let's upgrade.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
