### PR TITLE
Fix flaky E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,79 +11,79 @@ jobs:
   # Linting and formatting #
   ##########################
 
-#  clippy:
-#    name: Clippy
-#    if: ${{ github.ref == 'refs/heads/master'
-#            || startsWith(github.ref, 'refs/tags/medea-')
-#            || !contains(github.event.head_commit.message, '[skip ci]') }}
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: stable
-#          components: clippy
-#      - uses: Swatinem/rust-cache@v1
-#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-#      - run: make rustup.android
-#      - run: make lint
-#
-#  rustfmt:
-#    if: ${{ github.ref == 'refs/heads/master'
-#            || startsWith(github.ref, 'refs/tags/medea-')
-#            || !contains(github.event.head_commit.message, '[skip ci]') }}
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: nightly
-#          components: rustfmt
-#      - run: make fmt check=yes
-#
-#  helm-lint:
-#    name: Lint Helm chart
-#    if: ${{ github.ref == 'refs/heads/master'
-#            || (!startsWith(github.ref, 'refs/tags/medea-')
-#                && !contains(github.event.head_commit.message, '[skip ci]')) }}
-#    strategy:
-#      matrix:
-#        chart:
-#          - medea-demo
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: azure/setup-helm@v1
-#      - run: make helm.lint chart=${{ matrix.chart }}
-#
-#  dartfmt:
-#    if: ${{ github.ref == 'refs/heads/master'
-#            || startsWith(github.ref, 'refs/tags/medea-jason-')
-#            || (!startsWith(github.ref, 'refs/tags/medea-')
-#                && !contains(github.event.head_commit.message, '[skip ci]')) }}
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: subosito/flutter-action@v1
-#        with:
-#          channel: stable
-#      - run: make flutter.fmt check=yes
-#
-#  dartanalyzer:
-#    if: ${{ github.ref == 'refs/heads/master'
-#            || startsWith(github.ref, 'refs/tags/medea-jason-')
-#            || (!startsWith(github.ref, 'refs/tags/medea-')
-#                && !contains(github.event.head_commit.message, '[skip ci]')) }}
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: subosito/flutter-action@v1
-#        with:
-#          channel: dev
-#      - run: make flutter
-#      - run: make flutter.lint
+  clippy:
+    name: Clippy
+    if: ${{ github.ref == 'refs/heads/master'
+            || startsWith(github.ref, 'refs/tags/medea-')
+            || !contains(github.event.head_commit.message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+      - uses: Swatinem/rust-cache@v1
+        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+      - run: make rustup.android
+      - run: make lint
+
+  rustfmt:
+    if: ${{ github.ref == 'refs/heads/master'
+            || startsWith(github.ref, 'refs/tags/medea-')
+            || !contains(github.event.head_commit.message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt
+      - run: make fmt check=yes
+
+  helm-lint:
+    name: Lint Helm chart
+    if: ${{ github.ref == 'refs/heads/master'
+            || (!startsWith(github.ref, 'refs/tags/medea-')
+                && !contains(github.event.head_commit.message, '[skip ci]')) }}
+    strategy:
+      matrix:
+        chart:
+          - medea-demo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/setup-helm@v1
+      - run: make helm.lint chart=${{ matrix.chart }}
+
+  dartfmt:
+    if: ${{ github.ref == 'refs/heads/master'
+            || startsWith(github.ref, 'refs/tags/medea-jason-')
+            || (!startsWith(github.ref, 'refs/tags/medea-')
+                && !contains(github.event.head_commit.message, '[skip ci]')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: stable
+      - run: make flutter.fmt check=yes
+
+  dartanalyzer:
+    if: ${{ github.ref == 'refs/heads/master'
+            || startsWith(github.ref, 'refs/tags/medea-jason-')
+            || (!startsWith(github.ref, 'refs/tags/medea-')
+                && !contains(github.event.head_commit.message, '[skip ci]')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: dev
+      - run: make flutter
+      - run: make flutter.lint
 
 
 
@@ -92,86 +92,86 @@ jobs:
   # Testing #
   ###########
 
-#  test-unit:
-#    name: Unit tests
-#    if: ${{ github.ref == 'refs/heads/master'
-#            || startsWith(github.ref, 'refs/tags/medea-')
-#            || !contains(github.event.head_commit.message, '[skip ci]') }}
-#    strategy:
-#      matrix:
-#        include:
-#          - crate: medea-macro
-#            if: ${{ startsWith(github.ref, 'refs/tags/medea-macro-')
-#                    || !startsWith(github.ref, 'refs/tags/medea-') }}
-#          - crate: medea-reactive
-#            if: ${{ startsWith(github.ref, 'refs/tags/medea-reactive-')
-#                    || !startsWith(github.ref, 'refs/tags/medea-') }}
-#          - crate: medea-coturn-telnet-client
-#            if: ${{ startsWith(github.ref, 'refs/tags/medea-coturn-telnet-client-')
-#                    || !startsWith(github.ref, 'refs/tags/medea-') }}
-#          - crate: medea-client-api-proto
-#            if: ${{ startsWith(github.ref, 'refs/tags/medea-client-api-proto-')
-#                    || !startsWith(github.ref, 'refs/tags/medea-') }}
-#          - crate: medea
-#            if: ${{ !startsWith(github.ref, 'refs/tags/medea-')
-#                    || startsWith(github.ref, 'refs/tags/medea-0')
-#                    || startsWith(github.ref, 'refs/tags/medea-1')
-#                    || startsWith(github.ref, 'refs/tags/medea-2')
-#                    || startsWith(github.ref, 'refs/tags/medea-3')
-#                    || startsWith(github.ref, 'refs/tags/medea-4')
-#                    || startsWith(github.ref, 'refs/tags/medea-5')
-#                    || startsWith(github.ref, 'refs/tags/medea-6')
-#                    || startsWith(github.ref, 'refs/tags/medea-7')
-#                    || startsWith(github.ref, 'refs/tags/medea-8')
-#                    || startsWith(github.ref, 'refs/tags/medea-9') }}
-#                    # don't ask, pass through...
-#          - crate: medea-jason
-#            wasm: true
-#            if: ${{ startsWith(github.ref, 'refs/tags/medea-jason-')
-#                    || !startsWith(github.ref, 'refs/tags/medea-') }}
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#        if: ${{ matrix.if }}
-#
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: stable
-#        if: ${{ matrix.if && !matrix.wasm }}
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: stable
-#          target: wasm32-unknown-unknown
-#        if: ${{ matrix.if && matrix.wasm }}
-#
-#      - uses: Swatinem/rust-cache@v1
-#        if: ${{ matrix.if
-#                && !contains(github.event.head_commit.message, '[fresh ci]') }}
-#
-#      - name: Parse wasm-bindgen-cli version from Cargo.lock
-#        id: wasm-cli
-#        run: echo ::set-output
-#                  name=VERSION::$(cargo pkgid wasm-bindgen | grep -o '#.*'
-#                                                           | grep -o '[0-9\.]*')
-#        if: ${{ matrix.if && matrix.wasm }}
-#      - uses: actions-rs/install@v0.1
-#        with:
-#          crate: wasm-bindgen-cli
-#          version: ${{ steps.wasm-cli.outputs.VERSION }}
-#          use-tool-cache: true
-#        if: ${{ matrix.if && matrix.wasm }}
-#
-#      - name: Chrome
-#        run: make test.unit crate=${{ matrix.crate }} browser=chrome
-#        if: ${{ matrix.if && matrix.crate == 'medea-jason' }}
-#      - name: Firefox
-#        run: make test.unit crate=${{ matrix.crate }} browser=firefox
-#        if: ${{ matrix.if && matrix.crate == 'medea-jason' }}
-#
-#      - run: make test.unit crate=${{ matrix.crate }}
-#        if: ${{ matrix.if && matrix.crate != 'medea-jason' }}
+  test-unit:
+    name: Unit tests
+    if: ${{ github.ref == 'refs/heads/master'
+            || startsWith(github.ref, 'refs/tags/medea-')
+            || !contains(github.event.head_commit.message, '[skip ci]') }}
+    strategy:
+      matrix:
+        include:
+          - crate: medea-macro
+            if: ${{ startsWith(github.ref, 'refs/tags/medea-macro-')
+                    || !startsWith(github.ref, 'refs/tags/medea-') }}
+          - crate: medea-reactive
+            if: ${{ startsWith(github.ref, 'refs/tags/medea-reactive-')
+                    || !startsWith(github.ref, 'refs/tags/medea-') }}
+          - crate: medea-coturn-telnet-client
+            if: ${{ startsWith(github.ref, 'refs/tags/medea-coturn-telnet-client-')
+                    || !startsWith(github.ref, 'refs/tags/medea-') }}
+          - crate: medea-client-api-proto
+            if: ${{ startsWith(github.ref, 'refs/tags/medea-client-api-proto-')
+                    || !startsWith(github.ref, 'refs/tags/medea-') }}
+          - crate: medea
+            if: ${{ !startsWith(github.ref, 'refs/tags/medea-')
+                    || startsWith(github.ref, 'refs/tags/medea-0')
+                    || startsWith(github.ref, 'refs/tags/medea-1')
+                    || startsWith(github.ref, 'refs/tags/medea-2')
+                    || startsWith(github.ref, 'refs/tags/medea-3')
+                    || startsWith(github.ref, 'refs/tags/medea-4')
+                    || startsWith(github.ref, 'refs/tags/medea-5')
+                    || startsWith(github.ref, 'refs/tags/medea-6')
+                    || startsWith(github.ref, 'refs/tags/medea-7')
+                    || startsWith(github.ref, 'refs/tags/medea-8')
+                    || startsWith(github.ref, 'refs/tags/medea-9') }}
+                    # don't ask, pass through...
+          - crate: medea-jason
+            wasm: true
+            if: ${{ startsWith(github.ref, 'refs/tags/medea-jason-')
+                    || !startsWith(github.ref, 'refs/tags/medea-') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        if: ${{ matrix.if }}
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+        if: ${{ matrix.if && !matrix.wasm }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+        if: ${{ matrix.if && matrix.wasm }}
+
+      - uses: Swatinem/rust-cache@v1
+        if: ${{ matrix.if
+                && !contains(github.event.head_commit.message, '[fresh ci]') }}
+
+      - name: Parse wasm-bindgen-cli version from Cargo.lock
+        id: wasm-cli
+        run: echo ::set-output
+                  name=VERSION::$(cargo pkgid wasm-bindgen | grep -o '#.*'
+                                                           | grep -o '[0-9\.]*')
+        if: ${{ matrix.if && matrix.wasm }}
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: wasm-bindgen-cli
+          version: ${{ steps.wasm-cli.outputs.VERSION }}
+          use-tool-cache: true
+        if: ${{ matrix.if && matrix.wasm }}
+
+      - name: Chrome
+        run: make test.unit crate=${{ matrix.crate }} browser=chrome
+        if: ${{ matrix.if && matrix.crate == 'medea-jason' }}
+      - name: Firefox
+        run: make test.unit crate=${{ matrix.crate }} browser=firefox
+        if: ${{ matrix.if && matrix.crate == 'medea-jason' }}
+
+      - run: make test.unit crate=${{ matrix.crate }}
+        if: ${{ matrix.if && matrix.crate != 'medea-jason' }}
 
   test-e2e:
     name: E2E tests
@@ -214,246 +214,240 @@ jobs:
       - name: Unpack `medea-control-api-mock` Docker image
         run: make docker.untar from-file=image.tar
 
+      - name: Chrome
+        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
+
       - name: Chrome1
-        run: make test.e2e browser=chrome up=yes dockerized=yes
-                           tag=build-${{ github.run_number }}
+        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
 
       - name: Chrome2
-        run: make test.e2e browser=chrome up=yes dockerized=yes
-          tag=build-${{ github.run_number }}
+        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
 
       - name: Chrome3
-        run: make test.e2e browser=chrome up=yes dockerized=yes
-          tag=build-${{ github.run_number }}
+        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
 
       - name: Chrome4
-        run: make test.e2e browser=chrome up=yes dockerized=yes
-          tag=build-${{ github.run_number }}
+        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
 
       - name: Chrome5
-        run: make test.e2e browser=chrome up=yes dockerized=yes
-          tag=build-${{ github.run_number }}
+        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
 
       - name: Chrome6
-        run: make test.e2e browser=chrome up=yes dockerized=yes
-          tag=build-${{ github.run_number }}
+        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
 
       - name: Chrome7
-        run: make test.e2e browser=chrome up=yes dockerized=yes
-          tag=build-${{ github.run_number }}
+        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
 
       - name: Chrome8
-        run: make test.e2e browser=chrome up=yes dockerized=yes
-          tag=build-${{ github.run_number }}
+        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
 
       - name: Chrome9
-        run: make test.e2e browser=chrome up=yes dockerized=yes
-          tag=build-${{ github.run_number }}
+        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
 
-#  test-integration:
-#    name: Integration tests
-#    if: ${{ github.ref == 'refs/heads/master'
-#            || startsWith(github.ref, 'refs/tags/medea-')
-#            || !contains(github.event.head_commit.message, '[skip ci]') }}
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: stable
-#
-#      - uses: Swatinem/rust-cache@v1
-#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-#      - uses: satackey/action-docker-layer-caching@v0.0.11
-#        with:
-#          key: test-integration-{hash}
-#          restore-keys: test-integration-
-#        continue-on-error: true
-#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-#
-#      - run: make test.integration up=yes dockerized=no
-#
-#  test-flutter:
-#    name: Flutter tests
-#    if: ${{ github.ref == 'refs/heads/master'
-#            || startsWith(github.ref, 'refs/tags/medea-jason-')
-#            || (!startsWith(github.ref, 'refs/tags/medea-')
-#                && !contains(github.event.head_commit.message, '[skip ci]')) }}
-#    runs-on: macos-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: stable
-#          target: x86_64-linux-android
-#      - uses: Swatinem/rust-cache@v1
-#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-#
-#      - uses: actions-rs/install@v0.1
-#        with:
-#          crate: cargo-ndk
-#          use-tool-cache: true
-#      - uses: subosito/flutter-action@v1
-#        with:
-#          channel: dev
-#
-#      - name: Parse Android NDK versions
-#        id: ndk-version
-#        run: |
-#          echo ::set-output name=min::$(make flutter.android.version.min)
-#          echo ::set-output name=target::$(make flutter.android.version.compile)
-#
-#      - name: Compile shared object
-#        run: make cargo.build crate=medea-jason platform=android targets=x86_64
-#                              args="--features mockable"
-#
-#      - name: Test on min Android NDK version
-#        uses: reactivecircus/android-emulator-runner@v2
-#        with:
-#          api-level: ${{ steps.ndk-version.outputs.min }}
-#          target: google_apis
-#          arch: x86_64
-#          profile: Nexus 6
-#          script: make test.flutter
-#      - name: Test on target Android NDK version
-#        uses: reactivecircus/android-emulator-runner@v2
-#        with:
-#          api-level: ${{ steps.ndk-version.outputs.target }}
-#          target: google_apis
-#          arch: x86_64
-#          profile: Nexus 6
-#          script: make test.flutter
-#
-#
-#
-#
-#  ############
-#  # Building #
-#  ############
-#
-#  crate-jason:
-#    name: Build medea-jason
-#    if: ${{ github.ref == 'refs/heads/master'
-#            || startsWith(github.ref, 'refs/tags/medea-jason-')
-#            || (!startsWith(github.ref, 'refs/tags/medea-')
-#                && !contains(github.event.head_commit.message, '[skip ci]')) }}
-#    strategy:
-#      matrix:
-#        platform:
-#          - web
-#          - android
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: stable
-#        if: ${{ matrix.platform != 'web' }}
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: stable
-#          target: wasm32-unknown-unknown
-#        if: ${{ matrix.platform == 'web' }}
-#      - uses: Swatinem/rust-cache@v1
-#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-#
-#      - uses: jetli/wasm-pack-action@v0.3.0
-#        if: ${{ matrix.platform == 'web' }}
-#
-#      - uses: actions-rs/install@v0.1
-#        with:
-#          crate: cargo-ndk
-#          use-tool-cache: true
-#        if: ${{ matrix.platform == 'android' }}
-#      - run: make rustup.android
-#        if: ${{ matrix.platform == 'android' }}
-#
-#      - run: make cargo.build crate=medea-jason platform=${{ matrix.platform }}
-#                              dockerized=no debug=yes
-#
-#  crate-medea:
-#    name: Build medea
-#    if: ${{ github.ref == 'refs/heads/master'
-#            || startsWith(github.ref, 'refs/tags/medea-0')
-#            || startsWith(github.ref, 'refs/tags/medea-1')
-#            || startsWith(github.ref, 'refs/tags/medea-2')
-#            || startsWith(github.ref, 'refs/tags/medea-3')
-#            || startsWith(github.ref, 'refs/tags/medea-4')
-#            || startsWith(github.ref, 'refs/tags/medea-5')
-#            || startsWith(github.ref, 'refs/tags/medea-6')
-#            || startsWith(github.ref, 'refs/tags/medea-7')
-#            || startsWith(github.ref, 'refs/tags/medea-8')
-#            || startsWith(github.ref, 'refs/tags/medea-9')
-#            || (!startsWith(github.ref, 'refs/tags/medea-')
-#                && !contains(github.event.head_commit.message, '[skip ci]')) }}
-#            # nope, that's OK...
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: stable
-#      - uses: Swatinem/rust-cache@v1
-#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-#      - run: make cargo.build crate=medea dockerized=no debug=yes
-#
-#  rustdoc:
-#    if: ${{ github.ref == 'refs/heads/master'
-#            || startsWith(github.ref, 'refs/tags/medea-')
-#            || !contains(github.event.head_commit.message, '[skip ci]') }}
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: stable
-#      - uses: Swatinem/rust-cache@v1
-#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-#
-#      # Run all task sequentially to not flood the jobs list.
-#      - run: make docs.rust crate=medea-macro open=no
-#        if: ${{ startsWith(github.ref, 'refs/tags/medea-macro-')
-#                || !startsWith(github.ref, 'refs/tags/medea-') }}
-#
-#      - run: make docs.rust crate=medea-reactive open=no
-#        if: ${{ startsWith(github.ref, 'refs/tags/medea-reactive-')
-#                || !startsWith(github.ref, 'refs/tags/medea-') }}
-#
-#      - run: make docs.rust crate=medea-coturn-telnet-client open=no
-#        if: ${{ startsWith(github.ref, 'refs/tags/medea-coturn-telnet-client-')
-#                || !startsWith(github.ref, 'refs/tags/medea-') }}
-#
-#      - run: make docs.rust crate=medea-client-api-proto open=no
-#        if: ${{ startsWith(github.ref, 'refs/tags/medea-client-api-proto-')
-#                || !startsWith(github.ref, 'refs/tags/medea-') }}
-#
-#      - run: make docs.rust crate=medea-control-api-proto open=no
-#        if: ${{ startsWith(github.ref, 'refs/tags/medea-control-api-proto-')
-#                || !startsWith(github.ref, 'refs/tags/medea-') }}
-#
-#      - run: make docs.rust crate=medea-jason open=no
-#        if: ${{ startsWith(github.ref, 'refs/tags/medea-jason-')
-#                || !startsWith(github.ref, 'refs/tags/medea-') }}
-#
-#      - run: make docs.rust crate=medea open=no
-#        if: ${{ !startsWith(github.ref, 'refs/tags/medea-')
-#                || startsWith(github.ref, 'refs/tags/medea-0')
-#                || startsWith(github.ref, 'refs/tags/medea-1')
-#                || startsWith(github.ref, 'refs/tags/medea-2')
-#                || startsWith(github.ref, 'refs/tags/medea-3')
-#                || startsWith(github.ref, 'refs/tags/medea-4')
-#                || startsWith(github.ref, 'refs/tags/medea-5')
-#                || startsWith(github.ref, 'refs/tags/medea-6')
-#                || startsWith(github.ref, 'refs/tags/medea-7')
-#                || startsWith(github.ref, 'refs/tags/medea-8')
-#                || startsWith(github.ref, 'refs/tags/medea-9') }}
-#                # still, that's OK...
+  test-integration:
+    name: Integration tests
+    if: ${{ github.ref == 'refs/heads/master'
+            || startsWith(github.ref, 'refs/tags/medea-')
+            || !contains(github.event.head_commit.message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@v1
+        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        with:
+          key: test-integration-{hash}
+          restore-keys: test-integration-
+        continue-on-error: true
+        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+
+      - run: make test.integration up=yes dockerized=no
+
+  test-flutter:
+    name: Flutter tests
+    if: ${{ github.ref == 'refs/heads/master'
+            || startsWith(github.ref, 'refs/tags/medea-jason-')
+            || (!startsWith(github.ref, 'refs/tags/medea-')
+                && !contains(github.event.head_commit.message, '[skip ci]')) }}
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: x86_64-linux-android
+      - uses: Swatinem/rust-cache@v1
+        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-ndk
+          use-tool-cache: true
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: dev
+
+      - name: Parse Android NDK versions
+        id: ndk-version
+        run: |
+          echo ::set-output name=min::$(make flutter.android.version.min)
+          echo ::set-output name=target::$(make flutter.android.version.compile)
+
+      - name: Compile shared object
+        run: make cargo.build crate=medea-jason platform=android targets=x86_64
+                              args="--features mockable"
+
+      - name: Test on min Android NDK version
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ steps.ndk-version.outputs.min }}
+          target: google_apis
+          arch: x86_64
+          profile: Nexus 6
+          script: make test.flutter
+      - name: Test on target Android NDK version
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ steps.ndk-version.outputs.target }}
+          target: google_apis
+          arch: x86_64
+          profile: Nexus 6
+          script: make test.flutter
+
+
+
+
+  ############
+  # Building #
+  ############
+
+  crate-jason:
+    name: Build medea-jason
+    if: ${{ github.ref == 'refs/heads/master'
+            || startsWith(github.ref, 'refs/tags/medea-jason-')
+            || (!startsWith(github.ref, 'refs/tags/medea-')
+                && !contains(github.event.head_commit.message, '[skip ci]')) }}
+    strategy:
+      matrix:
+        platform:
+          - web
+          - android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+        if: ${{ matrix.platform != 'web' }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+        if: ${{ matrix.platform == 'web' }}
+      - uses: Swatinem/rust-cache@v1
+        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+
+      - uses: jetli/wasm-pack-action@v0.3.0
+        if: ${{ matrix.platform == 'web' }}
+
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-ndk
+          use-tool-cache: true
+        if: ${{ matrix.platform == 'android' }}
+      - run: make rustup.android
+        if: ${{ matrix.platform == 'android' }}
+
+      - run: make cargo.build crate=medea-jason platform=${{ matrix.platform }}
+                              dockerized=no debug=yes
+
+  crate-medea:
+    name: Build medea
+    if: ${{ github.ref == 'refs/heads/master'
+            || startsWith(github.ref, 'refs/tags/medea-0')
+            || startsWith(github.ref, 'refs/tags/medea-1')
+            || startsWith(github.ref, 'refs/tags/medea-2')
+            || startsWith(github.ref, 'refs/tags/medea-3')
+            || startsWith(github.ref, 'refs/tags/medea-4')
+            || startsWith(github.ref, 'refs/tags/medea-5')
+            || startsWith(github.ref, 'refs/tags/medea-6')
+            || startsWith(github.ref, 'refs/tags/medea-7')
+            || startsWith(github.ref, 'refs/tags/medea-8')
+            || startsWith(github.ref, 'refs/tags/medea-9')
+            || (!startsWith(github.ref, 'refs/tags/medea-')
+                && !contains(github.event.head_commit.message, '[skip ci]')) }}
+            # nope, that's OK...
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+      - run: make cargo.build crate=medea dockerized=no debug=yes
+
+  rustdoc:
+    if: ${{ github.ref == 'refs/heads/master'
+            || startsWith(github.ref, 'refs/tags/medea-')
+            || !contains(github.event.head_commit.message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+
+      # Run all task sequentially to not flood the jobs list.
+      - run: make docs.rust crate=medea-macro open=no
+        if: ${{ startsWith(github.ref, 'refs/tags/medea-macro-')
+                || !startsWith(github.ref, 'refs/tags/medea-') }}
+
+      - run: make docs.rust crate=medea-reactive open=no
+        if: ${{ startsWith(github.ref, 'refs/tags/medea-reactive-')
+                || !startsWith(github.ref, 'refs/tags/medea-') }}
+
+      - run: make docs.rust crate=medea-coturn-telnet-client open=no
+        if: ${{ startsWith(github.ref, 'refs/tags/medea-coturn-telnet-client-')
+                || !startsWith(github.ref, 'refs/tags/medea-') }}
+
+      - run: make docs.rust crate=medea-client-api-proto open=no
+        if: ${{ startsWith(github.ref, 'refs/tags/medea-client-api-proto-')
+                || !startsWith(github.ref, 'refs/tags/medea-') }}
+
+      - run: make docs.rust crate=medea-control-api-proto open=no
+        if: ${{ startsWith(github.ref, 'refs/tags/medea-control-api-proto-')
+                || !startsWith(github.ref, 'refs/tags/medea-') }}
+
+      - run: make docs.rust crate=medea-jason open=no
+        if: ${{ startsWith(github.ref, 'refs/tags/medea-jason-')
+                || !startsWith(github.ref, 'refs/tags/medea-') }}
+
+      - run: make docs.rust crate=medea open=no
+        if: ${{ !startsWith(github.ref, 'refs/tags/medea-')
+                || startsWith(github.ref, 'refs/tags/medea-0')
+                || startsWith(github.ref, 'refs/tags/medea-1')
+                || startsWith(github.ref, 'refs/tags/medea-2')
+                || startsWith(github.ref, 'refs/tags/medea-3')
+                || startsWith(github.ref, 'refs/tags/medea-4')
+                || startsWith(github.ref, 'refs/tags/medea-5')
+                || startsWith(github.ref, 'refs/tags/medea-6')
+                || startsWith(github.ref, 'refs/tags/medea-7')
+                || startsWith(github.ref, 'refs/tags/medea-8')
+                || startsWith(github.ref, 'refs/tags/medea-9') }}
+                # still, that's OK...
 
   docker:
     name: Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,12 +214,41 @@ jobs:
       - name: Unpack `medea-control-api-mock` Docker image
         run: make docker.untar from-file=image.tar
 
-      - name: Chrome
+      - name: Chrome1
         run: make test.e2e browser=chrome up=yes dockerized=yes
                            tag=build-${{ github.run_number }}
-      - name: Firefox
-        run: make test.e2e browser=firefox up=yes dockerized=yes
-                           tag=build-${{ github.run_number }}
+
+      - name: Chrome2
+        run: make test.e2e browser=chrome up=yes dockerized=yes
+          tag=build-${{ github.run_number }}
+
+      - name: Chrome3
+        run: make test.e2e browser=chrome up=yes dockerized=yes
+          tag=build-${{ github.run_number }}
+
+      - name: Chrome4
+        run: make test.e2e browser=chrome up=yes dockerized=yes
+          tag=build-${{ github.run_number }}
+
+      - name: Chrome5
+        run: make test.e2e browser=chrome up=yes dockerized=yes
+          tag=build-${{ github.run_number }}
+
+      - name: Chrome6
+        run: make test.e2e browser=chrome up=yes dockerized=yes
+          tag=build-${{ github.run_number }}
+
+      - name: Chrome7
+        run: make test.e2e browser=chrome up=yes dockerized=yes
+          tag=build-${{ github.run_number }}
+
+      - name: Chrome8
+        run: make test.e2e browser=chrome up=yes dockerized=yes
+          tag=build-${{ github.run_number }}
+
+      - name: Chrome9
+        run: make test.e2e browser=chrome up=yes dockerized=yes
+          tag=build-${{ github.run_number }}
 
 #  test-integration:
 #    name: Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,34 +215,11 @@ jobs:
         run: make docker.untar from-file=image.tar
 
       - name: Chrome
-        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
-
-      - name: Chrome1
-        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
-
-      - name: Chrome2
-        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
-
-      - name: Chrome3
-        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
-
-      - name: Chrome4
-        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
-
-      - name: Chrome5
-        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
-
-      - name: Chrome6
-        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
-
-      - name: Chrome7
-        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
-
-      - name: Chrome8
-        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
-
-      - name: Chrome9
-        run: make test.e2e browser=chrome up=yes dockerized=yes tag=build-${{ github.run_number }}
+        run: make test.e2e browser=chrome up=yes dockerized=yes
+                           tag=build-${{ github.run_number }}
+      - name: Firefox
+        run: make test.e2e browser=firefox up=yes dockerized=yes
+                           tag=build-${{ github.run_number }}
 
   test-integration:
     name: Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,79 +11,79 @@ jobs:
   # Linting and formatting #
   ##########################
 
-  clippy:
-    name: Clippy
-    if: ${{ github.ref == 'refs/heads/master'
-            || startsWith(github.ref, 'refs/tags/medea-')
-            || !contains(github.event.head_commit.message, '[skip ci]') }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: clippy
-      - uses: Swatinem/rust-cache@v1
-        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-      - run: make rustup.android
-      - run: make lint
-
-  rustfmt:
-    if: ${{ github.ref == 'refs/heads/master'
-            || startsWith(github.ref, 'refs/tags/medea-')
-            || !contains(github.event.head_commit.message, '[skip ci]') }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          components: rustfmt
-      - run: make fmt check=yes
-
-  helm-lint:
-    name: Lint Helm chart
-    if: ${{ github.ref == 'refs/heads/master'
-            || (!startsWith(github.ref, 'refs/tags/medea-')
-                && !contains(github.event.head_commit.message, '[skip ci]')) }}
-    strategy:
-      matrix:
-        chart:
-          - medea-demo
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: azure/setup-helm@v1
-      - run: make helm.lint chart=${{ matrix.chart }}
-
-  dartfmt:
-    if: ${{ github.ref == 'refs/heads/master'
-            || startsWith(github.ref, 'refs/tags/medea-jason-')
-            || (!startsWith(github.ref, 'refs/tags/medea-')
-                && !contains(github.event.head_commit.message, '[skip ci]')) }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
-        with:
-          channel: stable
-      - run: make flutter.fmt check=yes
-
-  dartanalyzer:
-    if: ${{ github.ref == 'refs/heads/master'
-            || startsWith(github.ref, 'refs/tags/medea-jason-')
-            || (!startsWith(github.ref, 'refs/tags/medea-')
-                && !contains(github.event.head_commit.message, '[skip ci]')) }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
-        with:
-          channel: dev
-      - run: make flutter
-      - run: make flutter.lint
+#  clippy:
+#    name: Clippy
+#    if: ${{ github.ref == 'refs/heads/master'
+#            || startsWith(github.ref, 'refs/tags/medea-')
+#            || !contains(github.event.head_commit.message, '[skip ci]') }}
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: stable
+#          components: clippy
+#      - uses: Swatinem/rust-cache@v1
+#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+#      - run: make rustup.android
+#      - run: make lint
+#
+#  rustfmt:
+#    if: ${{ github.ref == 'refs/heads/master'
+#            || startsWith(github.ref, 'refs/tags/medea-')
+#            || !contains(github.event.head_commit.message, '[skip ci]') }}
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: nightly
+#          components: rustfmt
+#      - run: make fmt check=yes
+#
+#  helm-lint:
+#    name: Lint Helm chart
+#    if: ${{ github.ref == 'refs/heads/master'
+#            || (!startsWith(github.ref, 'refs/tags/medea-')
+#                && !contains(github.event.head_commit.message, '[skip ci]')) }}
+#    strategy:
+#      matrix:
+#        chart:
+#          - medea-demo
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: azure/setup-helm@v1
+#      - run: make helm.lint chart=${{ matrix.chart }}
+#
+#  dartfmt:
+#    if: ${{ github.ref == 'refs/heads/master'
+#            || startsWith(github.ref, 'refs/tags/medea-jason-')
+#            || (!startsWith(github.ref, 'refs/tags/medea-')
+#                && !contains(github.event.head_commit.message, '[skip ci]')) }}
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: subosito/flutter-action@v1
+#        with:
+#          channel: stable
+#      - run: make flutter.fmt check=yes
+#
+#  dartanalyzer:
+#    if: ${{ github.ref == 'refs/heads/master'
+#            || startsWith(github.ref, 'refs/tags/medea-jason-')
+#            || (!startsWith(github.ref, 'refs/tags/medea-')
+#                && !contains(github.event.head_commit.message, '[skip ci]')) }}
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: subosito/flutter-action@v1
+#        with:
+#          channel: dev
+#      - run: make flutter
+#      - run: make flutter.lint
 
 
 
@@ -92,86 +92,86 @@ jobs:
   # Testing #
   ###########
 
-  test-unit:
-    name: Unit tests
-    if: ${{ github.ref == 'refs/heads/master'
-            || startsWith(github.ref, 'refs/tags/medea-')
-            || !contains(github.event.head_commit.message, '[skip ci]') }}
-    strategy:
-      matrix:
-        include:
-          - crate: medea-macro
-            if: ${{ startsWith(github.ref, 'refs/tags/medea-macro-')
-                    || !startsWith(github.ref, 'refs/tags/medea-') }}
-          - crate: medea-reactive
-            if: ${{ startsWith(github.ref, 'refs/tags/medea-reactive-')
-                    || !startsWith(github.ref, 'refs/tags/medea-') }}
-          - crate: medea-coturn-telnet-client
-            if: ${{ startsWith(github.ref, 'refs/tags/medea-coturn-telnet-client-')
-                    || !startsWith(github.ref, 'refs/tags/medea-') }}
-          - crate: medea-client-api-proto
-            if: ${{ startsWith(github.ref, 'refs/tags/medea-client-api-proto-')
-                    || !startsWith(github.ref, 'refs/tags/medea-') }}
-          - crate: medea
-            if: ${{ !startsWith(github.ref, 'refs/tags/medea-')
-                    || startsWith(github.ref, 'refs/tags/medea-0')
-                    || startsWith(github.ref, 'refs/tags/medea-1')
-                    || startsWith(github.ref, 'refs/tags/medea-2')
-                    || startsWith(github.ref, 'refs/tags/medea-3')
-                    || startsWith(github.ref, 'refs/tags/medea-4')
-                    || startsWith(github.ref, 'refs/tags/medea-5')
-                    || startsWith(github.ref, 'refs/tags/medea-6')
-                    || startsWith(github.ref, 'refs/tags/medea-7')
-                    || startsWith(github.ref, 'refs/tags/medea-8')
-                    || startsWith(github.ref, 'refs/tags/medea-9') }}
-                    # don't ask, pass through...
-          - crate: medea-jason
-            wasm: true
-            if: ${{ startsWith(github.ref, 'refs/tags/medea-jason-')
-                    || !startsWith(github.ref, 'refs/tags/medea-') }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        if: ${{ matrix.if }}
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-        if: ${{ matrix.if && !matrix.wasm }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: wasm32-unknown-unknown
-        if: ${{ matrix.if && matrix.wasm }}
-
-      - uses: Swatinem/rust-cache@v1
-        if: ${{ matrix.if
-                && !contains(github.event.head_commit.message, '[fresh ci]') }}
-
-      - name: Parse wasm-bindgen-cli version from Cargo.lock
-        id: wasm-cli
-        run: echo ::set-output
-                  name=VERSION::$(cargo pkgid wasm-bindgen | grep -o '#.*'
-                                                           | grep -o '[0-9\.]*')
-        if: ${{ matrix.if && matrix.wasm }}
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: wasm-bindgen-cli
-          version: ${{ steps.wasm-cli.outputs.VERSION }}
-          use-tool-cache: true
-        if: ${{ matrix.if && matrix.wasm }}
-
-      - name: Chrome
-        run: make test.unit crate=${{ matrix.crate }} browser=chrome
-        if: ${{ matrix.if && matrix.crate == 'medea-jason' }}
-      - name: Firefox
-        run: make test.unit crate=${{ matrix.crate }} browser=firefox
-        if: ${{ matrix.if && matrix.crate == 'medea-jason' }}
-
-      - run: make test.unit crate=${{ matrix.crate }}
-        if: ${{ matrix.if && matrix.crate != 'medea-jason' }}
+#  test-unit:
+#    name: Unit tests
+#    if: ${{ github.ref == 'refs/heads/master'
+#            || startsWith(github.ref, 'refs/tags/medea-')
+#            || !contains(github.event.head_commit.message, '[skip ci]') }}
+#    strategy:
+#      matrix:
+#        include:
+#          - crate: medea-macro
+#            if: ${{ startsWith(github.ref, 'refs/tags/medea-macro-')
+#                    || !startsWith(github.ref, 'refs/tags/medea-') }}
+#          - crate: medea-reactive
+#            if: ${{ startsWith(github.ref, 'refs/tags/medea-reactive-')
+#                    || !startsWith(github.ref, 'refs/tags/medea-') }}
+#          - crate: medea-coturn-telnet-client
+#            if: ${{ startsWith(github.ref, 'refs/tags/medea-coturn-telnet-client-')
+#                    || !startsWith(github.ref, 'refs/tags/medea-') }}
+#          - crate: medea-client-api-proto
+#            if: ${{ startsWith(github.ref, 'refs/tags/medea-client-api-proto-')
+#                    || !startsWith(github.ref, 'refs/tags/medea-') }}
+#          - crate: medea
+#            if: ${{ !startsWith(github.ref, 'refs/tags/medea-')
+#                    || startsWith(github.ref, 'refs/tags/medea-0')
+#                    || startsWith(github.ref, 'refs/tags/medea-1')
+#                    || startsWith(github.ref, 'refs/tags/medea-2')
+#                    || startsWith(github.ref, 'refs/tags/medea-3')
+#                    || startsWith(github.ref, 'refs/tags/medea-4')
+#                    || startsWith(github.ref, 'refs/tags/medea-5')
+#                    || startsWith(github.ref, 'refs/tags/medea-6')
+#                    || startsWith(github.ref, 'refs/tags/medea-7')
+#                    || startsWith(github.ref, 'refs/tags/medea-8')
+#                    || startsWith(github.ref, 'refs/tags/medea-9') }}
+#                    # don't ask, pass through...
+#          - crate: medea-jason
+#            wasm: true
+#            if: ${{ startsWith(github.ref, 'refs/tags/medea-jason-')
+#                    || !startsWith(github.ref, 'refs/tags/medea-') }}
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#        if: ${{ matrix.if }}
+#
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: stable
+#        if: ${{ matrix.if && !matrix.wasm }}
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: stable
+#          target: wasm32-unknown-unknown
+#        if: ${{ matrix.if && matrix.wasm }}
+#
+#      - uses: Swatinem/rust-cache@v1
+#        if: ${{ matrix.if
+#                && !contains(github.event.head_commit.message, '[fresh ci]') }}
+#
+#      - name: Parse wasm-bindgen-cli version from Cargo.lock
+#        id: wasm-cli
+#        run: echo ::set-output
+#                  name=VERSION::$(cargo pkgid wasm-bindgen | grep -o '#.*'
+#                                                           | grep -o '[0-9\.]*')
+#        if: ${{ matrix.if && matrix.wasm }}
+#      - uses: actions-rs/install@v0.1
+#        with:
+#          crate: wasm-bindgen-cli
+#          version: ${{ steps.wasm-cli.outputs.VERSION }}
+#          use-tool-cache: true
+#        if: ${{ matrix.if && matrix.wasm }}
+#
+#      - name: Chrome
+#        run: make test.unit crate=${{ matrix.crate }} browser=chrome
+#        if: ${{ matrix.if && matrix.crate == 'medea-jason' }}
+#      - name: Firefox
+#        run: make test.unit crate=${{ matrix.crate }} browser=firefox
+#        if: ${{ matrix.if && matrix.crate == 'medea-jason' }}
+#
+#      - run: make test.unit crate=${{ matrix.crate }}
+#        if: ${{ matrix.if && matrix.crate != 'medea-jason' }}
 
   test-e2e:
     name: E2E tests
@@ -221,210 +221,210 @@ jobs:
         run: make test.e2e browser=firefox up=yes dockerized=yes
                            tag=build-${{ github.run_number }}
 
-  test-integration:
-    name: Integration tests
-    if: ${{ github.ref == 'refs/heads/master'
-            || startsWith(github.ref, 'refs/tags/medea-')
-            || !contains(github.event.head_commit.message, '[skip ci]') }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
-      - uses: Swatinem/rust-cache@v1
-        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        with:
-          key: test-integration-{hash}
-          restore-keys: test-integration-
-        continue-on-error: true
-        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-
-      - run: make test.integration up=yes dockerized=no
-
-  test-flutter:
-    name: Flutter tests
-    if: ${{ github.ref == 'refs/heads/master'
-            || startsWith(github.ref, 'refs/tags/medea-jason-')
-            || (!startsWith(github.ref, 'refs/tags/medea-')
-                && !contains(github.event.head_commit.message, '[skip ci]')) }}
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: x86_64-linux-android
-      - uses: Swatinem/rust-cache@v1
-        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-ndk
-          use-tool-cache: true
-      - uses: subosito/flutter-action@v1
-        with:
-          channel: dev
-
-      - name: Parse Android NDK versions
-        id: ndk-version
-        run: |
-          echo ::set-output name=min::$(make flutter.android.version.min)
-          echo ::set-output name=target::$(make flutter.android.version.compile)
-
-      - name: Compile shared object
-        run: make cargo.build crate=medea-jason platform=android targets=x86_64
-                              args="--features mockable"
-
-      - name: Test on min Android NDK version
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ steps.ndk-version.outputs.min }}
-          target: google_apis
-          arch: x86_64
-          profile: Nexus 6
-          script: make test.flutter
-      - name: Test on target Android NDK version
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ steps.ndk-version.outputs.target }}
-          target: google_apis
-          arch: x86_64
-          profile: Nexus 6
-          script: make test.flutter
-
-
-
-
-  ############
-  # Building #
-  ############
-
-  crate-jason:
-    name: Build medea-jason
-    if: ${{ github.ref == 'refs/heads/master'
-            || startsWith(github.ref, 'refs/tags/medea-jason-')
-            || (!startsWith(github.ref, 'refs/tags/medea-')
-                && !contains(github.event.head_commit.message, '[skip ci]')) }}
-    strategy:
-      matrix:
-        platform:
-          - web
-          - android
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-        if: ${{ matrix.platform != 'web' }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: wasm32-unknown-unknown
-        if: ${{ matrix.platform == 'web' }}
-      - uses: Swatinem/rust-cache@v1
-        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-
-      - uses: jetli/wasm-pack-action@v0.3.0
-        if: ${{ matrix.platform == 'web' }}
-
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-ndk
-          use-tool-cache: true
-        if: ${{ matrix.platform == 'android' }}
-      - run: make rustup.android
-        if: ${{ matrix.platform == 'android' }}
-
-      - run: make cargo.build crate=medea-jason platform=${{ matrix.platform }}
-                              dockerized=no debug=yes
-
-  crate-medea:
-    name: Build medea
-    if: ${{ github.ref == 'refs/heads/master'
-            || startsWith(github.ref, 'refs/tags/medea-0')
-            || startsWith(github.ref, 'refs/tags/medea-1')
-            || startsWith(github.ref, 'refs/tags/medea-2')
-            || startsWith(github.ref, 'refs/tags/medea-3')
-            || startsWith(github.ref, 'refs/tags/medea-4')
-            || startsWith(github.ref, 'refs/tags/medea-5')
-            || startsWith(github.ref, 'refs/tags/medea-6')
-            || startsWith(github.ref, 'refs/tags/medea-7')
-            || startsWith(github.ref, 'refs/tags/medea-8')
-            || startsWith(github.ref, 'refs/tags/medea-9')
-            || (!startsWith(github.ref, 'refs/tags/medea-')
-                && !contains(github.event.head_commit.message, '[skip ci]')) }}
-            # nope, that's OK...
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v1
-        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-      - run: make cargo.build crate=medea dockerized=no debug=yes
-
-  rustdoc:
-    if: ${{ github.ref == 'refs/heads/master'
-            || startsWith(github.ref, 'refs/tags/medea-')
-            || !contains(github.event.head_commit.message, '[skip ci]') }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v1
-        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-
-      # Run all task sequentially to not flood the jobs list.
-      - run: make docs.rust crate=medea-macro open=no
-        if: ${{ startsWith(github.ref, 'refs/tags/medea-macro-')
-                || !startsWith(github.ref, 'refs/tags/medea-') }}
-
-      - run: make docs.rust crate=medea-reactive open=no
-        if: ${{ startsWith(github.ref, 'refs/tags/medea-reactive-')
-                || !startsWith(github.ref, 'refs/tags/medea-') }}
-
-      - run: make docs.rust crate=medea-coturn-telnet-client open=no
-        if: ${{ startsWith(github.ref, 'refs/tags/medea-coturn-telnet-client-')
-                || !startsWith(github.ref, 'refs/tags/medea-') }}
-
-      - run: make docs.rust crate=medea-client-api-proto open=no
-        if: ${{ startsWith(github.ref, 'refs/tags/medea-client-api-proto-')
-                || !startsWith(github.ref, 'refs/tags/medea-') }}
-
-      - run: make docs.rust crate=medea-control-api-proto open=no
-        if: ${{ startsWith(github.ref, 'refs/tags/medea-control-api-proto-')
-                || !startsWith(github.ref, 'refs/tags/medea-') }}
-
-      - run: make docs.rust crate=medea-jason open=no
-        if: ${{ startsWith(github.ref, 'refs/tags/medea-jason-')
-                || !startsWith(github.ref, 'refs/tags/medea-') }}
-
-      - run: make docs.rust crate=medea open=no
-        if: ${{ !startsWith(github.ref, 'refs/tags/medea-')
-                || startsWith(github.ref, 'refs/tags/medea-0')
-                || startsWith(github.ref, 'refs/tags/medea-1')
-                || startsWith(github.ref, 'refs/tags/medea-2')
-                || startsWith(github.ref, 'refs/tags/medea-3')
-                || startsWith(github.ref, 'refs/tags/medea-4')
-                || startsWith(github.ref, 'refs/tags/medea-5')
-                || startsWith(github.ref, 'refs/tags/medea-6')
-                || startsWith(github.ref, 'refs/tags/medea-7')
-                || startsWith(github.ref, 'refs/tags/medea-8')
-                || startsWith(github.ref, 'refs/tags/medea-9') }}
-                # still, that's OK...
+#  test-integration:
+#    name: Integration tests
+#    if: ${{ github.ref == 'refs/heads/master'
+#            || startsWith(github.ref, 'refs/tags/medea-')
+#            || !contains(github.event.head_commit.message, '[skip ci]') }}
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: stable
+#
+#      - uses: Swatinem/rust-cache@v1
+#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+#      - uses: satackey/action-docker-layer-caching@v0.0.11
+#        with:
+#          key: test-integration-{hash}
+#          restore-keys: test-integration-
+#        continue-on-error: true
+#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+#
+#      - run: make test.integration up=yes dockerized=no
+#
+#  test-flutter:
+#    name: Flutter tests
+#    if: ${{ github.ref == 'refs/heads/master'
+#            || startsWith(github.ref, 'refs/tags/medea-jason-')
+#            || (!startsWith(github.ref, 'refs/tags/medea-')
+#                && !contains(github.event.head_commit.message, '[skip ci]')) }}
+#    runs-on: macos-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: stable
+#          target: x86_64-linux-android
+#      - uses: Swatinem/rust-cache@v1
+#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+#
+#      - uses: actions-rs/install@v0.1
+#        with:
+#          crate: cargo-ndk
+#          use-tool-cache: true
+#      - uses: subosito/flutter-action@v1
+#        with:
+#          channel: dev
+#
+#      - name: Parse Android NDK versions
+#        id: ndk-version
+#        run: |
+#          echo ::set-output name=min::$(make flutter.android.version.min)
+#          echo ::set-output name=target::$(make flutter.android.version.compile)
+#
+#      - name: Compile shared object
+#        run: make cargo.build crate=medea-jason platform=android targets=x86_64
+#                              args="--features mockable"
+#
+#      - name: Test on min Android NDK version
+#        uses: reactivecircus/android-emulator-runner@v2
+#        with:
+#          api-level: ${{ steps.ndk-version.outputs.min }}
+#          target: google_apis
+#          arch: x86_64
+#          profile: Nexus 6
+#          script: make test.flutter
+#      - name: Test on target Android NDK version
+#        uses: reactivecircus/android-emulator-runner@v2
+#        with:
+#          api-level: ${{ steps.ndk-version.outputs.target }}
+#          target: google_apis
+#          arch: x86_64
+#          profile: Nexus 6
+#          script: make test.flutter
+#
+#
+#
+#
+#  ############
+#  # Building #
+#  ############
+#
+#  crate-jason:
+#    name: Build medea-jason
+#    if: ${{ github.ref == 'refs/heads/master'
+#            || startsWith(github.ref, 'refs/tags/medea-jason-')
+#            || (!startsWith(github.ref, 'refs/tags/medea-')
+#                && !contains(github.event.head_commit.message, '[skip ci]')) }}
+#    strategy:
+#      matrix:
+#        platform:
+#          - web
+#          - android
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: stable
+#        if: ${{ matrix.platform != 'web' }}
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: stable
+#          target: wasm32-unknown-unknown
+#        if: ${{ matrix.platform == 'web' }}
+#      - uses: Swatinem/rust-cache@v1
+#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+#
+#      - uses: jetli/wasm-pack-action@v0.3.0
+#        if: ${{ matrix.platform == 'web' }}
+#
+#      - uses: actions-rs/install@v0.1
+#        with:
+#          crate: cargo-ndk
+#          use-tool-cache: true
+#        if: ${{ matrix.platform == 'android' }}
+#      - run: make rustup.android
+#        if: ${{ matrix.platform == 'android' }}
+#
+#      - run: make cargo.build crate=medea-jason platform=${{ matrix.platform }}
+#                              dockerized=no debug=yes
+#
+#  crate-medea:
+#    name: Build medea
+#    if: ${{ github.ref == 'refs/heads/master'
+#            || startsWith(github.ref, 'refs/tags/medea-0')
+#            || startsWith(github.ref, 'refs/tags/medea-1')
+#            || startsWith(github.ref, 'refs/tags/medea-2')
+#            || startsWith(github.ref, 'refs/tags/medea-3')
+#            || startsWith(github.ref, 'refs/tags/medea-4')
+#            || startsWith(github.ref, 'refs/tags/medea-5')
+#            || startsWith(github.ref, 'refs/tags/medea-6')
+#            || startsWith(github.ref, 'refs/tags/medea-7')
+#            || startsWith(github.ref, 'refs/tags/medea-8')
+#            || startsWith(github.ref, 'refs/tags/medea-9')
+#            || (!startsWith(github.ref, 'refs/tags/medea-')
+#                && !contains(github.event.head_commit.message, '[skip ci]')) }}
+#            # nope, that's OK...
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: stable
+#      - uses: Swatinem/rust-cache@v1
+#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+#      - run: make cargo.build crate=medea dockerized=no debug=yes
+#
+#  rustdoc:
+#    if: ${{ github.ref == 'refs/heads/master'
+#            || startsWith(github.ref, 'refs/tags/medea-')
+#            || !contains(github.event.head_commit.message, '[skip ci]') }}
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: stable
+#      - uses: Swatinem/rust-cache@v1
+#        if: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
+#
+#      # Run all task sequentially to not flood the jobs list.
+#      - run: make docs.rust crate=medea-macro open=no
+#        if: ${{ startsWith(github.ref, 'refs/tags/medea-macro-')
+#                || !startsWith(github.ref, 'refs/tags/medea-') }}
+#
+#      - run: make docs.rust crate=medea-reactive open=no
+#        if: ${{ startsWith(github.ref, 'refs/tags/medea-reactive-')
+#                || !startsWith(github.ref, 'refs/tags/medea-') }}
+#
+#      - run: make docs.rust crate=medea-coturn-telnet-client open=no
+#        if: ${{ startsWith(github.ref, 'refs/tags/medea-coturn-telnet-client-')
+#                || !startsWith(github.ref, 'refs/tags/medea-') }}
+#
+#      - run: make docs.rust crate=medea-client-api-proto open=no
+#        if: ${{ startsWith(github.ref, 'refs/tags/medea-client-api-proto-')
+#                || !startsWith(github.ref, 'refs/tags/medea-') }}
+#
+#      - run: make docs.rust crate=medea-control-api-proto open=no
+#        if: ${{ startsWith(github.ref, 'refs/tags/medea-control-api-proto-')
+#                || !startsWith(github.ref, 'refs/tags/medea-') }}
+#
+#      - run: make docs.rust crate=medea-jason open=no
+#        if: ${{ startsWith(github.ref, 'refs/tags/medea-jason-')
+#                || !startsWith(github.ref, 'refs/tags/medea-') }}
+#
+#      - run: make docs.rust crate=medea open=no
+#        if: ${{ !startsWith(github.ref, 'refs/tags/medea-')
+#                || startsWith(github.ref, 'refs/tags/medea-0')
+#                || startsWith(github.ref, 'refs/tags/medea-1')
+#                || startsWith(github.ref, 'refs/tags/medea-2')
+#                || startsWith(github.ref, 'refs/tags/medea-3')
+#                || startsWith(github.ref, 'refs/tags/medea-4')
+#                || startsWith(github.ref, 'refs/tags/medea-5')
+#                || startsWith(github.ref, 'refs/tags/medea-6')
+#                || startsWith(github.ref, 'refs/tags/medea-7')
+#                || startsWith(github.ref, 'refs/tags/medea-8')
+#                || startsWith(github.ref, 'refs/tags/medea-9') }}
+#                # still, that's OK...
 
   docker:
     name: Docker image

--- a/mock/control-api/src/api/endpoint.rs
+++ b/mock/control-api/src/api/endpoint.rs
@@ -37,7 +37,9 @@ impl From<proto::web_rtc_publish_endpoint::P2p> for P2pMode {
 
 /// Publishing policy of the video or audio media type in the
 /// [`WebRtcPublishEndpoint`].
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, SmartDefault)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize, SmartDefault,
+)]
 pub enum PublishPolicy {
     /// Publish this media type if it possible.
     #[default]

--- a/mock/control-api/src/api/endpoint.rs
+++ b/mock/control-api/src/api/endpoint.rs
@@ -38,7 +38,7 @@ impl From<proto::web_rtc_publish_endpoint::P2p> for P2pMode {
 /// Publishing policy of the video or audio media type in the
 /// [`WebRtcPublishEndpoint`].
 #[derive(
-    Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize, SmartDefault,
+    Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, SmartDefault,
 )]
 pub enum PublishPolicy {
     /// Publish this media type if it possible.

--- a/tests/e2e/features/media_mute.feature
+++ b/tests/e2e/features/media_mute.feature
@@ -45,5 +45,5 @@ Feature: Media muting
     Given room with joined members Alice and Bob
     When Bob mutes audio and awaits it completes
     Then `on_muted` callback fires 1 time on Alice's remote audio track from Bob
-    When Bob unmutes audio awaits it completes
+    When Bob unmutes audio and awaits it completes
     Then `on_unmuted` callback fires 1 time on Alice's remote audio track from Bob

--- a/tests/e2e/object/room.rs
+++ b/tests/e2e/object/room.rs
@@ -16,7 +16,7 @@ use super::{AwaitCompletion, Error};
 pub struct Room;
 
 /// Representation of a `MediaKind` JS enum.
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum MediaKind {
     Audio,
     Video,
@@ -50,7 +50,7 @@ impl MediaKind {
 }
 
 /// Representation of a `MediaSourceKind` JS enum.
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum MediaSourceKind {
     Device,
     Display,

--- a/tests/e2e/object/tracks_store.rs
+++ b/tests/e2e/object/tracks_store.rs
@@ -39,6 +39,10 @@ impl<T> Object<TracksStore<T>> {
 
     /// Waits this [`TracksStore`] to contain `count` tracks.
     pub async fn wait_for_count(&self, count: u64) -> Result<(), Error> {
+        if count == 0 {
+            return Ok(());
+        }
+
         self.execute(Statement::new(
             // language=JavaScript
             r#"

--- a/tests/e2e/steps/track.rs
+++ b/tests/e2e/steps/track.rs
@@ -30,7 +30,6 @@ async fn then_member_has_remote_track(
     kind: String,
     remote_id: String,
 ) {
-    world.wait_for_interconnection(&id).await.unwrap();
     let member = world.get_member(&id).unwrap();
     let connection = member
         .connections()
@@ -150,7 +149,6 @@ async fn then_remote_media_track(
     partner_id: String,
     state: String,
 ) {
-    world.wait_for_interconnection(&id).await.unwrap();
     let member = world.get_member(&id).unwrap();
     let partner_connection = member
         .connections()
@@ -234,7 +232,6 @@ async fn then_member_has_n_remote_tracks_from(
     live_or_stopped: String,
     remote_id: String,
 ) {
-    sleep(Duration::from_millis(300)).await;
     let member = world.get_member(&id).unwrap();
     let connection = member
         .connections()

--- a/tests/e2e/steps/track.rs
+++ b/tests/e2e/steps/track.rs
@@ -248,9 +248,16 @@ async fn then_member_has_n_remote_tracks_from(
         (true, true)
     };
 
-    let actual_count = tracks_store
-        .count_tracks_by_selector(muted, stopped)
-        .await
-        .unwrap();
+    let mut actual_count = 0;
+    for _ in 0..5 {
+        actual_count = tracks_store
+            .count_tracks_by_selector(muted, stopped)
+            .await
+            .unwrap();
+        if actual_count != expected_count {
+            sleep(Duration::from_millis(300)).await;
+        }
+    }
+
     assert_eq!(actual_count, expected_count);
 }

--- a/tests/e2e/steps/track.rs
+++ b/tests/e2e/steps/track.rs
@@ -30,6 +30,7 @@ async fn then_member_has_remote_track(
     kind: String,
     remote_id: String,
 ) {
+    world.wait_for_interconnection(&id).await.unwrap();
     let member = world.get_member(&id).unwrap();
     let connection = member
         .connections()
@@ -149,6 +150,7 @@ async fn then_remote_media_track(
     partner_id: String,
     state: String,
 ) {
+    world.wait_for_interconnection(&id).await.unwrap();
     let member = world.get_member(&id).unwrap();
     let partner_connection = member
         .connections()

--- a/tests/e2e/world/mod.rs
+++ b/tests/e2e/world/mod.rs
@@ -112,7 +112,6 @@ impl World {
         builder: MemberBuilder,
     ) -> Result<()> {
         let mut pipeline = HashMap::new();
-
         let mut send_state = HashMap::new();
         let mut recv_state = HashMap::new();
 

--- a/tests/e2e/world/mod.rs
+++ b/tests/e2e/world/mod.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 use crate::{
     browser::{self, WindowFactory},
     control,
-    object::{self, Jason, Object},
+    object::{self, Jason, MediaKind, MediaSourceKind, Object},
 };
 
 pub use self::member::{Builder as MemberBuilder, Member};
@@ -112,7 +112,15 @@ impl World {
         builder: MemberBuilder,
     ) -> Result<()> {
         let mut pipeline = HashMap::new();
+
+        let mut send_state = HashMap::new();
+        let mut recv_state = HashMap::new();
+
         if builder.is_send {
+            send_state
+                .insert((MediaKind::Audio, MediaSourceKind::Device), true);
+            send_state
+                .insert((MediaKind::Video, MediaSourceKind::Device), true);
             pipeline.insert(
                 "publish".to_owned(),
                 proto::Endpoint::WebRtcPublishEndpoint(
@@ -127,6 +135,10 @@ impl World {
             );
         }
         if builder.is_recv {
+            recv_state
+                .insert((MediaKind::Audio, MediaSourceKind::Device), true);
+            recv_state
+                .insert((MediaKind::Video, MediaSourceKind::Device), true);
             self.members.values().filter(|m| m.is_send()).for_each(|m| {
                 let endpoint_id = format!("play-{}", m.id());
                 pipeline.insert(
@@ -198,7 +210,8 @@ impl World {
         let window = self.window_factory.new_window().await;
         let jason = Object::spawn(Jason, window.clone()).await?;
         let room = jason.init_room().await?;
-        let member = builder.build(room, window).await?;
+        let member =
+            builder.build(room, window, send_state, recv_state).await?;
 
         self.jasons.insert(member.id().to_owned(), jason);
         self.members.insert(member.id().to_owned(), member);
@@ -380,6 +393,25 @@ impl World {
         pair: MembersPair,
     ) -> Result<()> {
         if let Some(publish_endpoint) = pair.left.publish_endpoint() {
+            let left_member = self.members.get_mut(&pair.left.id).unwrap();
+            if publish_endpoint.audio_settings.publish_policy
+                != PublishPolicy::Disabled
+            {
+                left_member.update_send_media_state(
+                    Some(MediaKind::Audio),
+                    None,
+                    true,
+                );
+            }
+            if publish_endpoint.video_settings.publish_policy
+                != PublishPolicy::Disabled
+            {
+                left_member.update_send_media_state(
+                    Some(MediaKind::Video),
+                    None,
+                    true,
+                );
+            }
             self.control_client
                 .create(
                     &control_api_path!(self.room_id, pair.left.id, "publish"),
@@ -388,6 +420,25 @@ impl World {
                 .await?;
         }
         if let Some(publish_endpoint) = pair.right.publish_endpoint() {
+            let right_member = self.members.get_mut(&pair.right.id).unwrap();
+            if publish_endpoint.audio_settings.publish_policy
+                != PublishPolicy::Disabled
+            {
+                right_member.update_send_media_state(
+                    Some(MediaKind::Audio),
+                    None,
+                    true,
+                );
+            }
+            if publish_endpoint.video_settings.publish_policy
+                != PublishPolicy::Disabled
+            {
+                right_member.update_send_media_state(
+                    Some(MediaKind::Video),
+                    None,
+                    true,
+                );
+            }
             self.control_client
                 .create(
                     &control_api_path!(self.room_id, pair.right.id, "publish"),
@@ -399,6 +450,19 @@ impl World {
         if let Some(play_endpoint) =
             pair.left.play_endpoint_for(&self.room_id, &pair.right)
         {
+            let left_member = self.members.get_mut(&pair.left.id).unwrap();
+
+            left_member.update_recv_media_state(
+                Some(MediaKind::Video),
+                None,
+                true,
+            );
+            left_member.update_recv_media_state(
+                Some(MediaKind::Audio),
+                None,
+                true,
+            );
+
             self.control_client
                 .create(
                     &control_api_path!(
@@ -413,6 +477,19 @@ impl World {
         if let Some(play_endpoint) =
             pair.right.play_endpoint_for(&self.room_id, &pair.left)
         {
+            let right_member = self.members.get_mut(&pair.right.id).unwrap();
+
+            right_member.update_recv_media_state(
+                Some(MediaKind::Video),
+                None,
+                true,
+            );
+            right_member.update_recv_media_state(
+                Some(MediaKind::Audio),
+                None,
+                true,
+            );
+
             self.control_client
                 .create(
                     &control_api_path!(


### PR DESCRIPTION
## Synopsis

В #206 было обнаружено что e2e тесты синхронихации состояний на самом деле синхронизацию состояний не тестировали, в процесс внесения исправлений в паре место пришлось поубирать различного рода ожидания. Это привело к снижению стабильности работы других e2e тестов, надо чинить.


## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
