### PR TITLE
Extend Rust to Dart error propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite 0.2.6",
  "smallvec",
- "tokio 1.6.0",
+ "tokio 1.6.1",
  "tokio-util 0.6.7",
 ]
 
@@ -46,7 +46,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.6",
- "tokio 1.6.0",
+ "tokio 1.6.1",
  "tokio-util 0.6.7",
 ]
 
@@ -108,7 +108,7 @@ dependencies = [
  "sha-1",
  "smallvec",
  "time 0.2.26",
- "tokio 1.6.0",
+ "tokio 1.6.1",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ checksum = "bc7d7cd957c9ed92288a7c3c96af81fa5291f65247a76a34dac7b6af74e52ba0"
 dependencies = [
  "actix-macros",
  "futures-core",
- "tokio 1.6.0",
+ "tokio 1.6.1",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ dependencies = [
  "mio 0.7.11",
  "num_cpus",
  "slab",
- "tokio 1.6.0",
+ "tokio 1.6.1",
 ]
 
 [[package]]
@@ -276,7 +276,7 @@ dependencies = [
  "bytestring",
  "futures-core",
  "pin-project 1.0.7",
- "tokio 1.6.0",
+ "tokio 1.6.1",
 ]
 
 [[package]]
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "bytes"
@@ -643,7 +643,7 @@ dependencies = [
  "futures-util",
  "memchr",
  "pin-project-lite 0.2.6",
- "tokio 1.6.0",
+ "tokio 1.6.1",
 ]
 
 [[package]]
@@ -756,11 +756,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -872,14 +871,14 @@ checksum = "a2d41e5afb1b1e89cc7204eb9ca99e05ba6fc810962957e7fe285d5024ed5890"
 dependencies = [
  "async-trait",
  "num_cpus",
- "tokio 1.6.0",
+ "tokio 1.6.1",
 ]
 
 [[package]]
 name = "deadpool-redis"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0879c291510f6ca4218972d7f67e23b44798db22844f1054d60f7240a5c925"
+checksum = "637b3ef314fe3393113b2fbf2c98eb557aad7110dcf6b1a7e9b40bdd2589abc0"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -1059,12 +1058,12 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "hyper 0.14.7",
+ "hyper 0.14.8",
  "hyper-tls",
  "mime",
  "serde 1.0.126",
  "serde_json",
- "tokio 1.6.0",
+ "tokio 1.6.1",
  "url",
  "webdriver",
 ]
@@ -1401,7 +1400,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.6.0",
+ "tokio 1.6.1",
  "tokio-util 0.6.7",
  "tracing",
 ]
@@ -1547,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
+checksum = "d3f71a7eea53a3f8257a7b4795373ff886397178cd634430ea94e12d7fe4fe34"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
@@ -1563,7 +1562,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.7",
  "socket2 0.4.0",
- "tokio 1.6.0",
+ "tokio 1.6.1",
  "tower-service",
  "tracing",
  "want",
@@ -1576,9 +1575,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.0.1",
- "hyper 0.14.7",
+ "hyper 0.14.8",
  "native-tls",
- "tokio 1.6.0",
+ "tokio 1.6.1",
  "tokio-native-tls",
 ]
 
@@ -1740,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "linked-hash-map"
@@ -1821,7 +1820,7 @@ dependencies = [
  "function_name",
  "futures 0.3.15",
  "humantime-serde",
- "hyper 0.14.7",
+ "hyper 0.14.8",
  "lazy_static",
  "medea-client-api-proto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "medea-control-api-mock",
@@ -1848,7 +1847,7 @@ dependencies = [
  "smart-default",
  "subtle",
  "tempfile",
- "tokio 1.6.0",
+ "tokio 1.6.1",
  "tokio-stream",
  "tokio-util 0.6.7",
  "toml",
@@ -1931,7 +1930,7 @@ dependencies = [
  "futures 0.3.15",
  "once_cell",
  "regex",
- "tokio 1.6.0",
+ "tokio 1.6.1",
  "tokio-util 0.6.7",
 ]
 
@@ -2012,7 +2011,7 @@ name = "medea-reactive"
 version = "0.1.2-dev"
 dependencies = [
  "futures 0.3.15",
- "tokio 1.6.0",
+ "tokio 1.6.1",
 ]
 
 [[package]]
@@ -2671,7 +2670,7 @@ dependencies = [
  "itoa",
  "percent-encoding",
  "pin-project-lite 0.2.6",
- "tokio 1.6.0",
+ "tokio 1.6.1",
  "tokio-util 0.6.7",
  "url",
 ]
@@ -2734,7 +2733,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body 0.4.2",
- "hyper 0.14.7",
+ "hyper 0.14.8",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2747,7 +2746,7 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "serde_urlencoded 0.7.0",
- "tokio 1.6.0",
+ "tokio 1.6.1",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -3049,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
@@ -3476,9 +3475,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
+checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -3512,7 +3511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.6.0",
+ "tokio 1.6.1",
 ]
 
 [[package]]
@@ -3523,7 +3522,7 @@ checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.6",
- "tokio 1.6.0",
+ "tokio 1.6.1",
 ]
 
 [[package]]
@@ -3551,7 +3550,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.6",
- "tokio 1.6.0",
+ "tokio 1.6.1",
 ]
 
 [[package]]
