### PR TITLE
Basic Rust to Dart error propagation and extern functions integer arguments validation

### DIFF
--- a/jason/flutter/example/integration_test/jason.dart
+++ b/jason/flutter/example/integration_test/jason.dart
@@ -70,6 +70,19 @@ void main() {
     constraints.exactWidth(444);
     constraints.idealWidth(111);
     constraints.widthInRange(55, 66);
+
+    expect(() => constraints.exactHeight(-1), throwsArgumentError);
+    expect(() => constraints.idealHeight(-1), throwsArgumentError);
+    expect(() => constraints.exactHeight(1 << 32 + 1), throwsArgumentError);
+    expect(() => constraints.heightInRange(-1, 200), throwsArgumentError);
+    expect(() => constraints.heightInRange(200, -1), throwsArgumentError);
+
+    expect(() => constraints.exactWidth(-1), throwsArgumentError);
+    expect(() => constraints.idealWidth(-1), throwsArgumentError);
+    expect(() => constraints.exactWidth(1 << 32 + 1), throwsArgumentError);
+    expect(() => constraints.widthInRange(-1, 200), throwsArgumentError);
+    expect(() => constraints.widthInRange(200, -1), throwsArgumentError);
+
     constraints.free();
     expect(() => constraints.deviceId('deviceId'), throwsStateError);
 
@@ -255,6 +268,30 @@ void main() {
 
     await handle.reconnectWithDelay(155);
     await handle.reconnectWithBackoff(1, 2, 3);
+
+    var exception;
+    try {
+      await handle.reconnectWithDelay(-1);
+    } catch (e) {
+      exception = e;
+    }
+    expect(exception, isArgumentError);
+
+    var exception2;
+    try {
+      await handle.reconnectWithBackoff(-1, 2, 3);
+    } catch (e) {
+      exception2 = e;
+    }
+    expect(exception2, isArgumentError);
+
+    var exception3;
+    try {
+      await handle.reconnectWithBackoff(1, 2, -3);
+    } catch (e) {
+      exception3 = e;
+    }
+    expect(exception3, isArgumentError);
   });
 
   final returnsInputDevicePtr =

--- a/jason/flutter/example/integration_test/jason.dart
+++ b/jason/flutter/example/integration_test/jason.dart
@@ -292,6 +292,10 @@ void main() {
       exception3 = e;
     }
     expect(exception3, isArgumentError);
+    var argumentError = exception3 as ArgumentError;
+    expect(argumentError.invalidValue, equals(-3));
+    expect(argumentError.name, 'maxDelay');
+    expect(argumentError.message, 'Expected u32');
   });
 
   final returnsInputDevicePtr =

--- a/jason/flutter/example/pubspec.lock
+++ b/jason/flutter/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.1"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/jason/flutter/example/pubspec.lock
+++ b/jason/flutter/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.1"
+    version: "6.1.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/jason/flutter/lib/device_video_track_constraints.dart
+++ b/jason/flutter/lib/device_video_track_constraints.dart
@@ -126,8 +126,10 @@ class DeviceVideoTrackConstraints {
     _idealFacingMode(ptr.getInnerPtr(), facingMode.index);
   }
 
-  // TODO: add docs on args.
   /// Sets an exact [`height`][1] constraint.