@@ -3578,12 +3577,12 @@ dependencies = [
  "h2 0.3.3",
  "http",
  "http-body 0.4.2",
- "hyper 0.14.7",
+ "hyper 0.14.8",
  "percent-encoding",
  "pin-project 1.0.7",
  "prost",
  "prost-derive",
- "tokio 1.6.0",
+ "tokio 1.6.1",
  "tokio-stream",
  "tokio-util 0.6.7",
  "tower",
@@ -3606,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0aa6dfc29148c3826708dabbfa83c121eeb84df4d1468220825e3a33651687"
+checksum = "f60422bc7fefa2f3ec70359b8ff1caff59d785877eb70595904605bcc412470f"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3616,7 +3615,7 @@ dependencies = [
  "pin-project 1.0.7",
  "rand 0.8.3",
  "slab",
- "tokio 1.6.0",
+ "tokio 1.6.1",
  "tokio-stream",
  "tokio-util 0.6.7",
  "tower-layer",
@@ -3737,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "33717dca7ac877f497014e10d73f3acf948c342bee31b5ca7892faf94ccc6b49"
 dependencies = [
  "tinyvec",
 ]

--- a/jason/flutter/example/pubspec.lock
+++ b/jason/flutter/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.1"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/jason/flutter/example/pubspec.lock
+++ b/jason/flutter/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.1"
+    version: "6.1.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/jason/flutter/lib/connection_handle.dart
+++ b/jason/flutter/lib/connection_handle.dart
@@ -1,28 +1,27 @@
 import 'dart:ffi';
 
-import 'package:ffi/ffi.dart';
-
-import 'ffi/native_string.dart';
 import 'jason.dart';
 import 'remote_media_track.dart';
 import 'util/move_semantic.dart';
 import 'util/nullable_pointer.dart';
+import 'ffi/result.dart';
 
-typedef _getRemoteMemberId_C = Pointer<Utf8> Function(Pointer);
-typedef _getRemoteMemberId_Dart = Pointer<Utf8> Function(Pointer);
+typedef _getRemoteMemberId_C = Result Function(Pointer);
+typedef _getRemoteMemberId_Dart = Result Function(Pointer);
 
 typedef _free_C = Void Function(Pointer);
 typedef _free_Dart = void Function(Pointer);
 
-typedef _onClose_C = Void Function(Pointer, Handle);
-typedef _onClose_Dart = void Function(Pointer, void Function());
+typedef _onClose_C = Result Function(Pointer, Handle);
+typedef _onClose_Dart = Result Function(Pointer, void Function());
 
-typedef _onRemoteTrackAdded_C = Void Function(Pointer, Handle);
-typedef _onRemoteTrackAdded_Dart = void Function(
+typedef _onRemoteTrackAdded_C = Result Function(Pointer, Handle);
+typedef _onRemoteTrackAdded_Dart = Result Function(
     Pointer, void Function(Pointer));
 
-typedef _onQualityScoreUpdate_C = Void Function(Pointer, Handle);
-typedef _onQualityScoreUpdate_Dart = void Function(Pointer, void Function(int));
+typedef _onQualityScoreUpdate_C = Result Function(Pointer, Handle);
+typedef _onQualityScoreUpdate_Dart = Result Function(
+    Pointer, void Function(int));
 
 final _getRemoteMemberId =
     dl.lookupFunction<_getRemoteMemberId_C, _getRemoteMemberId_Dart>(
@@ -50,28 +49,32 @@ class ConnectionHandle {
   /// provided [Pointer].
   ConnectionHandle(this.ptr);
 
+  // TODO: add throws docs
   /// Returns ID of the remote `Member`.
   String getRemoteMemberId() {
-    return _getRemoteMemberId(ptr.getInnerPtr()).nativeStringToDartString();
+    return _getRemoteMemberId(ptr.getInnerPtr()).unwrap();
   }
 
+  // TODO: add throws docs
   /// Sets callback, invoked when this `Connection` is closed.
   void onClose(void Function() f) {
-    _onClose(ptr.getInnerPtr(), f);
+    _onClose(ptr.getInnerPtr(), f).unwrap();
   }
 
+  // TODO: add throws docs
   /// Sets callback, invoked when a new [RemoteMediaTrack] is added to this
   /// `Connection`.
   void onRemoteTrackAdded(void Function(RemoteMediaTrack) f) {
     _onRemoteTrackAdded(ptr.getInnerPtr(), (t) {
       f(RemoteMediaTrack(NullablePointer(t)));
-    });
+    }).unwrap();
   }
 
+  // TODO: add throws docs
   /// Sets callback, invoked when a connection quality score is updated by a
   /// server.
   void onQualityScoreUpdate(void Function(int) f) {
-    _onQualityScoreUpdate(ptr.getInnerPtr(), f);
+    _onQualityScoreUpdate(ptr.getInnerPtr(), f).unwrap();
   }
 
   /// Drops the associated Rust struct and nulls the local [Pointer] to it.

--- a/jason/flutter/lib/connection_handle.dart
+++ b/jason/flutter/lib/connection_handle.dart
@@ -52,7 +52,7 @@ class ConnectionHandle {
   /// Returns ID of the remote `Member`.
   ///
   /// Throws a [StateError] if an underlying object has been disposed, e.g.
-  /// [free] was called on this [ConnectionHandle] or on a [Jason] or a
+  /// [free] was called on this [ConnectionHandle], or on a [Jason], or on a
   /// `RoomHandle` that implicitly owns native object behind this
   /// [ConnectionHandle].
   String getRemoteMemberId() {
@@ -62,7 +62,7 @@ class ConnectionHandle {
   /// Sets callback, invoked when this `Connection` is closed.
   ///
   /// Throws a [StateError] if an underlying object has been disposed, e.g.
-  /// [free] was called on this [ConnectionHandle] or on a [Jason] or a
+  /// [free] was called on this [ConnectionHandle], or on a [Jason], or on a
   /// `RoomHandle` that implicitly owns native object behind this
   /// [ConnectionHandle].
   void onClose(void Function() f) {
@@ -73,7 +73,7 @@ class ConnectionHandle {
   /// `Connection`.
   ///
   /// Throws a [StateError] if an underlying object has been disposed, e.g.
-  /// [free] was called on this [ConnectionHandle] or on a [Jason] or a
+  /// [free] was called on this [ConnectionHandle], or on a [Jason], or on a
   /// `RoomHandle` that implicitly owns native object behind this
   /// [ConnectionHandle].
   void onRemoteTrackAdded(void Function(RemoteMediaTrack) f) {
@@ -86,7 +86,7 @@ class ConnectionHandle {
   /// server.
   ///
   /// Throws a [StateError] if an underlying object has been disposed, e.g.
-  /// [free] was called on this [ConnectionHandle] or on a [Jason] or a
+  /// [free] was called on this [ConnectionHandle], or on a [Jason], or on a
   /// `RoomHandle` that implicitly owns native object behind this
   /// [ConnectionHandle].
   void onQualityScoreUpdate(void Function(int) f) {

--- a/jason/flutter/lib/connection_handle.dart
+++ b/jason/flutter/lib/connection_handle.dart
@@ -1,10 +1,10 @@
 import 'dart:ffi';
 
+import 'ffi/result.dart';
 import 'jason.dart';
 import 'remote_media_track.dart';
 import 'util/move_semantic.dart';
 import 'util/nullable_pointer.dart';
-import 'ffi/result.dart';
 
 typedef _getRemoteMemberId_C = Result Function(Pointer);
 typedef _getRemoteMemberId_Dart = Result Function(Pointer);
@@ -49,30 +49,46 @@ class ConnectionHandle {
   /// provided [Pointer].
   ConnectionHandle(this.ptr);
 
-  // TODO: add throws docs
   /// Returns ID of the remote `Member`.
+  ///
+  /// Throws a [StateError] if an underlying object has been disposed, e.g.
+  /// [free] was called on this [ConnectionHandle] or on a [Jason] or a
+  /// `RoomHandle` that implicitly owns native object behind this
+  /// [ConnectionHandle].
   String getRemoteMemberId() {
     return _getRemoteMemberId(ptr.getInnerPtr()).unwrap();
   }
 
-  // TODO: add throws docs
   /// Sets callback, invoked when this `Connection` is closed.
+  ///
+  /// Throws a [StateError] if an underlying object has been disposed, e.g.
+  /// [free] was called on this [ConnectionHandle] or on a [Jason] or a
+  /// `RoomHandle` that implicitly owns native object behind this
+  /// [ConnectionHandle].
   void onClose(void Function() f) {
     _onClose(ptr.getInnerPtr(), f).unwrap();
   }
 
-  // TODO: add throws docs
   /// Sets callback, invoked when a new [RemoteMediaTrack] is added to this
   /// `Connection`.
+  ///
+  /// Throws a [StateError] if an underlying object has been disposed, e.g.
+  /// [free] was called on this [ConnectionHandle] or on a [Jason] or a
+  /// `RoomHandle` that implicitly owns native object behind this
+  /// [ConnectionHandle].
   void onRemoteTrackAdded(void Function(RemoteMediaTrack) f) {
     _onRemoteTrackAdded(ptr.getInnerPtr(), (t) {
       f(RemoteMediaTrack(NullablePointer(t)));
     }).unwrap();
   }
 
-  // TODO: add throws docs
   /// Sets callback, invoked when a connection quality score is updated by a
   /// server.
+  ///
+  /// Throws a [StateError] if an underlying object has been disposed, e.g.
+  /// [free] was called on this [ConnectionHandle] or on a [Jason] or a
+  /// `RoomHandle` that implicitly owns native object behind this
+  /// [ConnectionHandle].
   void onQualityScoreUpdate(void Function(int) f) {
     _onQualityScoreUpdate(ptr.getInnerPtr(), f).unwrap();
   }

--- a/jason/flutter/lib/ffi/exceptions.dart
+++ b/jason/flutter/lib/ffi/exceptions.dart
@@ -12,6 +12,13 @@ void registerFunctions(DynamicLibrary dl) {
       Pointer.fromFunction<
           Handle Function(
               ForeignValue, Pointer<Utf8>, Pointer<Utf8>)>(_newArgumentError));
+  dl.lookupFunction<Void Function(Pointer), void Function(Pointer)>(
+          'register_new_state_error_caller')(
+      Pointer.fromFunction<Handle Function(Pointer<Utf8>)>(_newStateError));
+  dl.lookupFunction<Void Function(Pointer), void Function(Pointer)>(
+      'register_new_media_manager_exception_caller')(Pointer.fromFunction<
+          Handle Function(Uint8, Pointer<Utf8>, ForeignValue, Pointer<Utf8>)>(
+      _newMediaManagerException));
 }
 
 /// Create a new [ArgumentError] from the provided invalid [value], its [name]
@@ -20,4 +27,37 @@ Object _newArgumentError(
     ForeignValue value, Pointer<Utf8> name, Pointer<Utf8> message) {
   return ArgumentError.value(value.toDart(), name.nativeStringToDartString(),
       message.nativeStringToDartString());
+}
+
+/// Create a new [StateError] with the provided error [message].
+Object _newStateError(Pointer<Utf8> message) {
+  return StateError(message.nativeStringToDartString());
+}
+
+enum MediaManagerExceptionKind {
+  GetUserMediaFailed,
+  GetDisplayMediaFailed,
+  EnumerateDevicesFailed,
+  LocalTrackIsEnded,
+}
+
+class MediaManagerException implements Exception {
+  late MediaManagerExceptionKind kind;
+  late String message;
+  late dynamic cause;
+  late String nativeStackTrace;
+
+  MediaManagerException(
+      this.kind, this.message, this.cause, this.nativeStackTrace);
+}
+
+/// Create a new [MediaManagerException] with the provided error [kind],
+/// [message], [cause] and [stacktrace].
+Object _newMediaManagerException(int kind, Pointer<Utf8> message,
+    ForeignValue cause, Pointer<Utf8> stacktrace) {
+  return MediaManagerException(
+      MediaManagerExceptionKind.values[kind],
+      message.nativeStringToDartString(),
+      cause.toDart(),
+      stacktrace.nativeStringToDartString());
 }

--- a/jason/flutter/lib/ffi/exceptions.dart
+++ b/jason/flutter/lib/ffi/exceptions.dart
@@ -21,7 +21,7 @@ void registerFunctions(DynamicLibrary dl) {
       _newMediaManagerException));
 }
 
-/// Create a new [ArgumentError] from the provided invalid [value], its [name]
+/// Creates a new [ArgumentError] from the provided invalid [value], its [name]
 /// and the [message] describing the problem.
 Object _newArgumentError(
     ForeignValue value, Pointer<Utf8> name, Pointer<Utf8> message) {
@@ -29,29 +29,12 @@ Object _newArgumentError(
       message.nativeStringToDartString());
 }
 
-/// Create a new [StateError] with the provided error [message].
+/// Creates a new [StateError] with the provided error [message].
 Object _newStateError(Pointer<Utf8> message) {
   return StateError(message.nativeStringToDartString());
 }
 
-enum MediaManagerExceptionKind {
-  GetUserMediaFailed,
-  GetDisplayMediaFailed,
-  EnumerateDevicesFailed,
-  LocalTrackIsEnded,
-}
-
-class MediaManagerException implements Exception {
-  late MediaManagerExceptionKind kind;
-  late String message;
-  late dynamic cause;
-  late String nativeStackTrace;
-
-  MediaManagerException(
-      this.kind, this.message, this.cause, this.nativeStackTrace);
-}
-
-/// Create a new [MediaManagerException] with the provided error [kind],
+/// Creates a new [MediaManagerException] with the provided error [kind],
 /// [message], [cause] and [stacktrace].
 Object _newMediaManagerException(int kind, Pointer<Utf8> message,
     ForeignValue cause, Pointer<Utf8> stacktrace) {
@@ -60,4 +43,49 @@ Object _newMediaManagerException(int kind, Pointer<Utf8> message,
       message.nativeStringToDartString(),
       cause.toDart(),
       stacktrace.nativeStringToDartString());
+}
+
+/// Exception that can be thrown when accessing media devices.
+class MediaManagerException implements Exception {
+  /// Concrete error kind of this [MediaManagerException].
+  late MediaManagerExceptionKind kind;
+
+  /// Error message describing the problem.
+  late String message;
+
+  /// Dart [Exception] or [Error] that caused this [MediaManagerException].
+  late Object? cause;
+
+  /// Native stacktrace.
+  late String nativeStackTrace;
+
+  /// Creates a new [MediaManagerException].
+  MediaManagerException(
+      this.kind, this.message, this.cause, this.nativeStackTrace);
+}
+
+/// Concrete error kind of a [MediaManagerException].
+enum MediaManagerExceptionKind {
+  /// Occurs if the [getUserMedia][1] request failed.
+  ///
+  /// [1]: https://tinyurl.com/w3-streams#dom-mediadevices-getusermedia
+  GetUserMediaFailed,
+
+  /// Occurs if the [getDisplayMedia()][1] request failed.
+  ///
+  /// [1]: https://w3.org/TR/screen-capture/#dom-mediadevices-getdisplaymedia
+  GetDisplayMediaFailed,
+
+  /// Occurs when cannot get info about connected [MediaDevices][1].
+  ///
+  /// [1]: https://w3.org/TR/mediacapture-streams#mediadevices
+  EnumerateDevicesFailed,
+
+  /// Occurs when local track is [`ended`][1] right after [getUserMedia()][2]
+  /// or [getDisplayMedia()][3] request.
+  ///
+  /// [1]: https://tinyurl.com/w3-streams#idl-def-MediaStreamTrackState.ended
+  /// [2]: https://tinyurl.com/rnxcavf
+  /// [3]: https://w3.org/TR/screen-capture#dom-mediadevices-getdisplaymedia
+  LocalTrackIsEnded,
 }

--- a/jason/flutter/lib/ffi/exceptions.dart
+++ b/jason/flutter/lib/ffi/exceptions.dart
@@ -29,7 +29,7 @@ Object _newArgumentError(
       message.nativeStringToDartString());
 }
 
-/// Creates a new [StateError] with the provided error [message].
+/// Creates a new [StateError] with the provided [message].
 Object _newStateError(Pointer<Utf8> message) {
   return StateError(message.nativeStringToDartString());
 }
@@ -45,7 +45,7 @@ Object _newMediaManagerException(int kind, Pointer<Utf8> message,
       stacktrace.nativeStringToDartString());
 }
 
-/// Exception that can be thrown when accessing media devices.
+/// Exception thrown when accessing media devices.
 class MediaManagerException implements Exception {
   /// Concrete error kind of this [MediaManagerException].
   late MediaManagerExceptionKind kind;
@@ -59,14 +59,14 @@ class MediaManagerException implements Exception {
   /// Native stacktrace.
   late String nativeStackTrace;
 
-  /// Creates a new [MediaManagerException].
+  /// Instantiates a new [MediaManagerException].
   MediaManagerException(
       this.kind, this.message, this.cause, this.nativeStackTrace);
 }
 
-/// Concrete error kind of a [MediaManagerException].
+/// Possible error kinds of a [MediaManagerException].
 enum MediaManagerExceptionKind {
-  /// Occurs if the [getUserMedia][1] request failed.
+  /// Occurs if the [getUserMedia()][1] request failed.
   ///
   /// [1]: https://tinyurl.com/w3-streams#dom-mediadevices-getusermedia
   GetUserMediaFailed,

--- a/jason/flutter/lib/media_manager.dart
+++ b/jason/flutter/lib/media_manager.dart
@@ -1,7 +1,5 @@
 import 'dart:ffi';
 
-import 'package:medea_jason/ffi/exceptions.dart';
-
 import 'ffi/ptrarray.dart';
 import 'input_device_info.dart';
 import 'jason.dart';
@@ -49,12 +47,12 @@ class MediaManagerHandle {
   /// Obtains [LocalMediaTrack]s objects from local media devices (or screen
   /// capture) basing on the provided [MediaStreamSettings].
   ///
-  /// Throws [StateError] if underlying object has been disposed, e.g. [free]
-  /// was called on this [MediaManagerHandle] or on a [Jason] that implicitly
-  /// owns this object.
+  /// Throws a [StateError] if an underlying object has been disposed, e.g.
+  /// [free] was called on this [MediaManagerHandle] or on a [Jason] that
+  /// implicitly owns native object behind this [MediaManagerHandle].
   ///
-  /// Throws [MediaManagerException] if platform media devices access request
-  /// failed.
+  /// Throws a `MediaManagerException` if a platform media devices access
+  /// request failed.
   Future<List<LocalMediaTrack>> initLocalTracks(
       MediaStreamSettings caps) async {
     Pointer tracks =
@@ -70,12 +68,12 @@ class MediaManagerHandle {
   /// Returns a list of [InputDeviceInfo] objects representing available media
   /// input devices, such as microphones, cameras, and so forth.
   ///
-  /// Throws [StateError] if underlying object has been disposed, e.g. [free]
-  /// was called on this [MediaManagerHandle] or on a [Jason] that implicitly
-  /// owns this object.
+  /// Throws a [StateError] if an underlying object has been disposed, e.g.
+  /// [free] was called on this [MediaManagerHandle] or on a [Jason] that
+  /// implicitly owns native object behind this [MediaManagerHandle].
   ///
-  /// Throws [MediaManagerException] if platform media devices access request
-  /// failed.
+  /// Throws a `MediaManagerException` if a platform media devices access
+  /// request failed.
   Future<List<InputDeviceInfo>> enumerateDevices() async {
     Pointer pointer = await (_enumerateDevices(ptr.getInnerPtr()) as Future);
     return pointer

--- a/jason/flutter/lib/media_manager.dart
+++ b/jason/flutter/lib/media_manager.dart
@@ -1,5 +1,7 @@
 import 'dart:ffi';
 
+import 'package:medea_jason/ffi/exceptions.dart';
+
 import 'ffi/ptrarray.dart';
 import 'input_device_info.dart';
 import 'jason.dart';
@@ -46,6 +48,13 @@ class MediaManagerHandle {
 
   /// Obtains [LocalMediaTrack]s objects from local media devices (or screen
   /// capture) basing on the provided [MediaStreamSettings].
+  ///
+  /// Throws [StateError] if underlying object has been disposed, e.g. [free]
+  /// was called on this [MediaManagerHandle] or on a [Jason] that implicitly
+  /// owns this object.
+  ///
+  /// Throws [MediaManagerException] if platform media devices access request
+  /// failed.
   Future<List<LocalMediaTrack>> initLocalTracks(
       MediaStreamSettings caps) async {
     Pointer tracks =
@@ -60,6 +69,13 @@ class MediaManagerHandle {
 
   /// Returns a list of [InputDeviceInfo] objects representing available media
   /// input devices, such as microphones, cameras, and so forth.
+  ///
+  /// Throws [StateError] if underlying object has been disposed, e.g. [free]
+  /// was called on this [MediaManagerHandle] or on a [Jason] that implicitly
+  /// owns this object.
+  ///
+  /// Throws [MediaManagerException] if platform media devices access request
+  /// failed.
   Future<List<InputDeviceInfo>> enumerateDevices() async {
     Pointer pointer = await (_enumerateDevices(ptr.getInnerPtr()) as Future);
     return pointer

--- a/jason/flutter/lib/media_manager.dart
+++ b/jason/flutter/lib/media_manager.dart
@@ -48,11 +48,11 @@ class MediaManagerHandle {
   /// capture) basing on the provided [MediaStreamSettings].
   ///
   /// Throws a [StateError] if an underlying object has been disposed, e.g.
-  /// [free] was called on this [MediaManagerHandle] or on a [Jason] that
+  /// [free] was called on this [MediaManagerHandle], or on a [Jason] that
   /// implicitly owns native object behind this [MediaManagerHandle].
   ///
-  /// Throws a `MediaManagerException` if a platform media devices access
-  /// request failed.
+  /// Throws a [MediaManagerException] if a request of platform media devices
+  /// access failed.
   Future<List<LocalMediaTrack>> initLocalTracks(
       MediaStreamSettings caps) async {
     Pointer tracks =
@@ -69,11 +69,11 @@ class MediaManagerHandle {
   /// input devices, such as microphones, cameras, and so forth.
   ///
   /// Throws a [StateError] if an underlying object has been disposed, e.g.
-  /// [free] was called on this [MediaManagerHandle] or on a [Jason] that
+  /// [free] was called on this [MediaManagerHandle], or on a [Jason] that
   /// implicitly owns native object behind this [MediaManagerHandle].
   ///
-  /// Throws a `MediaManagerException` if a platform media devices access
-  /// request failed.
+  /// Throws a [MediaManagerException] if a request of platform media devices
+  /// access failed.
   Future<List<InputDeviceInfo>> enumerateDevices() async {
     Pointer pointer = await (_enumerateDevices(ptr.getInnerPtr()) as Future);
     return pointer

--- a/jason/flutter/lib/reconnect_handle.dart
+++ b/jason/flutter/lib/reconnect_handle.dart
@@ -36,6 +36,7 @@ class ReconnectHandle {
   /// provided [Pointer].
   ReconnectHandle(this.ptr);
 
+  // TODO: add throws docs
   /// Tries to reconnect a `Room` after the provided delay in milliseconds.
   ///
   /// If the `Room` is already reconnecting then new reconnection attempt won't
@@ -45,6 +46,7 @@ class ReconnectHandle {
     await (_reconnect_with_delay(ptr.getInnerPtr(), delayMs) as Future);
   }
 
+  // TODO: add throws docs
   /// Tries to reconnect a `Room` in a loop with a growing backoff delay.
   ///
   /// The first attempt to reconnect is guaranteed to happen not earlier than

--- a/jason/flutter/lib/reconnect_handle.dart
+++ b/jason/flutter/lib/reconnect_handle.dart
@@ -36,7 +36,7 @@ class ReconnectHandle {
   /// provided [Pointer].
   ReconnectHandle(this.ptr);
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Tries to reconnect a `Room` after the provided delay in milliseconds.
   ///
   /// If the `Room` is already reconnecting then new reconnection attempt won't
@@ -46,7 +46,7 @@ class ReconnectHandle {
     await (_reconnect_with_delay(ptr.getInnerPtr(), delayMs) as Future);
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Tries to reconnect a `Room` in a loop with a growing backoff delay.
   ///
   /// The first attempt to reconnect is guaranteed to happen not earlier than

--- a/jason/flutter/lib/room_handle.dart
+++ b/jason/flutter/lib/room_handle.dart
@@ -12,21 +12,24 @@ import 'room_close_reason.dart';
 import 'track_kinds.dart';
 import 'util/move_semantic.dart';
 import 'util/nullable_pointer.dart';
+import 'ffi/result.dart';
 
 typedef _free_C = Void Function(Pointer);
 typedef _free_Dart = void Function(Pointer);
 
-typedef _onNewConnection_C = Void Function(Pointer, Handle);
-typedef _onNewConnection_Dart = void Function(Pointer, void Function(Pointer));
+typedef _onNewConnection_C = Result Function(Pointer, Handle);
+typedef _onNewConnection_Dart = Result Function(
+    Pointer, void Function(Pointer));
 
-typedef _onClose_C = Void Function(Pointer, Handle);
-typedef _onClose_Dart = void Function(Pointer, void Function(Pointer));
+typedef _onClose_C = Result Function(Pointer, Handle);
+typedef _onClose_Dart = Result Function(Pointer, void Function(Pointer));
 
-typedef _onLocalTrack_C = Void Function(Pointer, Handle);
-typedef _onLocalTrack_Dart = void Function(Pointer, void Function(Pointer));
+typedef _onLocalTrack_C = Result Function(Pointer, Handle);
+typedef _onLocalTrack_Dart = Result Function(Pointer, void Function(Pointer));
 
-typedef _onConnectionLoss_C = Void Function(Pointer, Handle);
-typedef _onConnectionLoss_Dart = void Function(Pointer, void Function(Pointer));
+typedef _onConnectionLoss_C = Result Function(Pointer, Handle);
+typedef _onConnectionLoss_Dart = Result Function(
+    Pointer, void Function(Pointer));
 
 typedef _join_C = Handle Function(Pointer, Pointer<Utf8>);
 typedef _join_Dart = Object Function(Pointer, Pointer<Utf8>);
@@ -143,6 +146,7 @@ class RoomHandle {
   /// provided [Pointer].
   RoomHandle(this.ptr);
 
+  // TODO: add throws docs
   /// Connects to a media server and joins the `Room` with the provided
   /// authorization [token].
   ///
@@ -188,21 +192,25 @@ class RoomHandle {
         stopFirst ? 1 : 0, rollbackOnFail ? 1 : 0) as Future);
   }
 
+  // TODO: add throws docs
   /// Mutes outbound audio in this `Room`.
   Future<void> muteAudio() async {
     await (_muteAudio(ptr.getInnerPtr()) as Future);
   }
 
+  // TODO: add throws docs
   /// Unmutes outbound audio in this `Room`.
   Future<void> unmuteAudio() async {
     await (_unmuteAudio(ptr.getInnerPtr()) as Future);
   }
 
+  // TODO: add throws docs
   /// Enables outbound audio in this `Room`.
   Future<void> enableAudio() async {
     await (_enableAudio(ptr.getInnerPtr()) as Future);
   }
 
+  // TODO: add throws docs
   /// Disables outbound audio in this `Room`.
   Future<void> disableAudio() async {
     await (_disableAudio(ptr.getInnerPtr()) as Future);
@@ -260,42 +268,49 @@ class RoomHandle {
     }
   }
 
+  // TODO: add throws docs
   /// Enables inbound audio in this `Room`.
   Future<void> enableRemoteAudio() async {
     await (_enableRemoteAudio(ptr.getInnerPtr()) as Future);
   }
 
+  // TODO: add throws docs
   /// Disables inbound audio in this `Room`.
   Future<void> disableRemoteAudio() async {
     await (_disableRemoteAudio(ptr.getInnerPtr()) as Future);
   }
 
+  // TODO: add throws docs
   /// Enables inbound video in this `Room`.
   Future<void> enableRemoteVideo() async {
     await (_enableRemoteVideo(ptr.getInnerPtr()) as Future);
   }
 
+  // TODO: add throws docs
   /// Disables inbound video in this `Room`.
   Future<void> disableRemoteVideo() async {
     await (_disableRemoteVideo(ptr.getInnerPtr()) as Future);
   }
 
+  // TODO: add throws docs
   /// Sets callback, invoked when a new `Connection` with some remote `Peer`
   /// is established.
   void onNewConnection(void Function(ConnectionHandle) f) {
     _onNewConnection(ptr.getInnerPtr(), (t) {
       f(ConnectionHandle(NullablePointer(t)));
-    });
+    }).unwrap();
   }
 
+  // TODO: add throws docs
   /// Sets callback, invoked when this `Room` is closed, providing a
   /// [RoomCloseReason].
   void onClose(void Function(RoomCloseReason) f) {
     _onClose(ptr.getInnerPtr(), (t) {
       f(RoomCloseReason(NullablePointer(t)));
-    });
+    }).unwrap();
   }
 
+  // TODO: add throws docs
   /// Sets callback, invoked when a new [LocalMediaTrack] is added to this
   /// `Room`.
   ///
@@ -307,16 +322,29 @@ class RoomHandle {
   void onLocalTrack(void Function(LocalMediaTrack) f) {
     _onLocalTrack(ptr.getInnerPtr(), (t) {
       f(LocalMediaTrack(NullablePointer(t)));
-    });
+    }).unwrap();
   }
 
+  // TODO: add throws docs
   /// Sets callback, invoked when a connection with a media server is lost,
   /// providing a [ReconnectHandle].
   void onConnectionLoss(void Function(ReconnectHandle) f) {
     _onConnectionLoss(ptr.getInnerPtr(), (t) {
       f(ReconnectHandle(NullablePointer(t)));
-    });
+    }).unwrap();
   }
+
+  // /// Sets `on_failed_local_media` callback, invoked on a local media
+  // /// acquisition failures.
+  // ///
+  // /// # Errors
+  // ///
+  // /// With [`RoomError::Detached`] if [`Weak`] pointer upgrade fails.
+  // void onFailedLocalMedia(void Function(ReconnectHandle) f) {
+  //   _onConnectionLoss(ptr.getInnerPtr(), (t) {
+  //     f(ReconnectHandle(NullablePointer(t)));
+  //   }).unwrap();
+  // }
 
   /// Drops the associated Rust struct and nulls the local [Pointer] to it.
   @moveSemantics

--- a/jason/flutter/lib/room_handle.dart
+++ b/jason/flutter/lib/room_handle.dart
@@ -4,6 +4,7 @@ import 'package:ffi/ffi.dart';
 
 import 'connection_handle.dart';
 import 'ffi/foreign_value.dart';
+import 'ffi/result.dart';
 import 'jason.dart';
 import 'local_media_track.dart';
 import 'media_stream_settings.dart';
@@ -12,7 +13,6 @@ import 'room_close_reason.dart';
 import 'track_kinds.dart';
 import 'util/move_semantic.dart';
 import 'util/nullable_pointer.dart';
-import 'ffi/result.dart';
 
 typedef _free_C = Void Function(Pointer);
 typedef _free_Dart = void Function(Pointer);
@@ -146,7 +146,7 @@ class RoomHandle {
   /// provided [Pointer].
   RoomHandle(this.ptr);
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Connects to a media server and joins the `Room` with the provided
   /// authorization [token].
   ///
@@ -192,25 +192,25 @@ class RoomHandle {
         stopFirst ? 1 : 0, rollbackOnFail ? 1 : 0) as Future);
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Mutes outbound audio in this `Room`.
   Future<void> muteAudio() async {
     await (_muteAudio(ptr.getInnerPtr()) as Future);
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Unmutes outbound audio in this `Room`.
   Future<void> unmuteAudio() async {
     await (_unmuteAudio(ptr.getInnerPtr()) as Future);
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Enables outbound audio in this `Room`.
   Future<void> enableAudio() async {
     await (_enableAudio(ptr.getInnerPtr()) as Future);
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Disables outbound audio in this `Room`.
   Future<void> disableAudio() async {
     await (_disableAudio(ptr.getInnerPtr()) as Future);
@@ -268,31 +268,31 @@ class RoomHandle {
     }
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Enables inbound audio in this `Room`.
   Future<void> enableRemoteAudio() async {
     await (_enableRemoteAudio(ptr.getInnerPtr()) as Future);
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Disables inbound audio in this `Room`.
   Future<void> disableRemoteAudio() async {
     await (_disableRemoteAudio(ptr.getInnerPtr()) as Future);
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Enables inbound video in this `Room`.
   Future<void> enableRemoteVideo() async {
     await (_enableRemoteVideo(ptr.getInnerPtr()) as Future);
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Disables inbound video in this `Room`.
   Future<void> disableRemoteVideo() async {
     await (_disableRemoteVideo(ptr.getInnerPtr()) as Future);
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Sets callback, invoked when a new `Connection` with some remote `Peer`
   /// is established.
   void onNewConnection(void Function(ConnectionHandle) f) {
@@ -301,7 +301,7 @@ class RoomHandle {
     }).unwrap();
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Sets callback, invoked when this `Room` is closed, providing a
   /// [RoomCloseReason].
   void onClose(void Function(RoomCloseReason) f) {
@@ -310,7 +310,7 @@ class RoomHandle {
     }).unwrap();
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Sets callback, invoked when a new [LocalMediaTrack] is added to this
   /// `Room`.
   ///
@@ -325,7 +325,7 @@ class RoomHandle {
     }).unwrap();
   }
 
-  // TODO: add throws docs
+  // TODO: Add throws docs when all errros are implemented.
   /// Sets callback, invoked when a connection with a media server is lost,
   /// providing a [ReconnectHandle].
   void onConnectionLoss(void Function(ReconnectHandle) f) {
@@ -334,6 +334,7 @@ class RoomHandle {
     }).unwrap();
   }
 
+  // TODO: Implement.
   // /// Sets `on_failed_local_media` callback, invoked on a local media
   // /// acquisition failures.
   // ///

--- a/jason/src/api/dart/connection_handle.rs
+++ b/jason/src/api/dart/connection_handle.rs
@@ -35,9 +35,8 @@ pub unsafe extern "C" fn ConnectionHandle__on_close(
     this: ptr::NonNull<ConnectionHandle>,
     f: Dart_Handle,
 ) -> DartResult {
-    let this = this.as_ref();
-
-    this.on_close(platform::Function::new(f))
+    this.as_ref()
+        .on_close(platform::Function::new(f))
         .map_err(DartError::from)
         .into()
 }
@@ -52,9 +51,8 @@ pub unsafe extern "C" fn ConnectionHandle__on_remote_track_added(
     this: ptr::NonNull<ConnectionHandle>,
     f: Dart_Handle,
 ) -> DartResult {
-    let this = this.as_ref();
-
-    this.on_remote_track_added(platform::Function::new(f))
+    this.as_ref()
+        .on_remote_track_added(platform::Function::new(f))
         .map_err(DartError::from)
         .into()
 }
@@ -66,9 +64,8 @@ pub unsafe extern "C" fn ConnectionHandle__on_quality_score_update(
     this: ptr::NonNull<ConnectionHandle>,
     f: Dart_Handle,
 ) -> DartResult {
-    let this = this.as_ref();
-
-    this.on_quality_score_update(platform::Function::new(f))
+    this.as_ref()
+        .on_quality_score_update(platform::Function::new(f))
         .map_err(DartError::from)
         .into()
 }
@@ -78,9 +75,10 @@ pub unsafe extern "C" fn ConnectionHandle__on_quality_score_update(
 pub unsafe extern "C" fn ConnectionHandle__get_remote_member_id(
     this: ptr::NonNull<ConnectionHandle>,
 ) -> DartResult {
-    let this = this.as_ref();
-
-    this.get_remote_member_id().map_err(DartError::from).into()
+    this.as_ref()
+        .get_remote_member_id()
+        .map_err(DartError::from)
+        .into()
 }
 
 /// Frees the data behind the provided pointer.

--- a/jason/src/api/dart/connection_handle.rs
+++ b/jason/src/api/dart/connection_handle.rs
@@ -19,9 +19,9 @@ pub use crate::connection::ConnectionHandle;
 impl ForeignClass for ConnectionHandle {}
 
 impl From<Traced<ConnectionError>> for DartError {
+    #[inline]
     fn from(err: Traced<ConnectionError>) -> Self {
-        let err = err.into_inner();
-        match err {
+        match err.into_inner() {
             ConnectionError::Detached => {
                 StateError::new("ConnectionHandle is in detached state.").into()
             }

--- a/jason/src/api/dart/media_manager_handle.rs
+++ b/jason/src/api/dart/media_manager_handle.rs
@@ -22,25 +22,24 @@ impl ForeignClass for MediaManagerHandle {}
 
 impl From<Traced<MediaManagerError>> for DartError {
     fn from(err: Traced<MediaManagerError>) -> Self {
+        use MediaManagerError as E;
+        use MediaManagerExceptionKind as Kind;
+
         let (err, stacktrace) = err.into_parts();
         let message = err.to_string();
 
         let (kind, cause) = match err {
-            MediaManagerError::GetUserMediaFailed(cause) => {
-                (MediaManagerExceptionKind::GetUserMediaFailed, Some(cause))
+            E::GetUserMediaFailed(cause) => {
+                (Kind::GetUserMediaFailed, Some(cause))
             }
-            MediaManagerError::GetDisplayMediaFailed(cause) => (
-                MediaManagerExceptionKind::GetDisplayMediaFailed,
-                Some(cause),
-            ),
-            MediaManagerError::EnumerateDevicesFailed(cause) => (
-                MediaManagerExceptionKind::EnumerateDevicesFailed,
-                Some(cause),
-            ),
-            MediaManagerError::LocalTrackIsEnded(_) => {
-                (MediaManagerExceptionKind::LocalTrackIsEnded, None)
+            E::GetDisplayMediaFailed(cause) => {
+                (Kind::GetDisplayMediaFailed, Some(cause))
             }
-            MediaManagerError::Detached => {
+            E::EnumerateDevicesFailed(cause) => {
+                (Kind::EnumerateDevicesFailed, Some(cause))
+            }
+            E::LocalTrackIsEnded(_) => (Kind::LocalTrackIsEnded, None),
+            E::Detached => {
                 return StateError::new(
                     "MediaManagerHandle is in detached state.",
                 )

--- a/jason/src/api/dart/media_manager_handle.rs
+++ b/jason/src/api/dart/media_manager_handle.rs
@@ -5,13 +5,12 @@ use tracerr::Traced;
 use crate::media::MediaManagerError;
 
 use super::{
-    api::dart::{InputDeviceInfo, LocalMediaTrack},
     media_stream_settings::MediaStreamSettings,
     utils::{
         DartError, DartFuture, IntoDartFuture, MediaManagerException,
         MediaManagerExceptionKind, PtrArray, StateError,
     },
-    ForeignClass,
+    ForeignClass, InputDeviceInfo, LocalMediaTrack,
 };
 
 #[cfg(feature = "mockable")]
@@ -104,8 +103,8 @@ mod mock {
     use crate::{
         api::{
             dart::{
-                utils::{DartFuture, IntoDartFuture},
-                DartError, DartResult,
+                utils::{DartFuture, DartResult, IntoDartFuture},
+                DartError,
             },
             InputDeviceInfo, LocalMediaTrack, MediaStreamSettings,
         },

--- a/jason/src/api/dart/mod.rs
+++ b/jason/src/api/dart/mod.rs
@@ -42,17 +42,12 @@ pub use self::{
     connection_handle::ConnectionHandle,
     device_video_track_constraints::DeviceVideoTrackConstraints,
     display_video_track_constraints::DisplayVideoTrackConstraints,
-    input_device_info::InputDeviceInfo,
-    jason::Jason,
-    jason_error::JasonError,
+    input_device_info::InputDeviceInfo, jason::Jason, jason_error::JasonError,
     local_media_track::LocalMediaTrack,
     media_manager_handle::MediaManagerHandle,
     media_stream_settings::MediaStreamSettings,
-    reconnect_handle::ReconnectHandle,
-    remote_media_track::RemoteMediaTrack,
-    room_close_reason::RoomCloseReason,
-    room_handle::RoomHandle,
-    utils::{DartError as Error, DartResult},
+    reconnect_handle::ReconnectHandle, remote_media_track::RemoteMediaTrack,
+    room_close_reason::RoomCloseReason, room_handle::RoomHandle,
 };
 
 /// Rust structure having wrapper class in Dart.

--- a/jason/src/api/dart/mod.rs
+++ b/jason/src/api/dart/mod.rs
@@ -42,12 +42,17 @@ pub use self::{
     connection_handle::ConnectionHandle,
     device_video_track_constraints::DeviceVideoTrackConstraints,
     display_video_track_constraints::DisplayVideoTrackConstraints,
-    input_device_info::InputDeviceInfo, jason::Jason, jason_error::JasonError,
+    input_device_info::InputDeviceInfo,
+    jason::Jason,
+    jason_error::JasonError,
     local_media_track::LocalMediaTrack,
     media_manager_handle::MediaManagerHandle,
     media_stream_settings::MediaStreamSettings,
-    reconnect_handle::ReconnectHandle, remote_media_track::RemoteMediaTrack,
-    room_close_reason::RoomCloseReason, room_handle::RoomHandle,
+    reconnect_handle::ReconnectHandle,
+    remote_media_track::RemoteMediaTrack,
+    room_close_reason::RoomCloseReason,
+    room_handle::RoomHandle,
+    utils::{DartError as Error, DartResult},
 };
 
 /// Rust structure having wrapper class in Dart.

--- a/jason/src/api/dart/reconnect_handle.rs
+++ b/jason/src/api/dart/reconnect_handle.rs
@@ -20,10 +20,9 @@ pub use crate::rpc::ReconnectHandle;
 impl ForeignClass for ReconnectHandle {}
 
 impl From<Traced<ReconnectError>> for DartError {
+    #[inline]
     fn from(err: Traced<ReconnectError>) -> Self {
-        let err = err.into_inner();
-
-        match err {
+        match err.into_inner() {
             ReconnectError::Session(_) => {
                 todo!()
             }

--- a/jason/src/api/dart/reconnect_handle.rs
+++ b/jason/src/api/dart/reconnect_handle.rs
@@ -1,10 +1,16 @@
 use std::{convert::TryFrom as _, ptr};
 
-use dart_sys::Dart_Handle;
+use tracerr::Traced;
 
-use crate::api::dart::utils::{ArgumentError, IntoDartFuture};
+use crate::{
+    api::dart::utils::{ArgumentError, DartFuture, IntoDartFuture},
+    rpc::ReconnectError,
+};
 
-use super::ForeignClass;
+use super::{
+    utils::{DartError, StateError},
+    ForeignClass,
+};
 
 #[cfg(feature = "mockable")]
 pub use self::mock::ReconnectHandle;
@@ -12,6 +18,21 @@ pub use self::mock::ReconnectHandle;
 pub use crate::rpc::ReconnectHandle;
 
 impl ForeignClass for ReconnectHandle {}
+
+impl From<Traced<ReconnectError>> for DartError {
+    fn from(err: Traced<ReconnectError>) -> Self {
+        let err = err.into_inner();
+
+        match err {
+            ReconnectError::Session(_) => {
+                todo!()
+            }
+            ReconnectError::Detached => {
+                StateError::new("ReconnectHandle is in detached state.").into()
+            }
+        }
+    }
+}
 
 /// Tries to reconnect a [`Room`] after the provided delay in milliseconds.
 ///
@@ -25,7 +46,7 @@ impl ForeignClass for ReconnectHandle {}
 pub unsafe extern "C" fn ReconnectHandle__reconnect_with_delay(
     this: ptr::NonNull<ReconnectHandle>,
     delay_ms: i64,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), DartError>> {
     let this = this.as_ref().clone();
 
     async move {
@@ -33,9 +54,7 @@ pub unsafe extern "C" fn ReconnectHandle__reconnect_with_delay(
             ArgumentError::new(delay_ms, "delayMs", "Expected u32")
         })?;
 
-        // TODO: Remove unwrap when propagating errors from Rust to Dart is
-        //       implemented.
-        this.reconnect_with_delay(delay_ms).await.unwrap();
+        this.reconnect_with_delay(delay_ms).await?;
         Ok(())
     }
     .into_dart_future()
@@ -67,7 +86,7 @@ pub unsafe extern "C" fn ReconnectHandle__reconnect_with_backoff(
     starting_delay: i64,
     multiplier: f64,
     max_delay: i64,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), DartError>> {
     let this = this.as_ref().clone();
 
     async move {
@@ -81,11 +100,9 @@ pub unsafe extern "C" fn ReconnectHandle__reconnect_with_backoff(
         let max_delay = u32::try_from(max_delay).map_err(|_| {
             ArgumentError::new(max_delay, "maxDelay", "Expected u32")
         })?;
-        // TODO: Remove unwrap when propagating errors from Rust to Dart is
-        //       implemented.
+
         this.reconnect_with_backoff(starting_delay, multiplier, max_delay)
-            .await
-            .unwrap();
+            .await?;
         Ok(())
     }
     .into_dart_future()
@@ -106,9 +123,9 @@ pub unsafe extern "C" fn ReconnectHandle__free(
 
 #[cfg(feature = "mockable")]
 mod mock {
-    use crate::{
-        api::dart::JasonError, rpc::ReconnectHandle as CoreReconnectHandle,
-    };
+    use tracerr::Traced;
+
+    use crate::rpc::{ReconnectError, ReconnectHandle as CoreReconnectHandle};
 
     #[derive(Clone)]
     pub struct ReconnectHandle;
@@ -123,7 +140,7 @@ mod mock {
         pub async fn reconnect_with_delay(
             &self,
             _delay_ms: u32,
-        ) -> Result<(), JasonError> {
+        ) -> Result<(), Traced<ReconnectError>> {
             Ok(())
         }
 
@@ -132,7 +149,7 @@ mod mock {
             _starting_delay_ms: u32,
             _multiplier: f64,
             _max_delay: u32,
-        ) -> Result<(), JasonError> {
+        ) -> Result<(), Traced<ReconnectError>> {
             Ok(())
         }
     }

--- a/jason/src/api/dart/room_handle.rs
+++ b/jason/src/api/dart/room_handle.rs
@@ -1,17 +1,20 @@
 use std::{convert::TryFrom as _, ptr};
 
 use dart_sys::Dart_Handle;
+use tracerr::Traced;
 
 use crate::{
     api::dart::{
-        utils::{c_str_into_string, IntoDartFuture},
-        DartValueArg, ForeignClass,
+        utils::{c_str_into_string, DartFuture, IntoDartFuture, StateError},
+        DartResult, DartValueArg, ForeignClass,
     },
     media::MediaSourceKind,
+    peer::PeerError,
     platform,
+    room::RoomError,
 };
 
-use super::MediaStreamSettings;
+use super::{utils::DartError, MediaStreamSettings};
 
 #[cfg(feature = "mockable")]
 pub use self::mock::RoomHandle;
@@ -19,6 +22,37 @@ pub use self::mock::RoomHandle;
 pub use crate::room::RoomHandle;
 
 impl ForeignClass for RoomHandle {}
+
+impl From<Traced<RoomError>> for DartError {
+    fn from(err: Traced<RoomError>) -> Self {
+        let err = err.into_inner();
+
+        match err {
+            RoomError::CallbackNotSet(_)
+            | RoomError::InvalidLocalTracks(_)
+            | RoomError::CouldNotGetLocalMedia(_)
+            | RoomError::NoSuchPeer(_)
+            | RoomError::PeerConnectionError(_)
+            | RoomError::UnknownRemoteMember
+            | RoomError::FailedTrackPatch(_)
+            | RoomError::MediaConnections(_)
+            | RoomError::SessionError(_)
+            | RoomError::MediaManagerError(_)
+            | RoomError::ConnectionInfoParse(_) => {
+                todo!()
+            }
+            RoomError::Detached => {
+                StateError::new("RoomHandle is in detached state.").into()
+            }
+        }
+    }
+}
+
+impl From<Traced<PeerError>> for DartError {
+    fn from(_err: Traced<PeerError>) -> Self {
+        todo!()
+    }
+}
 
 /// Connects to a media server and joins the [`Room`] with the provided
 /// authorization `token`.
@@ -32,13 +66,11 @@ impl ForeignClass for RoomHandle {}
 pub unsafe extern "C" fn RoomHandle__join(
     this: ptr::NonNull<RoomHandle>,
     token: ptr::NonNull<libc::c_char>,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), Traced<RoomError>>> {
     let this = this.as_ref().clone();
 
     async move {
-        // TODO: Remove unwrap when propagating errors from Rust to Dart is
-        //       implemented.
-        this.join(c_str_into_string(token)).await.unwrap();
+        this.join(c_str_into_string(token)).await?;
         Ok(())
     }
     .into_dart_future()
@@ -76,12 +108,12 @@ pub unsafe extern "C" fn RoomHandle__set_local_media_settings(
     settings: ptr::NonNull<MediaStreamSettings>,
     stop_first: bool,
     rollback_on_fail: bool,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), Traced<RoomError>>> {
     let this = this.as_ref().clone();
     let settings = settings.as_ref().clone();
 
     async move {
-        // TODO: Remove unwrap when propagating errors from Rust to Dart is
+        // TODO: Remove unwrap when ConstraintsUpdateException bindings will be
         //       implemented.
         this.set_local_media_settings(settings, stop_first, rollback_on_fail)
             .await
@@ -97,13 +129,11 @@ pub unsafe extern "C" fn RoomHandle__set_local_media_settings(
 #[no_mangle]
 pub unsafe extern "C" fn RoomHandle__mute_audio(
     this: ptr::NonNull<RoomHandle>,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), Traced<RoomError>>> {
     let this = this.as_ref().clone();
 
     async move {
-        // TODO: Remove unwrap when propagating errors from Rust to Dart is
-        //       implemented.
-        this.mute_audio().await.unwrap();
+        this.mute_audio().await?;
         Ok(())
     }
     .into_dart_future()
@@ -115,13 +145,11 @@ pub unsafe extern "C" fn RoomHandle__mute_audio(
 #[no_mangle]
 pub unsafe extern "C" fn RoomHandle__unmute_audio(
     this: ptr::NonNull<RoomHandle>,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), Traced<RoomError>>> {
     let this = this.as_ref().clone();
 
     async move {
-        // TODO: Remove unwrap when propagating errors from Rust to Dart is
-        //       implemented.
-        this.mute_audio().await.unwrap();
+        this.mute_audio().await?;
         Ok(())
     }
     .into_dart_future()
@@ -133,13 +161,11 @@ pub unsafe extern "C" fn RoomHandle__unmute_audio(
 #[no_mangle]
 pub unsafe extern "C" fn RoomHandle__enable_audio(
     this: ptr::NonNull<RoomHandle>,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), Traced<RoomError>>> {
     let this = this.as_ref().clone();
 
     async move {
-        // TODO: Remove unwrap when propagating errors from Rust to Dart is
-        //       implemented.
-        this.enable_audio().await.unwrap();
+        this.enable_audio().await?;
         Ok(())
     }
     .into_dart_future()
@@ -151,13 +177,11 @@ pub unsafe extern "C" fn RoomHandle__enable_audio(
 #[no_mangle]
 pub unsafe extern "C" fn RoomHandle__disable_audio(
     this: ptr::NonNull<RoomHandle>,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), Traced<RoomError>>> {
     let this = this.as_ref().clone();
 
     async move {
-        // TODO: Remove unwrap when propagating errors from Rust to Dart is
-        //       implemented.
-        this.disable_audio().await.unwrap();
+        this.disable_audio().await?;
         Ok(())
     }
     .into_dart_future()
@@ -172,8 +196,8 @@ pub unsafe extern "C" fn RoomHandle__disable_audio(
 pub unsafe extern "C" fn RoomHandle__mute_video(
     this: ptr::NonNull<RoomHandle>,
     source_kind: DartValueArg<Option<MediaSourceKind>>,
-) -> Dart_Handle {
-    // TODO: Remove unwraps when propagating errors from Rust to Dart is
+) -> DartFuture<Result<(), Traced<RoomError>>> {
+    // TODO: Remove unwraps when propagating fatal errors from Rust to Dart is
     //       implemented.
     let this = this.as_ref().clone();
     let source_kind = Option::<i64>::try_from(source_kind)
@@ -181,7 +205,7 @@ pub unsafe extern "C" fn RoomHandle__mute_video(
         .map(MediaSourceKind::from);
 
     async move {
-        this.mute_video(source_kind).await.unwrap();
+        this.mute_video(source_kind).await?;
         Ok(())
     }
     .into_dart_future()
@@ -196,16 +220,16 @@ pub unsafe extern "C" fn RoomHandle__mute_video(
 pub unsafe extern "C" fn RoomHandle__unmute_video(
     this: ptr::NonNull<RoomHandle>,
     source_kind: DartValueArg<Option<MediaSourceKind>>,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), Traced<RoomError>>> {
     let this = this.as_ref().clone();
-    // TODO: Remove unwraps when propagating errors from Rust to Dart is
+    // TODO: Remove unwraps when propagating fatal errors from Rust to Dart is
     //       implemented.
     let source_kind = Option::<i64>::try_from(source_kind)
         .unwrap()
         .map(MediaSourceKind::from);
 
     async move {
-        this.unmute_video(source_kind).await.unwrap();
+        this.unmute_video(source_kind).await?;
         Ok(())
     }
     .into_dart_future()
@@ -218,16 +242,16 @@ pub unsafe extern "C" fn RoomHandle__unmute_video(
 pub unsafe extern "C" fn RoomHandle__enable_video(
     this: ptr::NonNull<RoomHandle>,
     source_kind: DartValueArg<Option<MediaSourceKind>>,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), Traced<RoomError>>> {
     let this = this.as_ref().clone();
-    // TODO: Remove unwraps when propagating errors from Rust to Dart is
+    // TODO: Remove unwraps when propagating fatal errors from Rust to Dart is
     //       implemented.
     let source_kind = Option::<i64>::try_from(source_kind)
         .unwrap()
         .map(MediaSourceKind::from);
 
     async move {
-        this.enable_video(source_kind).await.unwrap();
+        this.enable_video(source_kind).await?;
         Ok(())
     }
     .into_dart_future()
@@ -240,8 +264,8 @@ pub unsafe extern "C" fn RoomHandle__enable_video(
 pub unsafe extern "C" fn RoomHandle__disable_video(
     this: ptr::NonNull<RoomHandle>,
     source_kind: DartValueArg<Option<MediaSourceKind>>,
-) -> Dart_Handle {
-    // TODO: Remove unwraps when propagating errors from Rust to Dart is
+) -> DartFuture<Result<(), Traced<RoomError>>> {
+    // TODO: Remove unwraps when propagating fatal errors from Rust to Dart is
     //       implemented.
     let this = this.as_ref().clone();
     let source_kind = Option::<i64>::try_from(source_kind)
@@ -249,7 +273,7 @@ pub unsafe extern "C" fn RoomHandle__disable_video(
         .map(MediaSourceKind::from);
 
     async move {
-        this.disable_video(source_kind).await.unwrap();
+        this.disable_video(source_kind).await?;
         Ok(())
     }
     .into_dart_future()
@@ -261,13 +285,11 @@ pub unsafe extern "C" fn RoomHandle__disable_video(
 #[no_mangle]
 pub unsafe extern "C" fn RoomHandle__enable_remote_audio(
     this: ptr::NonNull<RoomHandle>,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), Traced<RoomError>>> {
     let this = this.as_ref().clone();
 
     async move {
-        // TODO: Remove unwrap when propagating errors from Rust to Dart is
-        //       implemented.
-        this.enable_remote_audio().await.unwrap();
+        this.enable_remote_audio().await?;
         Ok(())
     }
     .into_dart_future()
@@ -279,13 +301,11 @@ pub unsafe extern "C" fn RoomHandle__enable_remote_audio(
 #[no_mangle]
 pub unsafe extern "C" fn RoomHandle__disable_remote_audio(
     this: ptr::NonNull<RoomHandle>,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), Traced<RoomError>>> {
     let this = this.as_ref().clone();
 
     async move {
-        // TODO: Remove unwrap when propagating errors from Rust to Dart is
-        //       implemented.
-        this.disable_remote_audio().await.unwrap();
+        this.disable_remote_audio().await?;
         Ok(())
     }
     .into_dart_future()
@@ -297,13 +317,11 @@ pub unsafe extern "C" fn RoomHandle__disable_remote_audio(
 #[no_mangle]
 pub unsafe extern "C" fn RoomHandle__enable_remote_video(
     this: ptr::NonNull<RoomHandle>,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), Traced<RoomError>>> {
     let this = this.as_ref().clone();
 
     async move {
-        // TODO: Remove unwrap when propagating errors from Rust to Dart is
-        //       implemented.
-        this.enable_remote_video().await.unwrap();
+        this.enable_remote_video().await?;
         Ok(())
     }
     .into_dart_future()
@@ -315,13 +333,11 @@ pub unsafe extern "C" fn RoomHandle__enable_remote_video(
 #[no_mangle]
 pub unsafe extern "C" fn RoomHandle__disable_remote_video(
     this: ptr::NonNull<RoomHandle>,
-) -> Dart_Handle {
+) -> DartFuture<Result<(), Traced<RoomError>>> {
     let this = this.as_ref().clone();
 
     async move {
-        // TODO: Remove unwrap when propagating errors from Rust to Dart is
-        //       implemented.
-        this.disable_remote_video().await.unwrap();
+        this.disable_remote_video().await?;
         Ok(())
     }
     .into_dart_future()
@@ -335,12 +351,12 @@ pub unsafe extern "C" fn RoomHandle__disable_remote_video(
 pub unsafe extern "C" fn RoomHandle__on_new_connection(
     this: ptr::NonNull<RoomHandle>,
     cb: Dart_Handle,
-) {
+) -> DartResult {
     let this = this.as_ref();
 
-    // TODO: Remove unwrap when propagating errors from Rust to Dart is
-    //       implemented.
-    this.on_new_connection(platform::Function::new(cb)).unwrap();
+    this.on_new_connection(platform::Function::new(cb))
+        .map_err(DartError::from)
+        .into()
 }
 
 /// Sets callback, invoked on this [`Room`] close, providing a
@@ -352,12 +368,12 @@ pub unsafe extern "C" fn RoomHandle__on_new_connection(
 pub unsafe extern "C" fn RoomHandle__on_close(
     this: ptr::NonNull<RoomHandle>,
     cb: Dart_Handle,
-) {
+) -> DartResult {
     let this = this.as_ref();
 
-    // TODO: Remove unwrap when propagating errors from Rust to Dart is
-    //       implemented.
-    this.on_close(platform::Function::new(cb)).unwrap();
+    this.on_close(platform::Function::new(cb))
+        .map_err(DartError::from)
+        .into()
 }
 
 /// Sets callback, invoked when a new [`LocalMediaTrack`] is added to this
@@ -375,12 +391,12 @@ pub unsafe extern "C" fn RoomHandle__on_close(
 pub unsafe extern "C" fn RoomHandle__on_local_track(
     this: ptr::NonNull<RoomHandle>,
     cb: Dart_Handle,
-) {
+) -> DartResult {
     let this = this.as_ref();
 
-    // TODO: Remove unwrap when propagating errors from Rust to Dart is
-    //       implemented.
-    this.on_local_track(platform::Function::new(cb)).unwrap();
+    this.on_local_track(platform::Function::new(cb))
+        .map_err(DartError::from)
+        .into()
 }
 
 /// Sets callback, invoked when a connection with server is lost.
@@ -388,13 +404,12 @@ pub unsafe extern "C" fn RoomHandle__on_local_track(
 pub unsafe extern "C" fn RoomHandle__on_connection_loss(
     this: ptr::NonNull<RoomHandle>,
     cb: Dart_Handle,
-) {
+) -> DartResult {
     let this = this.as_ref();
 
-    // TODO: Remove unwrap when propagating errors from Rust to Dart is
-    //       implemented.
     this.on_connection_loss(platform::Function::new(cb))
-        .unwrap();
+        .map_err(DartError::from)
+        .into()
 }
 
 /// Frees the data behind the provided pointer.
@@ -410,14 +425,16 @@ pub unsafe extern "C" fn RoomHandle__free(this: ptr::NonNull<RoomHandle>) {
 
 #[cfg(feature = "mockable")]
 mod mock {
+    use tracerr::Traced;
+
     use crate::{
         api::{
-            ConnectionHandle, JasonError, LocalMediaTrack, MediaStreamSettings,
+            ConnectionHandle, LocalMediaTrack, MediaStreamSettings,
             ReconnectHandle,
         },
         media::MediaSourceKind,
         platform,
-        room::RoomCloseReason,
+        room::{RoomCloseReason, RoomError},
         rpc::{ClientDisconnect, CloseReason},
     };
 
@@ -429,7 +446,7 @@ mod mock {
         pub fn on_new_connection(
             &self,
             cb: platform::Function<ConnectionHandle>,
-        ) -> Result<(), JasonError> {
+        ) -> Result<(), Traced<RoomError>> {
             cb.call1(ConnectionHandle);
             Ok(())
         }
@@ -437,7 +454,7 @@ mod mock {
         pub fn on_close(
             &self,
             cb: platform::Function<RoomCloseReason>,
-        ) -> Result<(), JasonError> {
+        ) -> Result<(), Traced<RoomError>> {
             cb.call1(RoomCloseReason::new(CloseReason::ByClient {
                 is_err: true,
                 reason: ClientDisconnect::RpcClientUnexpectedlyDropped,
@@ -448,7 +465,7 @@ mod mock {
         pub fn on_local_track(
             &self,
             cb: platform::Function<LocalMediaTrack>,
-        ) -> Result<(), JasonError> {
+        ) -> Result<(), Traced<RoomError>> {
             cb.call1(LocalMediaTrack);
             Ok(())
         }
@@ -456,12 +473,15 @@ mod mock {
         pub fn on_connection_loss(
             &self,
             cb: platform::Function<ReconnectHandle>,
-        ) -> Result<(), JasonError> {
+        ) -> Result<(), Traced<RoomError>> {
             cb.call1(ReconnectHandle);
             Ok(())
         }
 
-        pub async fn join(&self, _token: String) -> Result<(), JasonError> {
+        pub async fn join(
+            &self,
+            _token: String,
+        ) -> Result<(), Traced<RoomError>> {
             Ok(())
         }
 
@@ -477,30 +497,30 @@ mod mock {
             _settings: MediaStreamSettings,
             _stop_first: bool,
             _rollback_on_fail: bool,
-        ) -> Result<(), JasonError> {
+        ) -> Result<(), Traced<RoomError>> {
             Ok(())
         }
 
-        pub async fn mute_audio(&self) -> Result<(), JasonError> {
+        pub async fn mute_audio(&self) -> Result<(), Traced<RoomError>> {
             Ok(())
         }
 
-        pub async fn unmute_audio(&self) -> Result<(), JasonError> {
+        pub async fn unmute_audio(&self) -> Result<(), Traced<RoomError>> {
             Ok(())
         }
 
-        pub async fn enable_audio(&self) -> Result<(), JasonError> {
+        pub async fn enable_audio(&self) -> Result<(), Traced<RoomError>> {
             Ok(())
         }
 
-        pub async fn disable_audio(&self) -> Result<(), JasonError> {
+        pub async fn disable_audio(&self) -> Result<(), Traced<RoomError>> {
             Ok(())
         }
 
         pub async fn mute_video(
             &self,
             source_kind: Option<MediaSourceKind>,
-        ) -> Result<(), JasonError> {
+        ) -> Result<(), Traced<RoomError>> {
             assert_eq!(source_kind, None);
             Ok(())
         }
@@ -508,7 +528,7 @@ mod mock {
         pub async fn unmute_video(
             &self,
             source_kind: Option<MediaSourceKind>,
-        ) -> Result<(), JasonError> {
+        ) -> Result<(), Traced<RoomError>> {
             assert_eq!(source_kind, Some(MediaSourceKind::Display));
             Ok(())
         }
@@ -516,7 +536,7 @@ mod mock {
         pub async fn enable_video(
             &self,
             source_kind: Option<MediaSourceKind>,
-        ) -> Result<(), JasonError> {
+        ) -> Result<(), Traced<RoomError>> {
             assert_eq!(source_kind, Some(MediaSourceKind::Device));
             Ok(())
         }
@@ -524,24 +544,32 @@ mod mock {
         pub async fn disable_video(
             &self,
             source_kind: Option<MediaSourceKind>,
-        ) -> Result<(), JasonError> {
+        ) -> Result<(), Traced<RoomError>> {
             assert_eq!(source_kind, Some(MediaSourceKind::Display));
             Ok(())
         }
 
-        pub async fn enable_remote_audio(&self) -> Result<(), JasonError> {
+        pub async fn enable_remote_audio(
+            &self,
+        ) -> Result<(), Traced<RoomError>> {
             Ok(())
         }
 
-        pub async fn disable_remote_audio(&self) -> Result<(), JasonError> {
+        pub async fn disable_remote_audio(
+            &self,
+        ) -> Result<(), Traced<RoomError>> {
             Ok(())
         }
 
-        pub async fn enable_remote_video(&self) -> Result<(), JasonError> {
-            Ok(())
+        pub async fn enable_remote_video(
+            &self,
+        ) -> Result<(), Traced<RoomError>> {
+            Err(tracerr::new!(RoomError::Detached).into())
         }
 
-        pub async fn disable_remote_video(&self) -> Result<(), JasonError> {
+        pub async fn disable_remote_video(
+            &self,
+        ) -> Result<(), Traced<RoomError>> {
             Ok(())
         }
     }

--- a/jason/src/api/dart/room_handle.rs
+++ b/jason/src/api/dart/room_handle.rs
@@ -5,8 +5,11 @@ use tracerr::Traced;
 
 use crate::{
     api::dart::{
-        utils::{c_str_into_string, DartFuture, IntoDartFuture, StateError},
-        DartResult, DartValueArg, ForeignClass,
+        utils::{
+            c_str_into_string, DartFuture, DartResult, IntoDartFuture,
+            StateError,
+        },
+        DartValueArg, ForeignClass,
     },
     media::MediaSourceKind,
     peer::PeerError,

--- a/jason/src/api/dart/room_handle.rs
+++ b/jason/src/api/dart/room_handle.rs
@@ -27,10 +27,9 @@ pub use crate::room::RoomHandle;
 impl ForeignClass for RoomHandle {}
 
 impl From<Traced<RoomError>> for DartError {
+    #[inline]
     fn from(err: Traced<RoomError>) -> Self {
-        let err = err.into_inner();
-
-        match err {
+        match err.into_inner() {
             RoomError::CallbackNotSet(_)
             | RoomError::InvalidLocalTracks(_)
             | RoomError::CouldNotGetLocalMedia(_)

--- a/jason/src/api/dart/utils/err.rs
+++ b/jason/src/api/dart/utils/err.rs
@@ -5,8 +5,30 @@ use std::{borrow::Cow, ptr};
 use dart_sys::Dart_Handle;
 use derive_more::Into;
 use libc::c_char;
+use tracerr::Trace;
 
-use crate::api::dart::{utils::string_into_c_str, DartValue};
+use crate::{
+    api::dart::{utils::string_into_c_str, DartValue},
+    platform,
+};
+
+/// Pointer to an extern function that returns a new Dart [`StateError`] with
+/// the provided error message.
+///
+/// [`StateError`]: https://api.dart.dev/dart-core/StateError-class.html
+type NewStateErrorCaller = extern "C" fn(ptr::NonNull<c_char>) -> Dart_Handle;
+
+/// Pointer to an extern function that returns a new Dart
+/// `MediaManagerException` error `kind`,  `message` describing the problem,
+/// [`DartValue`] `cause` and `stacktrace`.
+///
+/// [`ArgumentError`]: https://api.dart.dev/dart-core/ArgumentError-class.html
+type NewMediaManagerExceptionCaller = extern "C" fn(
+    kind: MediaManagerExceptionKind,
+    message: ptr::NonNull<c_char>,
+    cause: DartValue,
+    stacktrace: ptr::NonNull<c_char>,
+) -> Dart_Handle;
 
 /// Pointer to an extern function that returns a new Dart [`ArgumentError`] with
 /// the provided invalid argument, its `name` and error `message` describing the
@@ -19,10 +41,42 @@ type NewArgumentErrorCaller = extern "C" fn(
     message: ptr::NonNull<c_char>,
 ) -> Dart_Handle;
 
+/// Stores pointer to the [`NewStateErrorCaller`] extern function.
+///
+/// Must be initialized by Dart during FFI initialization phase.
+static mut NEW_STATE_ERROR_CALLER: Option<NewStateErrorCaller> = None;
+
+/// Stores pointer to the [`NewMediaManagerExceptionCaller`] extern function.
+///
+/// Must be initialized by Dart during FFI initialization phase.
+static mut NEW_MEDIA_MANAGER_EXCEPTION_CALLER: Option<
+    NewMediaManagerExceptionCaller,
+> = None;
+
 /// Stores pointer to the [`NewArgumentErrorCaller`] extern function.
 ///
 /// Must be initialized by Dart during FFI initialization phase.
 static mut NEW_ARGUMENT_ERROR_CALLER: Option<NewArgumentErrorCaller> = None;
+
+/// An error that can be returned from Rust to Dart.
+#[derive(Into)]
+#[repr(transparent)]
+pub struct DartError(ptr::NonNull<Dart_Handle>);
+
+impl DartError {
+    /// Creates a new [`DartError`] from the provided [`Dart_Handle`].
+    #[inline]
+    #[must_use]
+    fn new(handle: Dart_Handle) -> DartError {
+        DartError(ptr::NonNull::from(Box::leak(Box::new(handle))))
+    }
+}
+
+impl From<platform::Error> for DartError {
+    fn from(err: platform::Error) -> Self {
+        Self::new(err.get_handle())
+    }
+}
 
 /// Registers the provided [`NewArgumentErrorCaller`] as
 /// [`NEW_ARGUMENT_ERROR_CALLER`].
@@ -37,18 +91,30 @@ pub unsafe extern "C" fn register_new_argument_error_caller(
     NEW_ARGUMENT_ERROR_CALLER = Some(f);
 }
 
-/// An error that can be returned from Rust to Dart.
-#[derive(Into)]
-#[repr(transparent)]
-pub struct DartError(ptr::NonNull<Dart_Handle>);
+/// Registers the provided [`NewStateErrorCaller`] as
+/// [`NEW_STATE_ERROR_CALLER`].
+///
+/// # Safety
+///
+/// Must ONLY be called by Dart during FFI initialization.
+#[no_mangle]
+pub unsafe extern "C" fn register_new_state_error_caller(
+    f: NewStateErrorCaller,
+) {
+    NEW_STATE_ERROR_CALLER = Some(f);
+}
 
-impl DartError {
-    /// Creates a new [`DartError`] from the provided [`Dart_Handle`].
-    #[inline]
-    #[must_use]
-    fn new(handle: Dart_Handle) -> DartError {
-        DartError(ptr::NonNull::from(Box::leak(Box::new(handle))))
-    }
+/// Registers the provided [`NewMediaManagerExceptionCaller`] as
+/// [`NEW_MEDIA_MANAGER_EXCEPTION_CALLER`].
+///
+/// # Safety
+///
+/// Must ONLY be called by Dart during FFI initialization.
+#[no_mangle]
+pub unsafe extern "C" fn register_new_media_manager_exception_caller(
+    f: NewMediaManagerExceptionCaller,
+) {
+    NEW_MEDIA_MANAGER_EXCEPTION_CALLER = Some(f);
 }
 
 /// Error returning by Rust when an unacceptable argument is passed to a
@@ -87,10 +153,84 @@ impl<T: Into<DartValue>> From<ArgumentError<T>> for DartError {
     #[inline]
     fn from(err: ArgumentError<T>) -> Self {
         unsafe {
-            DartError::new(NEW_ARGUMENT_ERROR_CALLER.unwrap()(
+            Self::new(NEW_ARGUMENT_ERROR_CALLER.unwrap()(
                 err.val.into(),
                 string_into_c_str(err.name.to_owned()),
                 string_into_c_str(err.message.into_owned()),
+            ))
+        }
+    }
+}
+
+/// Error that is thrown when the operation was not allowed by the current state
+/// of the object.
+///
+/// It can be converted into a [`DartError`] and passed to Dart.
+pub struct StateError(Cow<'static, str>);
+
+impl StateError {
+    /// Creates a new [`StateError`] with the provided error `message`
+    /// describing the problem.
+    pub fn new<T: Into<Cow<'static, str>>>(message: T) -> Self {
+        Self(message.into())
+    }
+}
+
+impl From<StateError> for DartError {
+    #[inline]
+    fn from(err: StateError) -> Self {
+        unsafe {
+            Self::new(NEW_STATE_ERROR_CALLER.unwrap()(string_into_c_str(
+                err.0.into_owned(),
+            )))
+        }
+    }
+}
+
+#[repr(u8)]
+pub enum MediaManagerExceptionKind {
+    GetUserMediaFailed,
+    GetDisplayMediaFailed,
+    EnumerateDevicesFailed,
+    LocalTrackIsEnded,
+}
+
+pub struct MediaManagerException {
+    kind: MediaManagerExceptionKind,
+    message: Cow<'static, str>,
+    cause: Option<platform::Error>,
+    trace: Trace,
+}
+
+impl MediaManagerException {
+    /// Creates a new [`MediaManagerException`] from the provided `name`, error
+    /// `message`, its `cause` and `trace`.
+    #[inline]
+    #[must_use]
+    pub fn new<M: Into<Cow<'static, str>>>(
+        kind: MediaManagerExceptionKind,
+        message: M,
+        cause: Option<platform::Error>,
+        trace: Trace,
+    ) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            cause,
+            trace,
+        }
+    }
+}
+
+impl From<MediaManagerException> for DartError {
+    #[inline]
+    fn from(err: MediaManagerException) -> Self {
+        unsafe {
+            Self::new(NEW_MEDIA_MANAGER_EXCEPTION_CALLER.unwrap()(
+                err.kind,
+                string_into_c_str(err.message.into_owned()),
+                err.cause.map(DartError::from).into(),
+                string_into_c_str(err.trace.to_string()),
             ))
         }
     }

--- a/jason/src/api/dart/utils/err.rs
+++ b/jason/src/api/dart/utils/err.rs
@@ -24,14 +24,14 @@ type NewArgumentErrorCaller = extern "C" fn(
 ) -> Dart_Handle;
 
 /// Pointer to an extern function that returns a new Dart [`StateError`] with
-/// the provided error message.
+/// the provided message.
 ///
 /// [`StateError`]: https://api.dart.dev/dart-core/StateError-class.html
 type NewStateErrorCaller = extern "C" fn(ptr::NonNull<c_char>) -> Dart_Handle;
 
 /// Pointer to an extern function that returns a new Dart
-/// `MediaManagerException` with the provided `kind`, `message`, `cause` and
-/// `stacktrace`.
+/// [`MediaManagerException`] with the provided error `kind`, `message`, `cause`
+/// and `stacktrace`.
 type NewMediaManagerExceptionCaller = extern "C" fn(
     kind: MediaManagerExceptionKind,
     message: ptr::NonNull<c_char>,
@@ -110,6 +110,7 @@ impl DartError {
 }
 
 impl From<platform::Error> for DartError {
+    #[inline]
     fn from(err: platform::Error) -> Self {
         Self::new(err.get_handle())
     }
@@ -160,15 +161,17 @@ impl<T: Into<DartValue>> From<ArgumentError<T>> for DartError {
     }
 }
 
-/// Error that is thrown when the operation was not allowed by the current state
-/// of the object.
+/// Error thrown when the operation wasn't allowed by the current state of the
+/// object.
 ///
 /// It can be converted into a [`DartError`] and passed to Dart.
 pub struct StateError(Cow<'static, str>);
 
 impl StateError {
-    /// Creates a new [`StateError`] with the provided error `message`
-    /// describing the problem.
+    /// Creates a new [`StateError`] with the provided `message` describing the
+    /// problem.
+    #[inline]
+    #[must_use]
     pub fn new<T: Into<Cow<'static, str>>>(message: T) -> Self {
         Self(message.into())
     }
@@ -185,10 +188,10 @@ impl From<StateError> for DartError {
     }
 }
 
-/// Concrete error kind of a [`MediaManagerException`].
+/// Possible error kinds of a [`MediaManagerException`].
 #[repr(u8)]
 pub enum MediaManagerExceptionKind {
-    /// Occurs if the [getUserMedia][1] request failed.
+    /// Occurs if the [getUserMedia()][1] request failed.
     ///
     /// [1]: https://tinyurl.com/w3-streams#dom-mediadevices-getusermedia
     GetUserMediaFailed,
@@ -212,7 +215,7 @@ pub enum MediaManagerExceptionKind {
     LocalTrackIsEnded,
 }
 
-/// Exception that can be thrown when accessing media devices.
+/// Exception thrown when accessing media devices.
 pub struct MediaManagerException {
     /// Concrete error kind of this [`MediaManagerException`].
     kind: MediaManagerExceptionKind,
@@ -228,7 +231,7 @@ pub struct MediaManagerException {
 }
 
 impl MediaManagerException {
-    /// Creates a new [`MediaManagerException`] from the provided `kind`, error
+    /// Creates a new [`MediaManagerException`] from the provided error `kind`,
     /// `message`, optional `cause` and `trace`.
     #[inline]
     #[must_use]

--- a/jason/src/api/dart/utils/mod.rs
+++ b/jason/src/api/dart/utils/mod.rs
@@ -29,9 +29,9 @@ pub use self::{
 pub struct DartFuture<O>(Dart_Handle, PhantomData<*const O>);
 
 /// Extension trait for a [`Future`] allowing to convert Rust [`Future`]s to
-/// Dart `Future`s.
+/// [`DartFuture`]s.
 pub trait IntoDartFuture {
-    /// The type of value produced on completion.
+    /// The type of the value produced on the [`DartFuture`]'s completion.
     type Output;
 
     /// Converts this [`Future`] into a Dart `Future`.

--- a/jason/src/api/dart/utils/mod.rs
+++ b/jason/src/api/dart/utils/mod.rs
@@ -3,7 +3,7 @@ mod err;
 mod result;
 mod string;
 
-use std::future::Future;
+use std::{future::Future, marker::PhantomData};
 
 use dart_sys::Dart_Handle;
 
@@ -14,29 +14,44 @@ use crate::{
 
 pub use self::{
     arrays::PtrArray,
-    err::{ArgumentError, DartError},
+    err::{
+        ArgumentError, DartError, MediaManagerException,
+        MediaManagerExceptionKind, StateError,
+    },
     result::DartResult,
     string::{c_str_into_string, string_into_c_str},
 };
 
+/// Rust representation of a Dart [`Future`].
+///
+/// [`Future`]: https://api.dart.dev/dart-async/Future-class.html
+#[repr(transparent)]
+pub struct DartFuture<O>(Dart_Handle, PhantomData<*const O>);
+
 /// Extension trait for a [`Future`] allowing to convert Rust [`Future`]s to
 /// Dart `Future`s.
 pub trait IntoDartFuture {
+    /// The type of value produced on completion.
+    type Output;
+
     /// Converts this [`Future`] into a Dart `Future`.
     ///
     /// Returns a [`Dart_Handle`] to the created Dart `Future`.
     ///
     /// __Note, that the Dart `Future` execution begins immediately and cannot
     /// be canceled.__
-    fn into_dart_future(self) -> Dart_Handle;
+    fn into_dart_future(self) -> DartFuture<Self::Output>;
 }
 
-impl<F, T> IntoDartFuture for F
+impl<Fut, Ok, Err> IntoDartFuture for Fut
 where
-    F: Future<Output = Result<T, DartError>> + 'static,
-    T: Into<DartValue> + 'static,
+    Fut: Future<Output = Result<Ok, Err>> + 'static,
+    Ok: Into<DartValue> + 'static,
+    Err: Into<DartError>,
 {
-    fn into_dart_future(self) -> Dart_Handle {
+    type Output = Fut::Output;
+
+    fn into_dart_future(self) -> DartFuture<Fut::Output> {
         let completer = Completer::new();
         let dart_future = completer.future();
         spawn(async move {
@@ -45,10 +60,10 @@ where
                     completer.complete(ok);
                 }
                 Err(e) => {
-                    completer.complete_error(e);
+                    completer.complete_error(e.into());
                 }
             }
         });
-        dart_future
+        DartFuture(dart_future, PhantomData)
     }
 }

--- a/jason/src/media/manager.rs
+++ b/jason/src/media/manager.rs
@@ -25,12 +25,6 @@ use super::track::local;
 #[derive(Clone, Debug, Display, JsCaused)]
 #[js(error = "platform::Error")]
 pub enum MediaManagerError {
-    /// Occurs when cannot get access to [MediaDevices][1] object.
-    ///
-    /// [1]: https://w3.org/TR/mediacapture-streams#mediadevices
-    #[display(fmt = "Navigator.mediaDevices() failed: {}", _0)]
-    CouldNotGetMediaDevices(platform::Error),
-
     /// Occurs if the [getUserMedia][1] request failed.
     ///
     /// [1]: https://tinyurl.com/w3-streams#dom-mediadevices-getusermedia
@@ -327,9 +321,8 @@ impl MediaManagerHandle {
     ///
     /// # Errors
     ///
-    /// With [`MediaManagerError::CouldNotGetMediaDevices`] or
-    /// [`MediaManagerError::EnumerateDevicesFailed`] if devices enumeration
-    /// failed.
+    /// With [`MediaManagerError::EnumerateDevicesFailed`] if devices
+    /// enumeration failed.
     pub async fn enumerate_devices(
         &self,
     ) -> Result<Vec<platform::InputDeviceInfo>> {
@@ -344,9 +337,6 @@ impl MediaManagerHandle {
     /// # Errors
     ///
     /// With [`MediaManagerError::Detached`] if [`Weak`] pointer upgrade fails.
-    ///
-    /// With [`MediaManagerError::CouldNotGetMediaDevices`] if media devices
-    /// request to User Agent failed.
     ///
     /// With [`MediaManagerError::GetUserMediaFailed`] if [getUserMedia()][1]
     /// request failed.

--- a/jason/src/peer/component/mod.rs
+++ b/jason/src/peer/component/mod.rs
@@ -350,21 +350,18 @@ impl State {
         &self,
         track: &proto::Track,
         send_constraints: LocalTracksConstraints,
-    ) -> Result<(), Traced<PeerError>> {
+    ) {
         match &track.direction {
             proto::Direction::Send { receivers, mid } => {
                 self.senders.insert(
                     track.id,
-                    Rc::new(
-                        sender::State::new(
-                            track.id,
-                            mid.clone(),
-                            track.media_type.clone(),
-                            receivers.clone(),
-                            send_constraints,
-                        )
-                        .map_err(tracerr::map_from_and_wrap!())?,
-                    ),
+                    Rc::new(sender::State::new(
+                        track.id,
+                        mid.clone(),
+                        track.media_type.clone(),
+                        receivers.clone(),
+                        send_constraints,
+                    )),
                 );
             }
             proto::Direction::Recv { sender, mid } => {
@@ -379,8 +376,6 @@ impl State {
                 );
             }
         }
-
-        Ok(())
     }
 
     /// Returns [`Future`] resolving once all [`State::senders`]' inserts and

--- a/jason/src/peer/media/mod.rs
+++ b/jason/src/peer/media/mod.rs
@@ -888,7 +888,7 @@ impl MediaConnections {
             media_type.clone(),
             receivers,
             send_constraints.clone(),
-        )?;
+        );
         let sender = sender::Sender::new(
             &sender_state,
             &self,

--- a/jason/src/peer/media/sender/component.rs
+++ b/jason/src/peer/media/sender/component.rs
@@ -228,14 +228,15 @@ impl State {
     ///
     /// Returns [`MediaConnectionsError::CannotDisableRequiredSender`] if this
     /// [`Sender`] cannot be disabled.
+    #[must_use]
     pub fn new(
         id: TrackId,
         mid: Option<String>,
         media_type: MediaType,
         receivers: Vec<MemberId>,
         send_constraints: LocalTracksConstraints,
-    ) -> Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             id,
             mid,
             media_type,
@@ -252,7 +253,7 @@ impl State {
             sync_state: ObservableCell::new(SyncState::Synced),
             send_constraints,
             local_track_state: ObservableCell::new(LocalTrackState::Stable),
-        })
+        }
     }
 
     /// Indicates whether this [`Sender`]'s media exchange state is in

--- a/jason/src/platform/dart/error.rs
+++ b/jason/src/platform/dart/error.rs
@@ -1,7 +1,50 @@
 //! Wrapper for Dart exceptions.
 
-use derive_more::Display;
+use std::{fmt, rc::Rc};
+
+use dart_sys::{Dart_Handle, Dart_PersistentHandle};
+
+use super::utils::dart_api::{
+    Dart_DeletePersistentHandle_DL_Trampolined,
+    Dart_HandleFromPersistent_DL_Trampolined,
+    Dart_NewPersistentHandle_DL_Trampolined,
+};
 
 /// Wrapper for Dart exception thrown when calling Dart code.
-#[derive(Clone, Debug, Display, PartialEq)]
-pub struct Error;
+#[derive(Clone, Debug, PartialEq)]
+pub struct Error(Rc<Dart_PersistentHandle>);
+
+impl Error {
+    /// Returns [`Dart_Handle`] to the underlying error.
+    #[inline]
+    #[must_use]
+    pub fn get_handle(&self) -> Dart_Handle {
+        // We dont expose inner Dart_PersistentHandle anywhere, so we are sure
+        // that it is valid at this point thus this should be safe.
+        unsafe { Dart_HandleFromPersistent_DL_Trampolined(*self.0) }
+    }
+}
+
+impl From<Dart_Handle> for Error {
+    #[inline]
+    fn from(err: Dart_Handle) -> Self {
+        Self(Rc::new(unsafe {
+            Dart_NewPersistentHandle_DL_Trampolined(err)
+        }))
+    }
+}
+
+impl Drop for Error {
+    #[inline]
+    fn drop(&mut self) {
+        if Rc::strong_count(&self.0) == 1 {
+            unsafe { Dart_DeletePersistentHandle_DL_Trampolined(*self.0) }
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DartPlatformError")
+    }
+}

--- a/jason/src/platform/dart/media_devices.rs
+++ b/jason/src/platform/dart/media_devices.rs
@@ -18,9 +18,6 @@ use crate::{
 ///
 /// # Errors
 ///
-/// With [`MediaManagerError::CouldNotGetMediaDevices`] if couldn't get
-/// [MediaDevices][2].
-///
 /// With [`MediaManagerError::EnumerateDevicesFailed`] if
 /// [MediaDevices.enumerateDevices()][1] returns error.
 ///
@@ -37,9 +34,6 @@ pub async fn enumerate_devices(
 /// Adapter for a [MediaDevices.getUserMedia()][1] function.
 ///
 /// # Errors
-///
-/// With [`MediaManagerError::CouldNotGetMediaDevices`] if couldn't get
-/// [MediaDevices][2].
 ///
 /// With [`MediaManagerError::GetUserMediaFailed`] if
 /// [MediaDevices.getUserMedia()][1] returns error.
@@ -59,9 +53,6 @@ pub async fn get_user_media(
 /// Adapter for a [MediaDevices.getDisplayMedia()][1] function.
 ///
 /// # Errors
-///
-/// With [`MediaManagerError::CouldNotGetMediaDevices`] if couldn't get
-/// [MediaDevices][2].
 ///
 /// With [`MediaManagerError::GetUserMediaFailed`] if
 /// [MediaDevices.getDisplayMedia()][1] returns error.

--- a/jason/src/platform/wasm/media_devices.rs
+++ b/jason/src/platform/wasm/media_devices.rs
@@ -23,11 +23,9 @@ use super::window;
 ///
 /// # Errors
 ///
-/// With [`MediaManagerError::CouldNotGetMediaDevices`] if couldn't get
-/// [MediaDevices][2].
-///
 /// With [`MediaManagerError::EnumerateDevicesFailed`] if
-/// [MediaDevices.enumerateDevices()][1] returns error.
+/// [MediaDevices.enumerateDevices()][1] returns error or couldn't get
+/// [MediaDevices][2].
 ///
 /// # Panics
 ///
@@ -38,13 +36,13 @@ use super::window;
 /// [2]: https://w3.org/TR/mediacapture-streams#mediadevices
 pub async fn enumerate_devices(
 ) -> Result<Vec<InputDeviceInfo>, Traced<MediaManagerError>> {
-    use MediaManagerError::{CouldNotGetMediaDevices, EnumerateDevicesFailed};
+    use MediaManagerError::EnumerateDevicesFailed;
 
     let devices = window()
         .navigator()
         .media_devices()
         .map_err(Error::from)
-        .map_err(CouldNotGetMediaDevices)
+        .map_err(EnumerateDevicesFailed)
         .map_err(tracerr::from_and_wrap!())?;
     let devices = JsFuture::from(
         devices
@@ -75,11 +73,9 @@ pub async fn enumerate_devices(
 ///
 /// # Errors
 ///
-/// With [`MediaManagerError::CouldNotGetMediaDevices`] if couldn't get
-/// [MediaDevices][2].
-///
 /// With [`MediaManagerError::GetUserMediaFailed`] if
-/// [MediaDevices.getUserMedia()][1] returns error.
+/// [MediaDevices.getUserMedia()][1] returns error or couldn't get
+/// [MediaDevices][2].
 ///
 /// # Panics
 ///
@@ -91,13 +87,13 @@ pub async fn enumerate_devices(
 pub async fn get_user_media(
     caps: MediaStreamConstraints,
 ) -> Result<Vec<MediaStreamTrack>, Traced<MediaManagerError>> {
-    use MediaManagerError::{CouldNotGetMediaDevices, GetUserMediaFailed};
+    use MediaManagerError::GetUserMediaFailed;
 
     let media_devices = window()
         .navigator()
         .media_devices()
         .map_err(Error::from)
-        .map_err(CouldNotGetMediaDevices)
+        .map_err(GetUserMediaFailed)
         .map_err(tracerr::from_and_wrap!())?;
 
     let stream = JsFuture::from(
@@ -128,11 +124,9 @@ pub async fn get_user_media(
 ///
 /// # Errors
 ///
-/// With [`MediaManagerError::CouldNotGetMediaDevices`] if couldn't get
-/// [MediaDevices][2].
-///
 /// With [`MediaManagerError::GetUserMediaFailed`] if
-/// [MediaDevices.getDisplayMedia()][1] returns error.
+/// [MediaDevices.getDisplayMedia()][1] returns error or couldn't get
+/// [MediaDevices][2]..
 ///
 /// # Panics
 ///
@@ -144,15 +138,13 @@ pub async fn get_user_media(
 pub async fn get_display_media(
     caps: DisplayMediaStreamConstraints,
 ) -> Result<Vec<MediaStreamTrack>, Traced<MediaManagerError>> {
-    use MediaManagerError::{
-        CouldNotGetMediaDevices, GetDisplayMediaFailed, GetUserMediaFailed,
-    };
+    use MediaManagerError::GetDisplayMediaFailed;
 
     let media_devices = window()
         .navigator()
         .media_devices()
         .map_err(Error::from)
-        .map_err(CouldNotGetMediaDevices)
+        .map_err(GetDisplayMediaFailed)
         .map_err(tracerr::from_and_wrap!())?;
 
     let stream = JsFuture::from(
@@ -165,7 +157,7 @@ pub async fn get_display_media(
     .await
     .map(web_sys::MediaStream::from)
     .map_err(Error::from)
-    .map_err(GetUserMediaFailed)
+    .map_err(GetDisplayMediaFailed)
     .map_err(tracerr::from_and_wrap!())?;
 
     Ok(js_sys::try_iter(&stream.get_tracks())

--- a/jason/src/room.rs
+++ b/jason/src/room.rs
@@ -606,7 +606,6 @@ impl RoomHandle {
     /// server didn't approve this state transition.
     ///
     /// With [`RoomError::MediaManagerError`] with
-    /// [`MediaManagerError::CouldNotGetMediaDevices`] or
     /// [`MediaManagerError::GetUserMediaFailed`] if media acquisition request
     /// failed.
     #[inline]
@@ -666,7 +665,6 @@ impl RoomHandle {
     /// server didn't approve this state transition.
     ///
     /// With [`RoomError::MediaManagerError`] with
-    /// [`MediaManagerError::CouldNotGetMediaDevices`] or
     /// [`MediaManagerError::GetUserMediaFailed`] if media acquisition request
     /// failed.
     #[inline]
@@ -1599,13 +1597,7 @@ impl EventHandler for InnerRoom {
             Some(negotiation_role),
         );
         for track in &tracks {
-            peer_state
-                .insert_track(track, self.send_constraints.clone())
-                .map_err(|e| {
-                    self.on_failed_local_media
-                        .call1(JasonError::from(e.clone()));
-                    tracerr::map_from_and_new!(e)
-                })?;
+            peer_state.insert_track(track, self.send_constraints.clone());
         }
 
         self.peers.state().insert(peer_id, peer_state);
@@ -1692,12 +1684,7 @@ impl EventHandler for InnerRoom {
         for update in updates {
             match update {
                 PeerUpdate::Added(track) => peer_state
-                    .insert_track(&track, self.send_constraints.clone())
-                    .map_err(|e| {
-                        self.on_failed_local_media
-                            .call1(JasonError::from(e.clone()));
-                        tracerr::map_from_and_new!(e)
-                    })?,
+                    .insert_track(&track, self.send_constraints.clone()),
                 PeerUpdate::Updated(patch) => peer_state.patch_track(&patch),
                 PeerUpdate::IceRestart => {
                     peer_state.restart_ice();

--- a/jason/tests/peer/mod.rs
+++ b/jason/tests/peer/mod.rs
@@ -78,11 +78,9 @@ async fn disable_enable_audio() {
     );
 
     peer.state()
-        .insert_track(&audio_track, send_constraints.clone())
-        .unwrap();
+        .insert_track(&audio_track, send_constraints.clone());
     peer.state()
-        .insert_track(&video_track, send_constraints.clone())
-        .unwrap();
+        .insert_track(&video_track, send_constraints.clone());
     peer.state().when_local_sdp_updated().await.unwrap();
     assert!(peer.is_send_audio_enabled());
     assert!(peer.is_send_video_enabled(None));
@@ -126,11 +124,9 @@ async fn disable_enable_video() {
         Rc::new(peer_state),
     );
     peer.state()
-        .insert_track(&audio_track, send_constraints.clone())
-        .unwrap();
+        .insert_track(&audio_track, send_constraints.clone());
     peer.state()
-        .insert_track(&video_track, send_constraints.clone())
-        .unwrap();
+        .insert_track(&video_track, send_constraints.clone());
     peer.state().when_local_sdp_updated().await.unwrap();
 
     assert!(peer.is_send_audio_enabled());
@@ -156,12 +152,8 @@ async fn new_with_disable_audio() {
     let (audio_track, video_track) = get_test_unrequired_tracks();
     let peer_state = peer::State::new(PeerId(1), Vec::new(), false, None);
     let send_constraints = local_constraints(false, true);
-    peer_state
-        .insert_track(&audio_track, send_constraints.clone())
-        .unwrap();
-    peer_state
-        .insert_track(&video_track, send_constraints.clone())
-        .unwrap();
+    peer_state.insert_track(&audio_track, send_constraints.clone());
+    peer_state.insert_track(&video_track, send_constraints.clone());
     let peer = peer::Component::new(
         peer::PeerConnection::new(
             &peer_state,
@@ -200,11 +192,9 @@ async fn new_with_disable_video() {
         Rc::new(peer_state),
     );
     peer.state()
-        .insert_track(&audio_track, send_constraints.clone())
-        .unwrap();
+        .insert_track(&audio_track, send_constraints.clone());
     peer.state()
-        .insert_track(&video_track, send_constraints.clone())
-        .unwrap();
+        .insert_track(&video_track, send_constraints.clone());
     peer.state().when_all_updated().await;
 
     assert!(peer.is_send_audio_enabled());
@@ -237,11 +227,9 @@ async fn add_candidates_to_answerer_before_offer() {
         Rc::new(pc1_state),
     );
     pc1.state()
-        .insert_track(&audio_track, LocalTracksConstraints::default())
-        .unwrap();
+        .insert_track(&audio_track, LocalTracksConstraints::default());
     pc1.state()
-        .insert_track(&video_track, LocalTracksConstraints::default())
-        .unwrap();
+        .insert_track(&video_track, LocalTracksConstraints::default());
     let pc1_offer = pc1.state().when_local_sdp_updated().await.unwrap();
 
     let pc2_state = peer::State::new(PeerId(2), Vec::new(), false, None);
@@ -294,11 +282,9 @@ async fn add_candidates_to_offerer_before_answer() {
         Rc::new(pc1_state),
     );
     pc1.state()
-        .insert_track(&audio_track, LocalTracksConstraints::default())
-        .unwrap();
+        .insert_track(&audio_track, LocalTracksConstraints::default());
     pc1.state()
-        .insert_track(&video_track, LocalTracksConstraints::default())
-        .unwrap();
+        .insert_track(&video_track, LocalTracksConstraints::default());
 
     let pc2_state = peer::State::new(PeerId(2), Vec::new(), false, None);
     let pc2 = peer::Component::new(
@@ -357,11 +343,9 @@ async fn normal_exchange_of_candidates() {
         Rc::new(pc1_state),
     );
     pc1.state()
-        .insert_track(&audio_track, LocalTracksConstraints::default())
-        .unwrap();
+        .insert_track(&audio_track, LocalTracksConstraints::default());
     pc1.state()
-        .insert_track(&video_track, LocalTracksConstraints::default())
-        .unwrap();
+        .insert_track(&video_track, LocalTracksConstraints::default());
 
     let pc2_state = peer::State::new(PeerId(2), Vec::new(), false, None);
     let pc2 = peer::Component::new(
@@ -432,12 +416,8 @@ async fn send_event_on_new_local_stream() {
         false,
         Some(NegotiationRole::Offerer),
     );
-    peer_state
-        .insert_track(&audio_track, send_constraints.clone())
-        .unwrap();
-    peer_state
-        .insert_track(&video_track, send_constraints.clone())
-        .unwrap();
+    peer_state.insert_track(&audio_track, send_constraints.clone());
+    peer_state.insert_track(&video_track, send_constraints.clone());
     let peer = peer::Component::new(
         peer::PeerConnection::new(
             &peer_state,
@@ -491,11 +471,9 @@ async fn ice_connection_state_changed_is_emitted() {
         Rc::new(pc1_state),
     );
     pc1.state()
-        .insert_track(&audio_track, LocalTracksConstraints::default())
-        .unwrap();
+        .insert_track(&audio_track, LocalTracksConstraints::default());
     pc1.state()
-        .insert_track(&video_track, LocalTracksConstraints::default())
-        .unwrap();
+        .insert_track(&video_track, LocalTracksConstraints::default());
     let pc1_offer = pc1.state().when_local_sdp_updated().await.unwrap();
 
     let pc2_state = peer::State::new(
@@ -605,9 +583,7 @@ impl InterconnectedPeers {
             Some(NegotiationRole::Offerer),
         );
         for track in Self::get_peer1_tracks() {
-            pc1_state
-                .insert_track(&track, pc1_send_cons.clone())
-                .unwrap();
+            pc1_state.insert_track(&track, pc1_send_cons.clone());
         }
         let pc1 = peer::Component::new(
             peer::PeerConnection::new(
@@ -631,9 +607,7 @@ impl InterconnectedPeers {
             Some(NegotiationRole::Answerer(pc1_offer)),
         );
         for track in Self::get_peer2_tracks() {
-            pc2_state
-                .insert_track(&track, pc2_send_cons.clone())
-                .unwrap();
+            pc2_state.insert_track(&track, pc2_send_cons.clone());
         }
         let pc2 = peer::Component::new(
             peer::PeerConnection::new(
@@ -1034,18 +1008,10 @@ async fn reset_transition_timers() {
     let recv_constraints = Rc::new(RecvConstraints::default());
     let (audio_tx, video_tx) = get_test_unrequired_tracks();
     let (audio_rx, video_rx) = get_test_recv_tracks();
-    peer_state
-        .insert_track(&audio_tx, send_constraints.clone())
-        .unwrap();
-    peer_state
-        .insert_track(&audio_rx, send_constraints.clone())
-        .unwrap();
-    peer_state
-        .insert_track(&video_tx, send_constraints.clone())
-        .unwrap();
-    peer_state
-        .insert_track(&video_rx, send_constraints.clone())
-        .unwrap();
+    peer_state.insert_track(&audio_tx, send_constraints.clone());
+    peer_state.insert_track(&audio_rx, send_constraints.clone());
+    peer_state.insert_track(&video_tx, send_constraints.clone());
+    peer_state.insert_track(&video_rx, send_constraints.clone());
     let peer = peer::Component::new(
         peer::PeerConnection::new(
             &peer_state,
@@ -1148,12 +1114,10 @@ async fn new_remote_track() {
         let (audio_track, video_track) = get_test_unrequired_tracks();
         sender_peer
             .state()
-            .insert_track(&audio_track, tx_caps.clone())
-            .unwrap();
+            .insert_track(&audio_track, tx_caps.clone());
         sender_peer
             .state()
-            .insert_track(&video_track, tx_caps.clone())
-            .unwrap();
+            .insert_track(&video_track, tx_caps.clone());
         sender_peer
             .state()
             .set_negotiation_role(NegotiationRole::Offerer)
@@ -1181,39 +1145,31 @@ async fn new_remote_track() {
             Rc::new(rcvr_peer_state),
         );
 
-        rcvr_peer
-            .state()
-            .insert_track(
-                &Track {
-                    id: TrackId(1),
-                    direction: Direction::Recv {
-                        sender: MemberId::from("whatever"),
-                        mid: Some(String::from("0")),
-                    },
-                    media_type: MediaType::Audio(AudioSettings {
-                        required: true,
-                    }),
+        rcvr_peer.state().insert_track(
+            &Track {
+                id: TrackId(1),
+                direction: Direction::Recv {
+                    sender: MemberId::from("whatever"),
+                    mid: Some(String::from("0")),
                 },
-                LocalTracksConstraints::default(),
-            )
-            .unwrap();
-        rcvr_peer
-            .state()
-            .insert_track(
-                &Track {
-                    id: TrackId(2),
-                    direction: Direction::Recv {
-                        sender: MemberId::from("whatever"),
-                        mid: Some(String::from("1")),
-                    },
-                    media_type: MediaType::Video(VideoSettings {
-                        required: true,
-                        source_kind: MediaSourceKind::Device,
-                    }),
+                media_type: MediaType::Audio(AudioSettings { required: true }),
+            },
+            LocalTracksConstraints::default(),
+        );
+        rcvr_peer.state().insert_track(
+            &Track {
+                id: TrackId(2),
+                direction: Direction::Recv {
+                    sender: MemberId::from("whatever"),
+                    mid: Some(String::from("1")),
                 },
-                LocalTracksConstraints::default(),
-            )
-            .unwrap();
+                media_type: MediaType::Video(VideoSettings {
+                    required: true,
+                    source_kind: MediaSourceKind::Device,
+                }),
+            },
+            LocalTracksConstraints::default(),
+        );
 
         rcvr_peer.state().when_all_tracks_created().await;
         rcvr_peer.state().stabilize_all();
@@ -1436,12 +1392,8 @@ async fn disable_and_enable_all_tracks() {
     let audio_track_id = audio_track.id;
     let video_track_id = video_track.id;
     let pc_state = peer::State::new(PeerId(0), Vec::new(), false, None);
-    pc_state
-        .insert_track(&audio_track, LocalTracksConstraints::default())
-        .unwrap();
-    pc_state
-        .insert_track(&video_track, LocalTracksConstraints::default())
-        .unwrap();
+    pc_state.insert_track(&audio_track, LocalTracksConstraints::default());
+    pc_state.insert_track(&video_track, LocalTracksConstraints::default());
 
     let (tx, _rx) = mpsc::unbounded();
     let pc = peer::Component::new(


### PR DESCRIPTION
## Synopsis

Продолжаем #204 расширяя список прокидываемых через FFI ошибок.



## Solution

1. Растовские `HandlerDetached` ошибки теперь прокидываются как дартовский стдшный `StateError`
2. Растовские `MediaManagerError`'ы теперь прокидываются как дартовский `MediaManagerException`.

Плюс небольшой рефакторинг футур Раст => Dart, а именно, обертка c тайп-параметром. 




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