+  ///
+  /// Converts the provided [height] into an `u32`. Throws and [ArgumentError]
+  /// if conversion fails.
   ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-height
   void exactHeight(int height) {
@@ -136,12 +138,18 @@ class DeviceVideoTrackConstraints {
 
   /// Sets an ideal [`height`][1] constraint.
   ///
+  /// Converts the provided [height] into an `u32`. Throws an [ArgumentError]
+  /// if conversion fails.
+  ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-height
   void idealHeight(int height) {
     _idealHeight(ptr.getInnerPtr(), height).unwrap();
   }
 
   /// Sets a range of a [`height`][1] constraint.
+  ///
+  /// Converts the provided [min] and [max] into an `u32`. Throws an
+  /// [ArgumentError] if conversion fails.
   ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-height
   void heightInRange(int min, int max) {
@@ -150,6 +158,9 @@ class DeviceVideoTrackConstraints {
 
   /// Sets an exact [`width`][1] constraint.
   ///
+  /// Converts the provided [width] into an `u32`. Throws an [ArgumentError] if
+  /// conversion fails.
+  ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-width
   void exactWidth(int width) {
     _exactWidth(ptr.getInnerPtr(), width).unwrap();
@@ -157,12 +168,18 @@ class DeviceVideoTrackConstraints {
 
   /// Sets an ideal [`width`][1] constraint.
   ///
+  /// Converts the provided [width] into an `u32`. Throws an [ArgumentError] if
+  /// conversion fails.
+  ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-width
   void idealWidth(int width) {
     _idealWidth(ptr.getInnerPtr(), width).unwrap();
   }
 
   /// Sets a range of a [`width`][1] constraint.
+  ///
+  /// Converts the provided [min] and [max] into an `u32`. Throws an
+  /// [ArgumentError] if conversion fails.
   ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-width
   void widthInRange(int min, int max) {

--- a/jason/flutter/lib/device_video_track_constraints.dart
+++ b/jason/flutter/lib/device_video_track_constraints.dart
@@ -2,6 +2,7 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 
+import 'ffi/result.dart';
 import 'jason.dart';
 import 'util/move_semantic.dart';
 import 'util/nullable_pointer.dart';
@@ -18,23 +19,23 @@ typedef _exactFacingMode_Dart = void Function(Pointer, int);
 typedef _idealFacingMode_C = Void Function(Pointer, Uint8);
 typedef _idealFacingMode_Dart = void Function(Pointer, int);
 
-typedef _exactHeight_C = Void Function(Pointer, Uint32);
-typedef _exactHeight_Dart = void Function(Pointer, int);
+typedef _exactHeight_C = Result Function(Pointer, Int64);
+typedef _exactHeight_Dart = Result Function(Pointer, int);
 
-typedef _idealHeight_C = Void Function(Pointer, Uint32);
-typedef _idealHeight_Dart = void Function(Pointer, int);
+typedef _idealHeight_C = Result Function(Pointer, Int64);
+typedef _idealHeight_Dart = Result Function(Pointer, int);
 
-typedef _heightInRange_C = Void Function(Pointer, Uint32, Uint32);
-typedef _heightInRange_Dart = void Function(Pointer, int, int);
+typedef _heightInRange_C = Result Function(Pointer, Int64, Int64);
+typedef _heightInRange_Dart = Result Function(Pointer, int, int);
 
-typedef _exactWidth_C = Void Function(Pointer, Uint32);
-typedef _exactWidth_Dart = void Function(Pointer, int);
+typedef _exactWidth_C = Result Function(Pointer, Int64);
+typedef _exactWidth_Dart = Result Function(Pointer, int);
 
-typedef _idealWidth_C = Void Function(Pointer, Uint32);
-typedef _idealWidth_Dart = void Function(Pointer, int);
+typedef _idealWidth_C = Result Function(Pointer, Int64);
+typedef _idealWidth_Dart = Result Function(Pointer, int);
 
-typedef _widthInRange_C = Void Function(Pointer, Uint32, Uint32);
-typedef _widthInRange_Dart = void Function(Pointer, int, int);
+typedef _widthInRange_C = Result Function(Pointer, Int64, Int64);
+typedef _widthInRange_Dart = Result Function(Pointer, int, int);
 
 typedef _free_C = Void Function(Pointer);
 typedef _free_Dart = void Function(Pointer);
@@ -125,46 +126,47 @@ class DeviceVideoTrackConstraints {
     _idealFacingMode(ptr.getInnerPtr(), facingMode.index);
   }
 
+  // TODO: add docs on args.
   /// Sets an exact [`height`][1] constraint.
   ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-height
   void exactHeight(int height) {
-    _exactHeight(ptr.getInnerPtr(), height);
+    _exactHeight(ptr.getInnerPtr(), height).unwrap();
   }
 
   /// Sets an ideal [`height`][1] constraint.
   ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-height
   void idealHeight(int height) {
-    _idealHeight(ptr.getInnerPtr(), height);
+    _idealHeight(ptr.getInnerPtr(), height).unwrap();
   }
 
   /// Sets a range of a [`height`][1] constraint.
   ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-height
   void heightInRange(int min, int max) {
-    _heightInRange(ptr.getInnerPtr(), min, max);
+    _heightInRange(ptr.getInnerPtr(), min, max).unwrap();
   }
 
   /// Sets an exact [`width`][1] constraint.
   ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-width
   void exactWidth(int width) {
-    _exactWidth(ptr.getInnerPtr(), width);
+    _exactWidth(ptr.getInnerPtr(), width).unwrap();
   }
 
   /// Sets an ideal [`width`][1] constraint.
   ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-width
   void idealWidth(int width) {
-    _idealWidth(ptr.getInnerPtr(), width);
+    _idealWidth(ptr.getInnerPtr(), width).unwrap();
   }
 
   /// Sets a range of a [`width`][1] constraint.
   ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-width
   void widthInRange(int min, int max) {
-    _widthInRange(ptr.getInnerPtr(), min, max);
+    _widthInRange(ptr.getInnerPtr(), min, max).unwrap();
   }
 
   /// Drops the associated Rust struct and nulls the local [Pointer] to it.

--- a/jason/flutter/lib/device_video_track_constraints.dart
+++ b/jason/flutter/lib/device_video_track_constraints.dart
@@ -128,8 +128,8 @@ class DeviceVideoTrackConstraints {
 
   /// Sets an exact [`height`][1] constraint.
   ///
-  /// Converts the provided [height] into an `u32`. Throws an [ArgumentError]
-  /// if conversion fails.
+  /// Converts the provided [height] into an `u32`. Throws an [ArgumentError] if
+  /// conversion fails.
   ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-height
   void exactHeight(int height) {
@@ -138,8 +138,8 @@ class DeviceVideoTrackConstraints {
 
   /// Sets an ideal [`height`][1] constraint.
   ///
-  /// Converts the provided [height] into an `u32`. Throws an [ArgumentError]
-  /// if conversion fails.
+  /// Converts the provided [height] into an `u32`. Throws an [ArgumentError] if
+  /// conversion fails.
   ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-height
   void idealHeight(int height) {

--- a/jason/flutter/lib/device_video_track_constraints.dart
+++ b/jason/flutter/lib/device_video_track_constraints.dart
@@ -128,7 +128,7 @@ class DeviceVideoTrackConstraints {
 
   /// Sets an exact [`height`][1] constraint.
   ///
-  /// Converts the provided [height] into an `u32`. Throws and [ArgumentError]
+  /// Converts the provided [height] into an `u32`. Throws an [ArgumentError]
   /// if conversion fails.
   ///
   /// [1]: https://tinyurl.com/w3-streams#def-constraint-height

--- a/jason/flutter/lib/ffi/completer.dart
+++ b/jason/flutter/lib/ffi/completer.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:ffi';
 
 import 'foreign_value.dart';
+import 'unbox_handle.dart';
 
 /// Registers functions that allow Rust to manage [Completer]s.
 void registerFunctions(DynamicLibrary dl) {
@@ -20,7 +21,7 @@ void registerFunctions(DynamicLibrary dl) {
 
   dl.lookupFunction<Void Function(Pointer), void Function(Pointer)>(
           'register_completer_complete_error_caller')(
-      Pointer.fromFunction<Void Function(Handle, Pointer)>(
+      Pointer.fromFunction<Void Function(Handle, Pointer<Handle>)>(
           _Completer_completeError_Pointer));
 }
 
@@ -40,6 +41,6 @@ void _Completer_complete(Object completer, ForeignValue arg) {
 }
 
 /// Complete the provided [Completer] with an error.
-void _Completer_completeError_Pointer(Object completer, Pointer arg) {
-  (completer as Completer).completeError(arg);
+void _Completer_completeError_Pointer(Object completer, Pointer<Handle> err) {
+  (completer as Completer).completeError(unboxDartHandle(err));
 }

--- a/jason/flutter/lib/ffi/exceptions.dart
+++ b/jason/flutter/lib/ffi/exceptions.dart
@@ -1,0 +1,15 @@
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+import 'native_string.dart';
+
+void registerFunctions(DynamicLibrary dl) {
+  dl.lookupFunction<Void Function(Pointer), void Function(Pointer)>(
+          'register_new_argument_error_caller')(
+      Pointer.fromFunction<Handle Function(Pointer<Utf8>)>(_newArgumentError));
+}
+
+Object _newArgumentError(Pointer<Utf8> message) {
+  return ArgumentError(message.nativeStringToDartString());
+}

--- a/jason/flutter/lib/ffi/exceptions.dart
+++ b/jason/flutter/lib/ffi/exceptions.dart
@@ -2,14 +2,23 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 
+import 'foreign_value.dart';
 import 'native_string.dart';
 
+/// Registers functions that allow Rust to create Dart [Exception]s and
+/// [Error]s.
 void registerFunctions(DynamicLibrary dl) {
   dl.lookupFunction<Void Function(Pointer), void Function(Pointer)>(
           'register_new_argument_error_caller')(
-      Pointer.fromFunction<Handle Function(Pointer<Utf8>)>(_newArgumentError));
+      Pointer.fromFunction<
+          Handle Function(
+              ForeignValue, Pointer<Utf8>, Pointer<Utf8>)>(_newArgumentError));
 }
 
-Object _newArgumentError(Pointer<Utf8> message) {
-  return ArgumentError(message.nativeStringToDartString());
+/// Create a new [ArgumentError] from provided invalid [value], its [name] and
+/// the [message] describing the problem.
+Object _newArgumentError(
+    ForeignValue value, Pointer<Utf8> name, Pointer<Utf8> message) {
+  return ArgumentError.value(value.toDart(), name.nativeStringToDartString(),
+      message.nativeStringToDartString());
 }

--- a/jason/flutter/lib/ffi/exceptions.dart
+++ b/jason/flutter/lib/ffi/exceptions.dart
@@ -5,8 +5,7 @@ import 'package:ffi/ffi.dart';
 import 'foreign_value.dart';
 import 'native_string.dart';
 
-/// Registers functions that allow Rust to create Dart [Exception]s and
-/// [Error]s.
+/// Registers functions allowing Rust to create Dart [Exception]s and [Error]s.
 void registerFunctions(DynamicLibrary dl) {
   dl.lookupFunction<Void Function(Pointer), void Function(Pointer)>(
           'register_new_argument_error_caller')(
@@ -15,8 +14,8 @@ void registerFunctions(DynamicLibrary dl) {
               ForeignValue, Pointer<Utf8>, Pointer<Utf8>)>(_newArgumentError));
 }
 
-/// Create a new [ArgumentError] from provided invalid [value], its [name] and
-/// the [message] describing the problem.
+/// Create a new [ArgumentError] from the provided invalid [value], its [name]
+/// and the [message] describing the problem.
 Object _newArgumentError(
     ForeignValue value, Pointer<Utf8> name, Pointer<Utf8> message) {
   return ArgumentError.value(value.toDart(), name.nativeStringToDartString(),

--- a/jason/flutter/lib/ffi/foreign_value.dart
+++ b/jason/flutter/lib/ffi/foreign_value.dart
@@ -2,17 +2,10 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 
-import '../jason.dart';
 import '../util/move_semantic.dart';
 import '../util/nullable_pointer.dart';
 import 'native_string.dart';
-
-typedef _unboxDartHandle_C = Handle Function(Pointer<Handle>);
-typedef _unboxDartHandle_Dart = Object Function(Pointer<Handle>);
-
-final _unboxDartHandle =
-    dl.lookupFunction<_unboxDartHandle_C, _unboxDartHandle_Dart>(
-        'unbox_dart_handle');
+import 'unbox_handle.dart';
 
 /// Type-erased value that can be transferred via FFI boundaries to/from Rust.
 class ForeignValue extends Struct {
@@ -41,7 +34,7 @@ class ForeignValue extends Struct {
       case 1:
         return _payload.ptr;
       case 2:
-        return _unboxDartHandle(_payload.handlePtr);
+        return unboxDartHandle(_payload.handlePtr);
       case 3:
         return _payload.string.nativeStringToDartString();
       case 4:

--- a/jason/flutter/lib/ffi/foreign_value.dart
+++ b/jason/flutter/lib/ffi/foreign_value.dart
@@ -9,14 +9,14 @@ import 'unbox_handle.dart';
 
 /// Type-erased value that can be transferred via FFI boundaries to/from Rust.
 class ForeignValue extends Struct {
-  /// Index of the used [ForeignValueFields] union field.
+  /// Index of the used [_ForeignValueFields] union field.
   ///
   /// `0` goes for no value.
   @Uint8()
   external int _tag;
 
   /// Actual [ForeignValue] payload.
-  external ForeignValueFields _payload;
+  external _ForeignValueFields _payload;
 
   /// Private constructor.
   ///
@@ -89,7 +89,7 @@ extension ForeignValuePointer on Pointer<ForeignValue> {
 }
 
 /// Possible fields of a [ForeignValue].
-class ForeignValueFields extends Union {
+class _ForeignValueFields extends Union {
   /// [Pointer] to some Rust object.
   external Pointer ptr;
 

--- a/jason/flutter/lib/ffi/result.dart
+++ b/jason/flutter/lib/ffi/result.dart
@@ -3,7 +3,7 @@ import 'dart:ffi';
 import 'foreign_value.dart';
 import 'unbox_handle.dart';
 
-/// Class that represents either success or failure.
+/// Class representing either success or failure.
 ///
 /// Implements error propagation from Rust to Dart.
 class Result extends Struct {
@@ -14,10 +14,8 @@ class Result extends Struct {
   /// Actual [Result] payload.
   external _ResultFields _payload;
 
-  /// Returns an underlying Dart value.
-  ///
-  /// Which is an [Object] that represent success, or throws an [Exception] or
-  /// an [Error] in case of failure.
+  /// Returns the underlying Dart value, which is an [Object] in case of
+  /// success, or throws an [Exception] or an [Error] in case of failure.
   dynamic unwrap() {
     if (_tag == 0) {
       return _payload.ok.toDart();

--- a/jason/flutter/lib/ffi/result.dart
+++ b/jason/flutter/lib/ffi/result.dart
@@ -7,12 +7,12 @@ import 'unbox_handle.dart';
 ///
 /// Implements error propagation from Rust to Dart.
 class Result extends Struct {
-  /// Index of the used [ResultFields] union field.
+  /// Index of the used [_ResultFields] union field.
   @Uint8()
   external int _tag;
 
   /// Actual [Result] payload.
-  external ResultFields _payload;
+  external _ResultFields _payload;
 
   /// Returns an underlying Dart value.
   ///
@@ -28,7 +28,7 @@ class Result extends Struct {
 }
 
 /// Possible fields of a [Result].
-class ResultFields extends Union {
+class _ResultFields extends Union {
   /// Success [ForeignValue].
   external ForeignValue ok;
 

--- a/jason/flutter/lib/ffi/result.dart
+++ b/jason/flutter/lib/ffi/result.dart
@@ -3,17 +3,21 @@ import 'dart:ffi';
 import 'foreign_value.dart';
 import 'unbox_handle.dart';
 
+/// Class that represents either success or failure.
+///
+/// Implements error propagation from Rust to Dart.
 class Result extends Struct {
-  /// Index of the [DartValueFields] union field. `0` goes for `Void`.
+  /// Index of the used [ResultFields] union field.
   @Uint8()
   external int _tag;
 
-  /// Actual [ForeignValue] payload.
+  /// Actual [Result] payload.
   external ResultFields _payload;
 
-  /// Returns Dart representation of the underlying foreign value.
+  /// Returns an underlying Dart value.
   ///
-  /// Returns `null` if underlying value is `void` or `()`.
+  /// Which is an [Object] that represent success, or throws an [Exception] or
+  /// an [Error] in case of failure.
   dynamic unwrap() {
     if (_tag == 0) {
       return _payload.ok.toDart();
@@ -23,10 +27,11 @@ class Result extends Struct {
   }
 }
 
+/// Possible fields of a [Result].
 class ResultFields extends Union {
   /// Success [ForeignValue].
   external ForeignValue ok;
 
-  /// [Error] value.
+  /// Failure value.
   external Pointer<Handle> errPtr;
 }

--- a/jason/flutter/lib/ffi/result.dart
+++ b/jason/flutter/lib/ffi/result.dart
@@ -1,0 +1,32 @@
+import 'dart:ffi';
+
+import 'foreign_value.dart';
+import 'unbox_handle.dart';
+
+class Result extends Struct {
+  /// Index of the [DartValueFields] union field. `0` goes for `Void`.
+  @Uint8()
+  external int _tag;
+
+  /// Actual [ForeignValue] payload.
+  external ResultFields _payload;
+
+  /// Returns Dart representation of the underlying foreign value.
+  ///
+  /// Returns `null` if underlying value is `void` or `()`.
+  dynamic unwrap() {
+    if (_tag == 0) {
+      return _payload.ok.toDart();
+    } else {
+      throw unboxDartHandle(_payload.errPtr);
+    }
+  }
+}
+
+class ResultFields extends Union {
+  /// Success [ForeignValue].
+  external ForeignValue ok;
+
+  /// [Error] value.
+  external Pointer<Handle> errPtr;
+}

--- a/jason/flutter/lib/ffi/unbox_handle.dart
+++ b/jason/flutter/lib/ffi/unbox_handle.dart
@@ -9,6 +9,7 @@ final _unboxDartHandle =
     dl.lookupFunction<_unboxDartHandle_C, _unboxDartHandle_Dart>(
         'unbox_dart_handle');
 
+/// Converts a [`Pointer<Handle>`] to an [Object] using a Rust trampoline.
 Object unboxDartHandle(Pointer<Handle> ptr) {
   return _unboxDartHandle(ptr);
 }

--- a/jason/flutter/lib/ffi/unbox_handle.dart
+++ b/jason/flutter/lib/ffi/unbox_handle.dart
@@ -1,0 +1,14 @@
+import 'dart:ffi';
+
+import '../jason.dart';
+
+typedef _unboxDartHandle_C = Handle Function(Pointer<Handle>);
+typedef _unboxDartHandle_Dart = Object Function(Pointer<Handle>);
+
+final _unboxDartHandle =
+    dl.lookupFunction<_unboxDartHandle_C, _unboxDartHandle_Dart>(
+        'unbox_dart_handle');
+
+Object unboxDartHandle(Pointer<Handle> ptr) {
+  return _unboxDartHandle(ptr);
+}

--- a/jason/flutter/lib/jason.dart
+++ b/jason/flutter/lib/jason.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'ffi/callback.dart' as callback;
 import 'ffi/completer.dart' as completer;
+import 'ffi/exceptions.dart' as exceptions;
 import 'ffi/executor.dart';
 import 'media_manager.dart';
 import 'room_handle.dart';
@@ -70,6 +71,7 @@ DynamicLibrary _dl_load() {
   }
   callback.registerFunctions(dl);
   completer.registerFunctions(dl);
+  exceptions.registerFunctions(dl);
 
   executor = Executor(dl);
 

--- a/jason/src/api/dart/device_video_track_constraints.rs
+++ b/jason/src/api/dart/device_video_track_constraints.rs
@@ -63,10 +63,7 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__exact_height(
     let height = match u32::try_from(height) {
         Ok(height) => height,
         Err(_) => {
-            return DartResult::from(ArgumentError::from(format!(
-                "Expected u32, got `{}`",
-                height
-            )));
+            return ArgumentError::new(height, "height", "Expected u32").into();
         }
     };
     this.as_mut().exact_height(height);
@@ -84,10 +81,7 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__ideal_height(
     let height = match u32::try_from(height) {
         Ok(height) => height,
         Err(_) => {
-            return DartResult::from(ArgumentError::from(format!(
-                "Expected u32, got `{}`",
-                height
-            )));
+            return ArgumentError::new(height, "height", "Expected u32").into();
         }
     };
     this.as_mut().ideal_height(height);
@@ -106,19 +100,13 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__height_in_range(
     let min = match u32::try_from(min) {
         Ok(min) => min,
         Err(_) => {
-            return DartResult::from(ArgumentError::from(format!(
-                "Expected u32, got `{}`",
-                min
-            )));
+            return ArgumentError::new(min, "min", "Expected u32").into();
         }
     };
     let max = match u32::try_from(max) {
         Ok(max) => max,
         Err(_) => {
-            return DartResult::from(ArgumentError::from(format!(
-                "Expected u32, got `{}`",
-                max
-            )));
+            return ArgumentError::new(max, "max", "Expected u32").into();
         }
     };
     this.as_mut().height_in_range(min, max);
@@ -136,10 +124,7 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__exact_width(
     let width = match u32::try_from(width) {
         Ok(width) => width,
         Err(_) => {
-            return DartResult::from(ArgumentError::from(format!(
-                "Expected u32, got `{}`",
-                width
-            )));
+            return ArgumentError::new(width, "width", "Expected u32").into();
         }
     };
     this.as_mut().exact_width(width);
@@ -157,10 +142,7 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__ideal_width(
     let width = match u32::try_from(width) {
         Ok(width) => width,
         Err(_) => {
-            return DartResult::from(ArgumentError::from(format!(
-                "Expected u32, got `{}`",
-                width
-            )));
+            return ArgumentError::new(width, "width", "Expected u32").into();
         }
     };
     this.as_mut().ideal_width(width);
@@ -179,19 +161,13 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__width_in_range(
     let min = match u32::try_from(min) {
         Ok(min) => min,
         Err(_) => {
-            return DartResult::from(ArgumentError::from(format!(
-                "Expected u32, got `{}`",
-                min
-            )));
+            return ArgumentError::new(min, "min", "Expected u32").into();
         }
     };
     let max = match u32::try_from(max) {
         Ok(max) => max,
         Err(_) => {
-            return DartResult::from(ArgumentError::from(format!(
-                "Expected u32, got `{}`",
-                max
-            )));
+            return ArgumentError::new(max, "max", "Expected u32").into();
         }
     };
     this.as_mut().width_in_range(min, max);

--- a/jason/src/api/dart/device_video_track_constraints.rs
+++ b/jason/src/api/dart/device_video_track_constraints.rs
@@ -60,13 +60,12 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__exact_height(
     mut this: ptr::NonNull<DeviceVideoTrackConstraints>,
     height: i64,
 ) -> DartResult {
-    let height = match u32::try_from(height) {
-        Ok(height) => height,
+    match u32::try_from(height) {
+        Ok(h) => this.as_mut().exact_height(h),
         Err(_) => {
             return ArgumentError::new(height, "height", "Expected u32").into();
         }
     };
-    this.as_mut().exact_height(height);
     Ok(()).into()
 }
 
@@ -78,13 +77,12 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__ideal_height(
     mut this: ptr::NonNull<DeviceVideoTrackConstraints>,
     height: i64,
 ) -> DartResult {
-    let height = match u32::try_from(height) {
-        Ok(height) => height,
+    match u32::try_from(height) {
+        Ok(h) => this.as_mut().ideal_height(h),
         Err(_) => {
             return ArgumentError::new(height, "height", "Expected u32").into();
         }
     };
-    this.as_mut().ideal_height(height);
     Ok(()).into()
 }
 
@@ -97,19 +95,15 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__height_in_range(
     min: i64,
     max: i64,
 ) -> DartResult {
-    let min = match u32::try_from(min) {
-        Ok(min) => min,
-        Err(_) => {
+    match (u32::try_from(min), u32::try_from(max)) {
+        (Ok(min), Ok(max)) => this.as_mut().height_in_range(min, max),
+        (Err(_), _) => {
             return ArgumentError::new(min, "min", "Expected u32").into();
         }
-    };
-    let max = match u32::try_from(max) {
-        Ok(max) => max,
-        Err(_) => {
+        (_, Err(_)) => {
             return ArgumentError::new(max, "max", "Expected u32").into();
         }
     };
-    this.as_mut().height_in_range(min, max);
     Ok(()).into()
 }
 
@@ -121,13 +115,12 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__exact_width(
     mut this: ptr::NonNull<DeviceVideoTrackConstraints>,
     width: i64,
 ) -> DartResult {
-    let width = match u32::try_from(width) {
-        Ok(width) => width,
+    match u32::try_from(width) {
+        Ok(w) => this.as_mut().exact_width(w),
         Err(_) => {
             return ArgumentError::new(width, "width", "Expected u32").into();
         }
     };
-    this.as_mut().exact_width(width);
     Ok(()).into()
 }
 
@@ -139,13 +132,12 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__ideal_width(
     mut this: ptr::NonNull<DeviceVideoTrackConstraints>,
     width: i64,
 ) -> DartResult {
-    let width = match u32::try_from(width) {
-        Ok(width) => width,
+    match u32::try_from(width) {
+        Ok(w) => this.as_mut().exact_width(w),
         Err(_) => {
             return ArgumentError::new(width, "width", "Expected u32").into();
         }
     };
-    this.as_mut().ideal_width(width);
     Ok(()).into()
 }
 
@@ -158,19 +150,15 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__width_in_range(
     min: i64,
     max: i64,
 ) -> DartResult {
-    let min = match u32::try_from(min) {
-        Ok(min) => min,
-        Err(_) => {
+    match (u32::try_from(min), u32::try_from(max)) {
+        (Ok(min), Ok(max)) => this.as_mut().width_in_range(min, max),
+        (Err(_), _) => {
             return ArgumentError::new(min, "min", "Expected u32").into();
         }
-    };
-    let max = match u32::try_from(max) {
-        Ok(max) => max,
-        Err(_) => {
+        (_, Err(_)) => {
             return ArgumentError::new(max, "max", "Expected u32").into();
         }
     };
-    this.as_mut().width_in_range(min, max);
     Ok(()).into()
 }
 

--- a/jason/src/api/dart/device_video_track_constraints.rs
+++ b/jason/src/api/dart/device_video_track_constraints.rs
@@ -1,8 +1,11 @@
-use std::{os::raw::c_char, ptr};
+use std::{convert::TryFrom as _, os::raw::c_char, ptr};
 
 use crate::media::FacingMode;
 
-use super::{utils::c_str_into_string, ForeignClass};
+use super::{
+    utils::{c_str_into_string, ArgumentError, DartResult},
+    ForeignClass,
+};
 
 pub use crate::media::DeviceVideoTrackConstraints;
 
@@ -55,9 +58,19 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__ideal_facing_mode(
 #[no_mangle]
 pub unsafe extern "C" fn DeviceVideoTrackConstraints__exact_height(
     mut this: ptr::NonNull<DeviceVideoTrackConstraints>,
-    height: u32,
-) {
+    height: i64,
+) -> DartResult {
+    let height = match u32::try_from(height) {
+        Ok(height) => height,
+        Err(_) => {
+            return DartResult::from(ArgumentError::from(format!(
+                "Expected u32, got `{}`",
+                height
+            )));
+        }
+    };
     this.as_mut().exact_height(height);
+    Ok(()).into()
 }
 
 /// Sets an ideal [height][1] constraint.
@@ -66,9 +79,19 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__exact_height(
 #[no_mangle]
 pub unsafe extern "C" fn DeviceVideoTrackConstraints__ideal_height(
     mut this: ptr::NonNull<DeviceVideoTrackConstraints>,
-    height: u32,
-) {
+    height: i64,
+) -> DartResult {
+    let height = match u32::try_from(height) {
+        Ok(height) => height,
+        Err(_) => {
+            return DartResult::from(ArgumentError::from(format!(
+                "Expected u32, got `{}`",
+                height
+            )));
+        }
+    };
     this.as_mut().ideal_height(height);
+    Ok(()).into()
 }
 
 /// Sets a range of a [height][1] constraint.
@@ -77,10 +100,29 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__ideal_height(
 #[no_mangle]
 pub unsafe extern "C" fn DeviceVideoTrackConstraints__height_in_range(
     mut this: ptr::NonNull<DeviceVideoTrackConstraints>,
-    min: u32,
-    max: u32,
-) {
+    min: i64,
+    max: i64,
+) -> DartResult {
+    let min = match u32::try_from(min) {
+        Ok(min) => min,
+        Err(_) => {
+            return DartResult::from(ArgumentError::from(format!(
+                "Expected u32, got `{}`",
+                min
+            )));
+        }
+    };
+    let max = match u32::try_from(max) {
+        Ok(max) => max,
+        Err(_) => {
+            return DartResult::from(ArgumentError::from(format!(
+                "Expected u32, got `{}`",
+                max
+            )));
+        }
+    };
     this.as_mut().height_in_range(min, max);
+    Ok(()).into()
 }
 
 /// Sets an exact [width][1] constraint.
@@ -89,9 +131,19 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__height_in_range(
 #[no_mangle]
 pub unsafe extern "C" fn DeviceVideoTrackConstraints__exact_width(
     mut this: ptr::NonNull<DeviceVideoTrackConstraints>,
-    width: u32,
-) {
+    width: i64,
+) -> DartResult {
+    let width = match u32::try_from(width) {
+        Ok(width) => width,
+        Err(_) => {
+            return DartResult::from(ArgumentError::from(format!(
+                "Expected u32, got `{}`",
+                width
+            )));
+        }
+    };
     this.as_mut().exact_width(width);
+    Ok(()).into()
 }
 
 /// Sets an ideal [width][1] constraint.
@@ -100,9 +152,19 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__exact_width(
 #[no_mangle]
 pub unsafe extern "C" fn DeviceVideoTrackConstraints__ideal_width(
     mut this: ptr::NonNull<DeviceVideoTrackConstraints>,
-    width: u32,
-) {
+    width: i64,
+) -> DartResult {
+    let width = match u32::try_from(width) {
+        Ok(width) => width,
+        Err(_) => {
+            return DartResult::from(ArgumentError::from(format!(
+                "Expected u32, got `{}`",
+                width
+            )));
+        }
+    };
     this.as_mut().ideal_width(width);
+    Ok(()).into()
 }
 
 /// Sets a range of a [width][1] constraint.
@@ -111,10 +173,29 @@ pub unsafe extern "C" fn DeviceVideoTrackConstraints__ideal_width(
 #[no_mangle]
 pub unsafe extern "C" fn DeviceVideoTrackConstraints__width_in_range(
     mut this: ptr::NonNull<DeviceVideoTrackConstraints>,
-    min: u32,
-    max: u32,
-) {
+    min: i64,
+    max: i64,
+) -> DartResult {
+    let min = match u32::try_from(min) {
+        Ok(min) => min,
+        Err(_) => {
+            return DartResult::from(ArgumentError::from(format!(
+                "Expected u32, got `{}`",
+                min
+            )));
+        }
+    };
+    let max = match u32::try_from(max) {
+        Ok(max) => max,
+        Err(_) => {
+            return DartResult::from(ArgumentError::from(format!(
+                "Expected u32, got `{}`",
+                max
+            )));
+        }
+    };
     this.as_mut().width_in_range(min, max);
+    Ok(()).into()
 }
 
 /// Frees the data behind the provided pointer.

--- a/jason/src/api/dart/media_manager_handle.rs
+++ b/jason/src/api/dart/media_manager_handle.rs
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn MediaManagerHandle__init_local_tracks(
     async move {
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
         //       implemented.
-        Ok::<_, ()>(PtrArray::new(this.init_local_tracks(caps).await.unwrap()))
+        Ok(PtrArray::new(this.init_local_tracks(caps).await.unwrap()))
     }
     .into_dart_future()
 }
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn MediaManagerHandle__enumerate_devices(
     async move {
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
         //       implemented.
-        Ok::<_, ()>(PtrArray::new(this.enumerate_devices().await.unwrap()))
+        Ok(PtrArray::new(this.enumerate_devices().await.unwrap()))
     }
     .into_dart_future()
 }

--- a/jason/src/api/dart/mod.rs
+++ b/jason/src/api/dart/mod.rs
@@ -48,7 +48,6 @@ pub use self::{
     media_stream_settings::MediaStreamSettings,
     reconnect_handle::ReconnectHandle, remote_media_track::RemoteMediaTrack,
     room_close_reason::RoomCloseReason, room_handle::RoomHandle,
-    utils::DartError as Error,
 };
 
 /// Rust structure having wrapper class in Dart.

--- a/jason/src/api/dart/mod.rs
+++ b/jason/src/api/dart/mod.rs
@@ -31,7 +31,9 @@ use derive_more::From;
 use libc::c_char;
 
 use crate::{
-    api::dart::utils::{c_str_into_string, string_into_c_str, PtrArray},
+    api::dart::utils::{
+        c_str_into_string, string_into_c_str, DartError, PtrArray,
+    },
     media::MediaSourceKind,
 };
 
@@ -46,6 +48,7 @@ pub use self::{
     media_stream_settings::MediaStreamSettings,
     reconnect_handle::ReconnectHandle, remote_media_track::RemoteMediaTrack,
     room_close_reason::RoomCloseReason, room_handle::RoomHandle,
+    utils::DartError as Error,
 };
 
 /// Rust structure having wrapper class in Dart.
@@ -72,126 +75,6 @@ pub trait ForeignClass: Sized {
         *Box::from_raw(this.as_ptr())
     }
 }
-
-/// Type-erased value that can be transferred via FFI boundaries to/from Dart.
-#[derive(Debug)]
-#[repr(u8)]
-pub enum DartValue {
-    /// No value. It can mean `()`, `void` or [`Option::None`] basing on the
-    /// contexts.
-    None,
-
-    /// Pointer to a [`Box`]ed Rust object.
-    Ptr(ptr::NonNull<c_void>),
-
-    /// Pointer to a [`Dart_Handle`] of some Dart object.
-    Handle(ptr::NonNull<Dart_Handle>),
-
-    /// Native string.
-    String(ptr::NonNull<c_char>),
-
-    /// Integer value.
-    ///
-    /// This can also be used to transfer boolean values and C-like enums.
-    Int(i64),
-}
-
-impl From<()> for DartValue {
-    #[inline]
-    fn from(_: ()) -> Self {
-        Self::None
-    }
-}
-
-impl<T: ForeignClass> From<T> for DartValue {
-    #[inline]
-    fn from(val: T) -> Self {
-        Self::Ptr(val.into_ptr().cast())
-    }
-}
-
-impl<T: ForeignClass> From<Option<T>> for DartValue {
-    #[inline]
-    fn from(val: Option<T>) -> Self {
-        match val {
-            None => Self::None,
-            Some(t) => Self::from(t),
-        }
-    }
-}
-
-impl<T> From<PtrArray<T>> for DartValue {
-    #[inline]
-    fn from(val: PtrArray<T>) -> Self {
-        Self::Ptr(ptr::NonNull::from(Box::leak(Box::new(val))).cast())
-    }
-}
-
-impl<T> From<Option<PtrArray<T>>> for DartValue {
-    #[inline]
-    fn from(val: Option<PtrArray<T>>) -> Self {
-        match val {
-            None => Self::None,
-            Some(arr) => Self::from(arr),
-        }
-    }
-}
-
-impl From<String> for DartValue {
-    #[inline]
-    fn from(string: String) -> Self {
-        Self::String(string_into_c_str(string))
-    }
-}
-
-impl From<Option<String>> for DartValue {
-    #[inline]
-    fn from(val: Option<String>) -> Self {
-        match val {
-            None => Self::None,
-            Some(string) => Self::from(string),
-        }
-    }
-}
-
-impl From<Dart_Handle> for DartValue {
-    #[inline]
-    fn from(handle: Dart_Handle) -> Self {
-        Self::Handle(ptr::NonNull::from(Box::leak(Box::new(handle))))
-    }
-}
-
-impl From<Option<Dart_Handle>> for DartValue {
-    #[inline]
-    fn from(val: Option<Dart_Handle>) -> Self {
-        match val {
-            None => Self::None,
-            Some(handle) => Self::from(handle),
-        }
-    }
-}
-
-/// Implements [`From`] types that can by casted to `i64` for the [`DartValue`].
-/// Should be called for all the integer types fitting in `2^63`.
-macro_rules! impl_from_num_for_dart_value {
-    ($arg:ty) => {
-        impl From<$arg> for DartValue {
-            #[inline]
-            fn from(val: $arg) -> Self {
-                DartValue::Int(i64::from(val))
-            }
-        }
-    };
-}
-
-impl_from_num_for_dart_value!(i8);
-impl_from_num_for_dart_value!(i16);
-impl_from_num_for_dart_value!(i32);
-impl_from_num_for_dart_value!(i64);
-impl_from_num_for_dart_value!(u8);
-impl_from_num_for_dart_value!(u16);
-impl_from_num_for_dart_value!(u32);
-impl_from_num_for_dart_value!(bool);
 
 /// [`DartValue`] marked by a Rust type.
 ///
@@ -331,6 +214,143 @@ impl<T> TryFrom<DartValueArg<T>> for Option<i64> {
     }
 }
 
+/// Type-erased value that can be transferred via FFI boundaries to/from Dart.
+#[derive(Debug)]
+#[repr(u8)]
+pub enum DartValue {
+    /// No value. It can mean `()`, `void` or [`Option::None`] basing on the
+    /// contexts.
+    None,
+
+    /// Pointer to a [`Box`]ed Rust object.
+    Ptr(ptr::NonNull<c_void>),
+
+    /// Pointer to a [`Dart_Handle`] of some Dart object.
+    Handle(ptr::NonNull<Dart_Handle>),
+
+    /// Native string.
+    String(ptr::NonNull<c_char>),
+
+    /// Integer value.
+    ///
+    /// This can also be used to transfer boolean values and C-like enums.
+    Int(i64),
+}
+
+impl From<()> for DartValue {
+    #[inline]
+    fn from(_: ()) -> Self {
+        Self::None
+    }
+}
+
+impl<T: ForeignClass> From<T> for DartValue {
+    #[inline]
+    fn from(val: T) -> Self {
+        Self::Ptr(val.into_ptr().cast())
+    }
+}
+
+impl<T: ForeignClass> From<Option<T>> for DartValue {
+    #[inline]
+    fn from(val: Option<T>) -> Self {
+        match val {
+            None => Self::None,
+            Some(t) => Self::from(t),
+        }
+    }
+}
+
+impl<T> From<PtrArray<T>> for DartValue {
+    #[inline]
+    fn from(val: PtrArray<T>) -> Self {
+        Self::Ptr(ptr::NonNull::from(Box::leak(Box::new(val))).cast())
+    }
+}
+
+impl<T> From<Option<PtrArray<T>>> for DartValue {
+    #[inline]
+    fn from(val: Option<PtrArray<T>>) -> Self {
+        match val {
+            None => Self::None,
+            Some(arr) => Self::from(arr),
+        }
+    }
+}
+
+impl From<String> for DartValue {
+    #[inline]
+    fn from(string: String) -> Self {
+        Self::String(string_into_c_str(string))
+    }
+}
+
+impl From<Option<String>> for DartValue {
+    #[inline]
+    fn from(val: Option<String>) -> Self {
+        match val {
+            None => Self::None,
+            Some(string) => Self::from(string),
+        }
+    }
+}
+
+impl From<Dart_Handle> for DartValue {
+    #[inline]
+    fn from(handle: Dart_Handle) -> Self {
+        Self::Handle(ptr::NonNull::from(Box::leak(Box::new(handle))))
+    }
+}
+
+impl From<Option<Dart_Handle>> for DartValue {
+    #[inline]
+    fn from(val: Option<Dart_Handle>) -> Self {
+        match val {
+            None => Self::None,
+            Some(handle) => Self::from(handle),
+        }
+    }
+}
+
+impl From<DartError> for DartValue {
+    #[inline]
+    fn from(err: DartError) -> Self {
+        Self::Handle(err.into())
+    }
+}
+
+impl From<Option<DartError>> for DartValue {
+    #[inline]
+    fn from(val: Option<DartError>) -> Self {
+        match val {
+            None => Self::None,
+            Some(err) => Self::from(err),
+        }
+    }
+}
+
+/// Implements [`From`] types that can by casted to `i64` for the [`DartValue`].
+/// Should be called for all the integer types fitting in `2^63`.
+macro_rules! impl_from_num_for_dart_value {
+    ($arg:ty) => {
+        impl From<$arg> for DartValue {
+            #[inline]
+            fn from(val: $arg) -> Self {
+                DartValue::Int(i64::from(val))
+            }
+        }
+    };
+}
+
+impl_from_num_for_dart_value!(i8);
+impl_from_num_for_dart_value!(i16);
+impl_from_num_for_dart_value!(i32);
+impl_from_num_for_dart_value!(i64);
+impl_from_num_for_dart_value!(u8);
+impl_from_num_for_dart_value!(u16);
+impl_from_num_for_dart_value!(u32);
+impl_from_num_for_dart_value!(bool);
+
 /// Error of converting a [`DartValue`] to the concrete type.
 #[derive(Debug, From)]
 #[from(forward)]
@@ -347,7 +367,8 @@ impl From<i64> for MediaSourceKind {
     }
 }
 
-/// Returns a [`Dart_Handle`] dereferenced from the provided pointer.
+/// Returns a [`Dart_Handle`] dereferencing the provided [`Dart_Handle`]
+/// pointer.
 #[no_mangle]
 pub unsafe extern "C" fn unbox_dart_handle(
     val: ptr::NonNull<Dart_Handle>,

--- a/jason/src/api/dart/reconnect_handle.rs
+++ b/jason/src/api/dart/reconnect_handle.rs
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn ReconnectHandle__reconnect_with_delay(
 
     async move {
         let delay_ms = u32::try_from(delay_ms).map_err(|_| {
-            ArgumentError::from(format!("Expected u32, got `{}`", delay_ms))
+            ArgumentError::new(delay_ms, "delayMs", "Expected u32")
         })?;
 
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
@@ -72,13 +72,14 @@ pub unsafe extern "C" fn ReconnectHandle__reconnect_with_backoff(
 
     async move {
         let starting_delay = u32::try_from(starting_delay).map_err(|_| {
-            ArgumentError::from(format!(
-                "Expected u32, got `{}`",
-                starting_delay
-            ))
+            ArgumentError::new(
+                starting_delay,
+                "startingDelayMs",
+                "Expected u32",
+            )
         })?;
         let max_delay = u32::try_from(max_delay).map_err(|_| {
-            ArgumentError::from(format!("Expected u32, got `{}`", max_delay))
+            ArgumentError::new(max_delay, "maxDelay", "Expected u32")
         })?;
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
         //       implemented.

--- a/jason/src/api/dart/room_handle.rs
+++ b/jason/src/api/dart/room_handle.rs
@@ -39,7 +39,7 @@ pub unsafe extern "C" fn RoomHandle__join(
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
         //       implemented.
         this.join(c_str_into_string(token)).await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn RoomHandle__set_local_media_settings(
         this.set_local_media_settings(settings, stop_first, rollback_on_fail)
             .await
             .unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn RoomHandle__mute_audio(
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
         //       implemented.
         this.mute_audio().await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn RoomHandle__unmute_audio(
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
         //       implemented.
         this.mute_audio().await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -140,7 +140,7 @@ pub unsafe extern "C" fn RoomHandle__enable_audio(
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
         //       implemented.
         this.enable_audio().await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn RoomHandle__disable_audio(
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
         //       implemented.
         this.disable_audio().await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn RoomHandle__mute_video(
 
     async move {
         this.mute_video(source_kind).await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn RoomHandle__unmute_video(
 
     async move {
         this.unmute_video(source_kind).await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -228,7 +228,7 @@ pub unsafe extern "C" fn RoomHandle__enable_video(
 
     async move {
         this.enable_video(source_kind).await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -250,7 +250,7 @@ pub unsafe extern "C" fn RoomHandle__disable_video(
 
     async move {
         this.disable_video(source_kind).await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -268,7 +268,7 @@ pub unsafe extern "C" fn RoomHandle__enable_remote_audio(
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
         //       implemented.
         this.enable_remote_audio().await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -286,7 +286,7 @@ pub unsafe extern "C" fn RoomHandle__disable_remote_audio(
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
         //       implemented.
         this.disable_remote_audio().await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -304,7 +304,7 @@ pub unsafe extern "C" fn RoomHandle__enable_remote_video(
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
         //       implemented.
         this.enable_remote_video().await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }
@@ -322,7 +322,7 @@ pub unsafe extern "C" fn RoomHandle__disable_remote_video(
         // TODO: Remove unwrap when propagating errors from Rust to Dart is
         //       implemented.
         this.disable_remote_video().await.unwrap();
-        Ok::<_, ()>(())
+        Ok(())
     }
     .into_dart_future()
 }

--- a/jason/src/api/dart/utils/err.rs
+++ b/jason/src/api/dart/utils/err.rs
@@ -1,4 +1,4 @@
-//! Facility for creating Dart exceptions from Rust.
+//! Facilities for creating Dart exceptions from Rust.
 
 use std::{borrow::Cow, ptr};
 
@@ -9,33 +9,20 @@ use libc::c_char;
 use crate::api::dart::{utils::string_into_c_str, DartValue};
 
 /// Pointer to an extern function that returns a new Dart [`ArgumentError`] with
-/// the provided invalid argument, its name and error message describing the
+/// the provided invalid argument, its `name` and error `message` describing the
 /// problem.
 ///
 /// [`ArgumentError`]: https://api.dart.dev/dart-core/ArgumentError-class.html
 type NewArgumentErrorCaller = extern "C" fn(
     value: DartValue,
-    arg_name: ptr::NonNull<c_char>,
-    msg: ptr::NonNull<c_char>,
+    name: ptr::NonNull<c_char>,
+    message: ptr::NonNull<c_char>,
 ) -> Dart_Handle;
 
 /// Stores pointer to the [`NewArgumentErrorCaller`] extern function.
 ///
 /// Must be initialized by Dart during FFI initialization phase.
 static mut NEW_ARGUMENT_ERROR_CALLER: Option<NewArgumentErrorCaller> = None;
-
-/// An error that can be returned from Rust to Dart.
-#[derive(Into)]
-#[repr(transparent)]
-pub struct DartError(ptr::NonNull<Dart_Handle>);
-
-impl DartError {
-    /// Creates a new [`DartError`] from the provided [`Dart_Handle`].
-    #[inline]
-    fn new(handle: Dart_Handle) -> DartError {
-        DartError(ptr::NonNull::from(Box::leak(Box::new(handle))))
-    }
-}
 
 /// Registers the provided [`NewArgumentErrorCaller`] as
 /// [`NEW_ARGUMENT_ERROR_CALLER`].
@@ -50,21 +37,40 @@ pub unsafe extern "C" fn register_new_argument_error_caller(
     NEW_ARGUMENT_ERROR_CALLER = Some(f);
 }
 
-/// Error that Rust returns when a function is passed an unacceptable argument.
+/// An error that can be returned from Rust to Dart.
+#[derive(Into)]
+#[repr(transparent)]
+pub struct DartError(ptr::NonNull<Dart_Handle>);
+
+impl DartError {
+    /// Creates a new [`DartError`] from the provided [`Dart_Handle`].
+    #[inline]
+    #[must_use]
+    fn new(handle: Dart_Handle) -> DartError {
+        DartError(ptr::NonNull::from(Box::leak(Box::new(handle))))
+    }
+}
+
+/// Error returning by Rust when an unacceptable argument is passed to a
+/// function through FFI.
 ///
-/// It can be converted into [`DartError`] and passed to Dart.
+/// It can be converted into a [`DartError`] and passed to Dart.
 pub struct ArgumentError<T> {
-    /// The invalid value.
+    /// Invalid value of the argument.
     val: T,
+
     /// Name of the invalid argument.
     name: &'static str,
+
     /// Message describing the problem.
     message: Cow<'static, str>,
 }
 
 impl<T> ArgumentError<T> {
-    /// Creates new [`ArgumentError`] from provided invalid argument, its name
-    /// and error message.
+    /// Creates a new [`ArgumentError`] from the provided invalid argument, its
+    /// `name` and error `message` describing the problem.
+    #[inline]
+    #[must_use]
     pub fn new<V>(val: T, name: &'static str, message: V) -> Self
     where
         V: Into<Cow<'static, str>>,

--- a/jason/src/api/dart/utils/errs.rs
+++ b/jason/src/api/dart/utils/errs.rs
@@ -1,26 +1,48 @@
-use std::ptr;
+//! Facility for creating Dart exceptions from Rust.
+
+use std::{borrow::Cow, ptr};
 
 use dart_sys::Dart_Handle;
-use derive_more::{From, Into};
+use derive_more::Into;
 use libc::c_char;
 
-use crate::api::dart::utils::string_into_c_str;
+use crate::api::dart::{utils::string_into_c_str, DartValue};
 
-type NewArgumentErrorCaller =
-    extern "C" fn(ptr::NonNull<c_char>) -> Dart_Handle;
+/// Pointer to an extern function that returns a new Dart [`ArgumentError`] with
+/// the provided invalid argument, its name and error message describing the
+/// problem.
+///
+/// [`ArgumentError`]: https://api.dart.dev/dart-core/ArgumentError-class.html
+type NewArgumentErrorCaller = extern "C" fn(
+    DartValue,
+    ptr::NonNull<c_char>,
+    ptr::NonNull<c_char>,
+) -> Dart_Handle;
 
+/// Stores pointer to the [`NewArgumentErrorCaller`] extern function.
+///
+/// Must be initialized by Dart during FFI initialization phase.
 static mut NEW_ARGUMENT_ERROR_CALLER: Option<NewArgumentErrorCaller> = None;
 
+/// An error that can be returned from Rust to Dart.
 #[derive(Into)]
 #[repr(transparent)]
 pub struct DartError(ptr::NonNull<Dart_Handle>);
 
 impl DartError {
+    /// Creates a new [`DartError`] from the provided [`Dart_Handle`].
+    #[inline]
     fn new(handle: Dart_Handle) -> DartError {
         DartError(ptr::NonNull::from(Box::leak(Box::new(handle))))
     }
 }
 
+/// Registers the provided [`NewArgumentErrorCaller`] as
+/// [`NEW_ARGUMENT_ERROR_CALLER`].
+///
+/// # Safety
+///
+/// Must ONLY be called by Dart during FFI initialization.
 #[no_mangle]
 pub unsafe extern "C" fn register_new_argument_error_caller(
     f: NewArgumentErrorCaller,
@@ -28,15 +50,41 @@ pub unsafe extern "C" fn register_new_argument_error_caller(
     NEW_ARGUMENT_ERROR_CALLER = Some(f);
 }
 
-#[derive(From)]
-#[from(forward)]
-pub struct ArgumentError(String);
+/// Error that Rust returns when a function is passed an unacceptable argument.
+///
+/// It can be converted into [`DartError`] and passed to Dart.
+pub struct ArgumentError<T> {
+    /// The invalid value.
+    val: T,
+    /// Name of the invalid argument.
+    name: &'static str,
+    /// Message describing the problem.
+    message: Cow<'static, str>,
+}
 
-impl From<ArgumentError> for DartError {
-    fn from(err: ArgumentError) -> Self {
+impl<T> ArgumentError<T> {
+    /// Creates new [`ArgumentError`] from provided invalid argument, its name
+    /// and error message.
+    pub fn new<V>(val: T, name: &'static str, message: V) -> Self
+    where
+        V: Into<Cow<'static, str>>,
+    {
+        Self {
+            val,
+            name,
+            message: message.into(),
+        }
+    }
+}
+
+impl<T: Into<DartValue>> From<ArgumentError<T>> for DartError {
+    #[inline]
+    fn from(err: ArgumentError<T>) -> Self {
         unsafe {
             DartError::new(NEW_ARGUMENT_ERROR_CALLER.unwrap()(
-                string_into_c_str(err.0),
+                err.val.into(),
+                string_into_c_str(err.name.to_owned()),
+                string_into_c_str(err.message.into_owned()),
             ))
         }
     }

--- a/jason/src/api/dart/utils/errs.rs
+++ b/jason/src/api/dart/utils/errs.rs
@@ -14,9 +14,9 @@ use crate::api::dart::{utils::string_into_c_str, DartValue};
 ///
 /// [`ArgumentError`]: https://api.dart.dev/dart-core/ArgumentError-class.html
 type NewArgumentErrorCaller = extern "C" fn(
-    DartValue,
-    ptr::NonNull<c_char>,
-    ptr::NonNull<c_char>,
+    value: DartValue,
+    arg_name: ptr::NonNull<c_char>,
+    msg: ptr::NonNull<c_char>,
 ) -> Dart_Handle;
 
 /// Stores pointer to the [`NewArgumentErrorCaller`] extern function.

--- a/jason/src/api/dart/utils/errs.rs
+++ b/jason/src/api/dart/utils/errs.rs
@@ -1,0 +1,43 @@
+use std::ptr;
+
+use dart_sys::Dart_Handle;
+use derive_more::{From, Into};
+use libc::c_char;
+
+use crate::api::dart::utils::string_into_c_str;
+
+type NewArgumentErrorCaller =
+    extern "C" fn(ptr::NonNull<c_char>) -> Dart_Handle;
+
+static mut NEW_ARGUMENT_ERROR_CALLER: Option<NewArgumentErrorCaller> = None;
+
+#[derive(Into)]
+#[repr(transparent)]
+pub struct DartError(ptr::NonNull<Dart_Handle>);
+
+impl DartError {
+    fn new(handle: Dart_Handle) -> DartError {
+        DartError(ptr::NonNull::from(Box::leak(Box::new(handle))))
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn register_new_argument_error_caller(
+    f: NewArgumentErrorCaller,
+) {
+    NEW_ARGUMENT_ERROR_CALLER = Some(f);
+}
+
+#[derive(From)]
+#[from(forward)]
+pub struct ArgumentError(String);
+
+impl From<ArgumentError> for DartError {
+    fn from(err: ArgumentError) -> Self {
+        unsafe {
+            DartError::new(NEW_ARGUMENT_ERROR_CALLER.unwrap()(
+                string_into_c_str(err.0),
+            ))
+        }
+    }
+}

--- a/jason/src/api/dart/utils/mod.rs
+++ b/jason/src/api/dart/utils/mod.rs
@@ -1,5 +1,5 @@
 mod arrays;
-mod errs;
+mod err;
 mod result;
 mod string;
 
@@ -14,7 +14,7 @@ use crate::{
 
 pub use self::{
     arrays::PtrArray,
-    errs::{ArgumentError, DartError},
+    err::{ArgumentError, DartError},
     result::DartResult,
     string::{c_str_into_string, string_into_c_str},
 };

--- a/jason/src/api/dart/utils/mod.rs
+++ b/jason/src/api/dart/utils/mod.rs
@@ -1,4 +1,6 @@
 mod arrays;
+mod errs;
+mod result;
 mod string;
 
 use std::future::Future;
@@ -12,6 +14,8 @@ use crate::{
 
 pub use self::{
     arrays::PtrArray,
+    errs::{ArgumentError, DartError},
+    result::DartResult,
     string::{c_str_into_string, string_into_c_str},
 };
 
@@ -27,11 +31,10 @@ pub trait IntoDartFuture {
     fn into_dart_future(self) -> Dart_Handle;
 }
 
-impl<F, T, E> IntoDartFuture for F
+impl<F, T> IntoDartFuture for F
 where
-    F: Future<Output = Result<T, E>> + 'static,
+    F: Future<Output = Result<T, DartError>> + 'static,
     T: Into<DartValue> + 'static,
-    E: Into<DartValue> + 'static,
 {
     fn into_dart_future(self) -> Dart_Handle {
         let completer = Completer::new();

--- a/jason/src/api/dart/utils/result.rs
+++ b/jason/src/api/dart/utils/result.rs
@@ -1,16 +1,18 @@
+//! FFI-compatible [Result].
+
 use crate::api::dart::{utils::DartError, DartValue};
 
-/// Dart structure which represents [`Result`] for the Dart error.
+/// FFI-compatible [Result].
 #[repr(u8)]
 pub enum DartResult {
+    /// Contains the success [DartValue].
     Ok(DartValue),
+    /// Contains the [DartError] value.
     Err(DartError),
 }
 
-impl<T> From<Result<T, DartError>> for DartResult
-where
-    T: Into<DartValue>,
-{
+impl<T: Into<DartValue>> From<Result<T, DartError>> for DartResult {
+    #[inline]
     fn from(res: Result<T, DartError>) -> Self {
         match res {
             Ok(val) => Self::Ok(val.into()),
@@ -20,6 +22,7 @@ where
 }
 
 impl<T: Into<DartError>> From<T> for DartResult {
+    #[inline]
     fn from(err: T) -> Self {
         DartResult::Err(err.into())
     }

--- a/jason/src/api/dart/utils/result.rs
+++ b/jason/src/api/dart/utils/result.rs
@@ -1,13 +1,14 @@
-//! FFI-compatible [Result].
+//! FFI-compatible [`Result`] for Dart.
 
 use crate::api::dart::{utils::DartError, DartValue};
 
-/// FFI-compatible [Result].
+/// FFI-compatible [`Result`] for Dart.
 #[repr(u8)]
 pub enum DartResult {
-    /// Contains the success [DartValue].
+    /// Success [`DartValue`].
     Ok(DartValue),
-    /// Contains the [DartError] value.
+
+    /// [`DartError`] value.
     Err(DartError),
 }
 

--- a/jason/src/api/dart/utils/result.rs
+++ b/jason/src/api/dart/utils/result.rs
@@ -1,0 +1,26 @@
+use crate::api::dart::{utils::DartError, DartValue};
+
+/// Dart structure which represents [`Result`] for the Dart error.
+#[repr(u8)]
+pub enum DartResult {
+    Ok(DartValue),
+    Err(DartError),
+}
+
+impl<T> From<Result<T, DartError>> for DartResult
+where
+    T: Into<DartValue>,
+{
+    fn from(res: Result<T, DartError>) -> Self {
+        match res {
+            Ok(val) => Self::Ok(val.into()),
+            Err(e) => Self::Err(e),
+        }
+    }
+}
+
+impl<T: Into<DartError>> From<T> for DartResult {
+    fn from(err: T) -> Self {
+        DartResult::Err(err.into())
+    }
+}

--- a/jason/src/api/wasm/reconnect_handle.rs
+++ b/jason/src/api/wasm/reconnect_handle.rs
@@ -72,7 +72,7 @@ impl ReconnectHandle {
         future_to_promise(async move {
             this.reconnect_with_backoff(
                 starting_delay_ms,
-                multiplier,
+                f64::from(multiplier),
                 max_delay,
             )
             .await

--- a/jason/src/api/wasm/reconnect_handle.rs
+++ b/jason/src/api/wasm/reconnect_handle.rs
@@ -72,7 +72,7 @@ impl ReconnectHandle {
         future_to_promise(async move {
             this.reconnect_with_backoff(
                 starting_delay_ms,
-                f64::from(multiplier),
+                multiplier.into(),
                 max_delay,
             )
             .await

--- a/jason/src/rpc/backoff_delayer.rs
+++ b/jason/src/rpc/backoff_delayer.rs
@@ -37,7 +37,7 @@ impl BackoffDelayer {
         Self {
             current_interval: starting_interval,
             max_interval,
-            interval_multiplier: interval_multiplier.max(0_f64),
+            interval_multiplier: interval_multiplier.max(0.0),
         }
     }
 

--- a/jason/src/rpc/backoff_delayer.rs
+++ b/jason/src/rpc/backoff_delayer.rs
@@ -22,7 +22,7 @@ pub struct BackoffDelayer {
 
     /// The multiplier by which [`BackoffDelayer::current_interval`] will be
     /// multiplied on [`BackoffDelayer::delay`] call.
-    interval_multiplier: f32,
+    interval_multiplier: f64,
 }
 
 impl BackoffDelayer {
@@ -31,13 +31,13 @@ impl BackoffDelayer {
     #[must_use]
     pub fn new(
         starting_interval: Duration,
-        interval_multiplier: f32,
+        interval_multiplier: f64,
         max_interval: Duration,
     ) -> Self {
         Self {
             current_interval: starting_interval,
             max_interval,
-            interval_multiplier: interval_multiplier.max(0_f32),
+            interval_multiplier: interval_multiplier.max(0_f64),
         }
     }
 
@@ -59,8 +59,8 @@ impl BackoffDelayer {
             self.max_interval
         } else {
             let delay = self.current_interval;
-            self.current_interval = Duration::from_secs_f32(
-                self.current_interval.as_secs_f32() * self.interval_multiplier,
+            self.current_interval = Duration::from_secs_f64(
+                self.current_interval.as_secs_f64() * self.interval_multiplier,
             );
             delay
         }

--- a/jason/src/rpc/reconnect_handle.rs
+++ b/jason/src/rpc/reconnect_handle.rs
@@ -90,7 +90,7 @@ impl ReconnectHandle {
     pub async fn reconnect_with_backoff(
         &self,
         starting_delay_ms: u32,
-        multiplier: f32,
+        multiplier: f64,
         max_delay: u32,
     ) -> Result<(), Traced<ReconnectError>> {
         let mut backoff_delayer = BackoffDelayer::new(


### PR DESCRIPTION
## Synopsis

Пора уже думать как прокидывать ошибки из раста в дарт. 

## Solution

Понятно что будем в дарте делать throw. По самим ошибкам хочется уйти от какого-то `JasonError` в котором в `name` и `message` стрингами лежат конкретные растовские ошибки, ибо такой вариант не шибко future proof. Думаю, тут следует провести категоризацию растовских ошибок, и выкидывать уже что-то более конкретное. По возможности используя ошибки из дартовского стд.

В этом PR'е идет базовая реализация всего этого механизма, ошибки в extern функциях пока по прежнему анврапятся, этот момент подьедет в следующем PR'е.

Про валидацию аргументов. В данный момент дарту без разницы на тип целочисленных значений. Т.е. в Uint8 можно прокинуть -1, а там просто произойдет каст с оверфловом. В этом PR'е все целочисленные типы (кроме случаев с bool и enum) заменены на In64, а раст уже делает checked cast к нужному типу, возвращая в дарт ошибку если он не удался.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
