### PR TITLE
Upgrade stable Rust to 1.53 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite 0.2.6",
  "smallvec",
- "tokio 1.6.1",
+ "tokio 1.7.0",
  "tokio-util 0.6.7",
 ]
 
@@ -48,7 +48,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.6",
- "tokio 1.6.1",
+ "tokio 1.7.0",
  "tokio-util 0.6.7",
 ]
 
@@ -102,15 +102,15 @@ dependencies = [
  "percent-encoding",
  "pin-project 1.0.7",
  "pin-project-lite 0.2.6",
- "rand 0.8.3",
+ "rand 0.8.4",
  "regex",
  "serde 1.0.126",
  "serde_json",
  "serde_urlencoded 0.7.0",
  "sha-1",
  "smallvec",
- "time 0.2.26",
- "tokio 1.6.1",
+ "time 0.2.27",
+ "tokio 1.7.0",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ dependencies = [
  "serde_urlencoded 0.7.0",
  "slab",
  "socket2 0.4.0",
- "time 0.2.26",
+ "time 0.2.27",
 ]
 
 [[package]]
@@ -146,7 +146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2f86cd6857c135e6e9fe57b1619a88d1f94a7df34c00e11fe13e64fd3438837"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -170,7 +170,7 @@ checksum = "bc7d7cd957c9ed92288a7c3c96af81fa5291f65247a76a34dac7b6af74e52ba0"
 dependencies = [
  "actix-macros",
  "futures-core",
- "tokio 1.6.1",
+ "tokio 1.7.0",
 ]
 
 [[package]]
@@ -184,10 +184,10 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "log",
- "mio 0.7.11",
+ "mio 0.7.13",
  "num_cpus",
  "slab",
- "tokio 1.6.1",
+ "tokio 1.7.0",
 ]
 
 [[package]]
@@ -260,7 +260,7 @@ dependencies = [
  "serde_urlencoded 0.7.0",
  "smallvec",
  "socket2 0.4.0",
- "time 0.2.26",
+ "time 0.2.27",
  "url",
 ]
 
@@ -278,7 +278,7 @@ dependencies = [
  "bytestring",
  "futures-core",
  "pin-project 1.0.7",
- "tokio 1.6.1",
+ "tokio 1.7.0",
 ]
 
 [[package]]
@@ -289,7 +289,7 @@ checksum = "7f138ac357a674c3b480ddb7bbd894b13c1b6e8927d728bc9ea5e17eee2f8fc9"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -300,7 +300,7 @@ checksum = "6d44b8fee1ced9671ba043476deddef739dd0959bf77030b26b738cc591737a7"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
 name = "arc-swap"
@@ -397,7 +397,7 @@ checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -418,7 +418,7 @@ checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -429,7 +429,7 @@ checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -468,7 +468,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite 0.2.6",
- "rand 0.8.3",
+ "rand 0.8.4",
  "serde 1.0.126",
  "serde_json",
  "serde_urlencoded 0.7.0",
@@ -484,7 +484,7 @@ dependencies = [
  "getrandom",
  "instant",
  "pin-project 1.0.7",
- "rand 0.8.3",
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -650,15 +650,15 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.5.2"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4369b5e4c0cddf64ad8981c0111e7df4f7078f4d6ba98fb31f2e17c4c57b7e"
+checksum = "a2d47c1b11006b87e492b53b313bb699ce60e16613c4dddaa91f8f7c220ab2fa"
 dependencies = [
  "bytes 1.0.1",
  "futures-util",
  "memchr",
  "pin-project-lite 0.2.6",
- "tokio 1.6.1",
+ "tokio 1.7.0",
 ]
 
 [[package]]
@@ -721,7 +721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
 dependencies = [
  "percent-encoding",
- "time 0.2.26",
+ "time 0.2.27",
  "version_check",
 ]
 
@@ -786,7 +786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -824,7 +824,7 @@ dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "regex",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -834,7 +834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed431abf442833fd62ad7cc527a3833d969155c803f0dcf7f8a68db8adddc4c5"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -868,7 +868,7 @@ dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "strsim 0.10.0",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -882,7 +882,7 @@ dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "strsim 0.10.0",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -893,7 +893,7 @@ checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
  "darling_core 0.12.4",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -904,7 +904,7 @@ checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
  "darling_core 0.13.0",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -921,7 +921,7 @@ checksum = "a2d41e5afb1b1e89cc7204eb9ca99e05ba6fc810962957e7fe285d5024ed5890"
 dependencies = [
  "async-trait",
  "num_cpus",
- "tokio 1.6.1",
+ "tokio 1.7.0",
 ]
 
 [[package]]
@@ -944,7 +944,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -965,7 +965,7 @@ dependencies = [
  "darling 0.12.4",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -975,7 +975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
 dependencies = [
  "derive_builder_core",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -987,7 +987,7 @@ dependencies = [
  "convert_case",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1067,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "log",
  "regex",
@@ -1093,7 +1093,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "synstructure",
 ]
 
@@ -1113,8 +1113,8 @@ dependencies = [
  "mime",
  "serde 1.0.126",
  "serde_json",
- "time 0.2.26",
- "tokio 1.6.1",
+ "time 0.2.27",
+ "tokio 1.7.0",
  "url",
  "webdriver",
 ]
@@ -1283,7 +1283,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1365,7 +1365,7 @@ dependencies = [
  "quote 1.0.9",
  "serde 1.0.126",
  "serde_json",
- "syn 1.0.72",
+ "syn 1.0.73",
  "textwrap 0.12.1",
  "thiserror",
  "typed-builder",
@@ -1379,7 +1379,7 @@ checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1390,9 +1390,9 @@ checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "globset"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
+checksum = "f0fc1b9fa0e64ffb1aa5b95daa0f0f167734fd528b7c02eabc581d9d843649b1"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1446,7 +1446,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.6.1",
+ "tokio 1.7.0",
  "tokio-util 0.6.7",
  "tracing",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.6",
  "socket2 0.4.0",
- "tokio 1.6.1",
+ "tokio 1.7.0",
  "tower-service",
  "tracing",
  "want",
@@ -1623,7 +1623,7 @@ dependencies = [
  "bytes 1.0.1",
  "hyper 0.14.9",
  "native-tls",
- "tokio 1.6.1",
+ "tokio 1.7.0",
  "tokio-native-tls",
 ]
 
@@ -1646,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b287fb45c60bb826a0dc68ff08742b9d88a2fea13d6e0c286b3172065aaf878c"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
 dependencies = [
  "crossbeam-utils",
  "globset",
@@ -1709,7 +1709,7 @@ checksum = "75c094e94816723ab936484666968f5b58060492e880f3c8d00489a1e244fa51"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1723,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -1788,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.96"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5600b4e6efc5421841a2138a6b082e07fe12f9aaa12783d50e5d13325b26b4fc"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "linked-hash-map"
@@ -1878,7 +1878,7 @@ dependencies = [
  "medea-macro 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockall",
  "once_cell",
- "rand 0.8.3",
+ "rand 0.8.4",
  "redis",
  "reqwest",
  "rust-argon2",
@@ -1896,7 +1896,7 @@ dependencies = [
  "smart-default",
  "subtle",
  "tempfile",
- "tokio 1.6.1",
+ "tokio 1.7.0",
  "tokio-stream",
  "tokio-util 0.6.7",
  "toml",
@@ -1979,7 +1979,7 @@ dependencies = [
  "futures",
  "once_cell",
  "regex",
- "tokio 1.6.1",
+ "tokio 1.7.0",
  "tokio-util 0.6.7",
 ]
 
@@ -2031,7 +2031,7 @@ dependencies = [
  "medea-jason",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "synstructure",
 ]
 
@@ -2044,7 +2044,7 @@ dependencies = [
  "Inflector",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "synstructure",
 ]
 
@@ -2062,7 +2062,7 @@ name = "medea-reactive"
 version = "0.1.2-dev"
 dependencies = [
  "futures",
- "tokio 1.6.1",
+ "tokio 1.7.0",
 ]
 
 [[package]]
@@ -2124,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -2180,7 +2180,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2284,18 +2284,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bc1d42047cf336f0f939c99e97183cf31551bf0f2865a2ec9c8d91fd4ffb5e"
+checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -2436,7 +2436,7 @@ checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2447,7 +2447,7 @@ checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2586,7 +2586,7 @@ dependencies = [
  "itertools",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2601,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.23.0"
+version = "2.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45604fc7a88158e7d514d8e22e14ac746081e7a70d7690074dd0029ee37458d6"
+checksum = "db50e77ae196458ccd3dc58a31ea1a90b0698ab1b7928d89f644c25d72070267"
 
 [[package]]
 name = "quote"
@@ -2648,24 +2648,24 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
  "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2685,20 +2685,20 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a32cb439c4e89c1e6415e5b3b23d9d8cc6dc1bf5a8cade19adbd5418de803be"
+checksum = "d4f0ceb2ec0dd769483ecd283f6615aa83dcd0be556d5294c6e659caefe7cc54"
 dependencies = [
  "async-trait",
  "bytes 1.0.1",
@@ -2724,16 +2724,16 @@ dependencies = [
  "itoa",
  "percent-encoding",
  "pin-project-lite 0.2.6",
- "tokio 1.6.1",
+ "tokio 1.7.0",
  "tokio-util 0.6.7",
  "url",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
@@ -2800,7 +2800,7 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "serde_urlencoded 0.7.0",
- "tokio 1.6.1",
+ "tokio 1.7.0",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -2976,7 +2976,7 @@ checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3016,9 +3016,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3132bd01cfb74aac8b1b10083ad1f38dbf756df3176d5e63dd91e3f62a87f5"
+checksum = "6a3b379ba4fd515d3fdccfe8584eb9fcc6f7dd1bbe14636a12c98a36fbbfc850"
 dependencies = [
  "rustversion",
  "serde 1.0.126",
@@ -3034,7 +3034,7 @@ dependencies = [
  "darling 0.13.0",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3068,7 +3068,7 @@ checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3209,7 +3209,7 @@ checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3272,7 +3272,7 @@ dependencies = [
  "quote 1.0.9",
  "serde 1.0.126",
  "serde_derive",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3288,7 +3288,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3328,9 +3328,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -3345,7 +3345,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "unicode-xid 0.2.2",
 ]
 
@@ -3363,7 +3363,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.3",
+ "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -3435,7 +3435,7 @@ checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3459,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a8cbfbf47955132d0202d1662f49b2423ae35862aee471f3ba4b133358f372"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
 dependencies = [
  "const_fn",
  "libc",
@@ -3484,15 +3484,15 @@ dependencies = [
 
 [[package]]
 name = "time-macros-impl"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "standback",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3529,15 +3529,15 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
+checksum = "c79ba603c337335df6ba6dd6afc38c38a7d5e1b0c871678439ea973cd62a118e"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
  "libc",
  "memchr",
- "mio 0.7.11",
+ "mio 0.7.13",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -3555,7 +3555,7 @@ checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3565,7 +3565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.6.1",
+ "tokio 1.7.0",
 ]
 
 [[package]]
@@ -3576,7 +3576,7 @@ checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.6",
- "tokio 1.6.1",
+ "tokio 1.7.0",
 ]
 
 [[package]]
@@ -3604,7 +3604,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.6",
- "tokio 1.6.1",
+ "tokio 1.7.0",
 ]
 
 [[package]]
@@ -3636,7 +3636,7 @@ dependencies = [
  "pin-project 1.0.7",
  "prost",
  "prost-derive",
- "tokio 1.6.1",
+ "tokio 1.7.0",
  "tokio-stream",
  "tokio-util 0.6.7",
  "tower",
@@ -3654,7 +3654,7 @@ dependencies = [
  "proc-macro2 1.0.27",
  "prost-build",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3667,9 +3667,9 @@ dependencies = [
  "futures-util",
  "indexmap",
  "pin-project 1.0.7",
- "rand 0.8.3",
+ "rand 0.8.4",
  "slab",
- "tokio 1.6.1",
+ "tokio 1.7.0",
  "tokio-stream",
  "tokio-util 0.6.7",
  "tower-layer",
@@ -3719,7 +3719,7 @@ checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3761,7 +3761,7 @@ checksum = "f85f4270f4f449a3f2c0cf2aecc8415e388a597aeacc7d55fc749c5c968c8533"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3850,9 +3850,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
+checksum = "70455df2fdf4e9bf580a92e443f1eb0303c390d682e2ea817312c9e81f8c3399"
 
 [[package]]
 name = "vec_map"
@@ -3942,7 +3942,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "wasm-bindgen-shared",
 ]
 
@@ -3976,7 +3976,7 @@ checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ IMAGE_NAME := $(strip \
 	$(if $(call eq,$(image),medea-demo-edge),medea-demo,\
 	$(image))))
 
-RUST_VER := 1.52
+RUST_VER := 1.53
 CHROME_VERSION := 91.0
 FIREFOX_VERSION := 88.0.1
 

--- a/crates/medea-coturn-telnet-client/src/lib.rs
+++ b/crates/medea-coturn-telnet-client/src/lib.rs
@@ -18,7 +18,7 @@
     trivial_casts,
     trivial_numeric_casts
 )]
-#![forbid(unsafe_code, non_ascii_idents)]
+#![forbid(non_ascii_idents, unsafe_code)]
 #![warn(
     deprecated_in_future,
     missing_copy_implementations,

--- a/crates/medea-coturn-telnet-client/src/lib.rs
+++ b/crates/medea-coturn-telnet-client/src/lib.rs
@@ -18,7 +18,7 @@
     trivial_casts,
     trivial_numeric_casts
 )]
-#![forbid(unsafe_code)]
+#![forbid(unsafe_code, non_ascii_idents)]
 #![warn(
     deprecated_in_future,
     missing_copy_implementations,

--- a/crates/medea-macro/src/dispatchable.rs
+++ b/crates/medea-macro/src/dispatchable.rs
@@ -360,7 +360,7 @@ mod to_handler_fn_name_spec {
 
     #[test]
     fn converts_name_from_camel_case_to_snake_case() {
-        for (name, expected) in &[
+        for (name, expected) in [
             ("SomeTestTrait", "on_some_test_trait"),
             ("RPCConnection", "on_rpc_connection"),
             ("RConnection", "on_r_connection"),

--- a/crates/medea-macro/src/dispatchable.rs
+++ b/crates/medea-macro/src/dispatchable.rs
@@ -372,7 +372,7 @@ mod to_handler_fn_name_spec {
             ("s", "on_s"),
             ("ASDF", "on_asdf"),
         ] {
-            assert_eq!(to_handler_fn_name(name), *expected);
+            assert_eq!(to_handler_fn_name(name), expected);
         }
     }
 

--- a/crates/medea-macro/src/lib.rs
+++ b/crates/medea-macro/src/lib.rs
@@ -5,6 +5,7 @@
 //! [Medea]: https://github.com/instrumentisto/medea
 
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+#![forbid(unsafe_code, non_ascii_idents)]
 
 mod dispatchable;
 mod enum_delegate;

--- a/crates/medea-macro/src/lib.rs
+++ b/crates/medea-macro/src/lib.rs
@@ -5,7 +5,7 @@
 //! [Medea]: https://github.com/instrumentisto/medea
 
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
-#![forbid(unsafe_code, non_ascii_idents)]
+#![forbid(non_ascii_idents, unsafe_code)]
 
 mod dispatchable;
 mod enum_delegate;

--- a/crates/medea-macro/src/watchers.rs
+++ b/crates/medea-macro/src/watchers.rs
@@ -24,7 +24,7 @@ use syn::{
 pub fn expand(mut input: ItemImpl) -> Result<TokenStream> {
     let component_ty = input.self_ty.clone();
 
-    #[allow(clippy::filter_map)]
+    #[allow(clippy::manual_filter_map)]
     let watchers = input
         .items
         .iter_mut()

--- a/crates/medea-macro/src/watchers.rs
+++ b/crates/medea-macro/src/watchers.rs
@@ -24,7 +24,6 @@ use syn::{
 pub fn expand(mut input: ItemImpl) -> Result<TokenStream> {
     let component_ty = input.self_ty.clone();
 
-    #[allow(clippy::manual_filter_map)]
     let watchers = input
         .items
         .iter_mut()

--- a/crates/medea-macro/tests/js_caused.rs
+++ b/crates/medea-macro/tests/js_caused.rs
@@ -1,3 +1,5 @@
+#![forbid(non_ascii_idents, unsafe_code)]
+
 use medea_jason::utils::JsCaused;
 
 struct JsError {}

--- a/crates/medea-reactive/src/collections/hash_map.rs
+++ b/crates/medea-reactive/src/collections/hash_map.rs
@@ -356,9 +356,9 @@ impl<K, V, S: SubscribersStore<(K, V), O>, O> Drop for HashMap<K, V, S, O> {
     /// [`HashMap::on_remove`] subs.
     fn drop(&mut self) {
         let mut store = std::mem::take(&mut self.store);
-        store.drain().for_each(|(key, value)| {
+        for (key, value) in store.drain() {
             self.on_remove_subs.send_update((key, value));
-        });
+        }
     }
 }
 

--- a/crates/medea-reactive/src/collections/hash_map.rs
+++ b/crates/medea-reactive/src/collections/hash_map.rs
@@ -355,9 +355,9 @@ impl<K, V, S: SubscribersStore<(K, V), O>, O> Drop for HashMap<K, V, S, O> {
     /// Sends all key-values of a dropped [`HashMap`] to the
     /// [`HashMap::on_remove`] subs.
     fn drop(&mut self) {
-        let mut store = std::mem::take(&mut self.store);
-        for (key, value) in store.drain() {
-            self.on_remove_subs.send_update((key, value));
+        let store = std::mem::take(&mut self.store);
+        for (k, v) in store {
+            self.on_remove_subs.send_update((k, v));
         }
     }
 }

--- a/crates/medea-reactive/src/collections/hash_map.rs
+++ b/crates/medea-reactive/src/collections/hash_map.rs
@@ -355,8 +355,7 @@ impl<K, V, S: SubscribersStore<(K, V), O>, O> Drop for HashMap<K, V, S, O> {
     /// Sends all key-values of a dropped [`HashMap`] to the
     /// [`HashMap::on_remove`] subs.
     fn drop(&mut self) {
-        let store = std::mem::take(&mut self.store);
-        for (k, v) in store {
+        for (k, v) in self.store.drain() {
             self.on_remove_subs.send_update((k, v));
         }
     }

--- a/crates/medea-reactive/src/collections/hash_set.rs
+++ b/crates/medea-reactive/src/collections/hash_set.rs
@@ -307,10 +307,9 @@ where
     /// Sends all values of a dropped [`HashSet`] to the
     /// [`HashSet::on_remove()`] subscriptions.
     fn drop(&mut self) {
-        let store = &mut self.store;
-        let on_remove_subs = &self.on_remove_subs;
-        for value in store.drain() {
-            on_remove_subs.send_update(value);
+        let store = std::mem::take(&mut self.store);
+        for val in store {
+            self.on_remove_subs.send_update(val);
         }
     }
 }

--- a/crates/medea-reactive/src/collections/hash_set.rs
+++ b/crates/medea-reactive/src/collections/hash_set.rs
@@ -309,9 +309,9 @@ where
     fn drop(&mut self) {
         let store = &mut self.store;
         let on_remove_subs = &self.on_remove_subs;
-        store.drain().for_each(|value| {
+        for value in store.drain() {
             on_remove_subs.send_update(value);
-        });
+        }
     }
 }
 

--- a/crates/medea-reactive/src/collections/hash_set.rs
+++ b/crates/medea-reactive/src/collections/hash_set.rs
@@ -307,8 +307,7 @@ where
     /// Sends all values of a dropped [`HashSet`] to the
     /// [`HashSet::on_remove()`] subscriptions.
     fn drop(&mut self) {
-        let store = std::mem::take(&mut self.store);
-        for val in store {
+        for val in self.store.drain() {
             self.on_remove_subs.send_update(val);
         }
     }

--- a/crates/medea-reactive/src/lib.rs
+++ b/crates/medea-reactive/src/lib.rs
@@ -9,7 +9,7 @@
     trivial_casts,
     trivial_numeric_casts
 )]
-#![forbid(unsafe_code, non_ascii_idents)]
+#![forbid(non_ascii_idents, unsafe_code)]
 #![warn(
     deprecated_in_future,
     missing_copy_implementations,

--- a/crates/medea-reactive/src/lib.rs
+++ b/crates/medea-reactive/src/lib.rs
@@ -9,7 +9,7 @@
     trivial_casts,
     trivial_numeric_casts
 )]
-#![forbid(unsafe_code)]
+#![forbid(unsafe_code, non_ascii_idents)]
 #![warn(
     deprecated_in_future,
     missing_copy_implementations,

--- a/jason/build.rs
+++ b/jason/build.rs
@@ -1,5 +1,7 @@
 //! Compiles `trampoline.c` and links it into the final library.
 
+#![forbid(non_ascii_idents, unsafe_code)]
+
 use std::env;
 
 fn main() {

--- a/jason/flutter/example/pubspec.lock
+++ b/jason/flutter/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -130,7 +130,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   path:
     dependency: transitive
     description:
@@ -212,7 +212,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.0"
   typed_data:
     dependency: transitive
     description:

--- a/jason/src/api/wasm/constraints_update_exception.rs
+++ b/jason/src/api/wasm/constraints_update_exception.rs
@@ -2,8 +2,6 @@
 //!
 //! [1]: crate::api::RoomHandle::set_local_media_settings
 
-use std::iter::FromIterator as _;
-
 use derive_more::From;
 use wasm_bindgen::prelude::*;
 
@@ -39,14 +37,13 @@ impl ConstraintsUpdateException {
     /// [`ConstraintsUpdateException`] represents a `RecoverFailedException`.
     #[must_use]
     pub fn recover_fail_reasons(&self) -> JsValue {
-        js_sys::Array::from_iter(
-            self.0
-                .recover_fail_reasons()
-                .into_iter()
-                .map(JasonError::from)
-                .map(JsValue::from),
-        )
-        .into()
+        self.0
+            .recover_fail_reasons()
+            .into_iter()
+            .map(JasonError::from)
+            .map(JsValue::from)
+            .collect::<js_sys::Array>()
+            .into()
     }
 
     /// Returns [`JasonError`] if this [`ConstraintsUpdateException`] represents

--- a/jason/src/lib.rs
+++ b/jason/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![allow(clippy::module_name_repetitions)]
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+#![forbid(non_ascii_idents)]
 #![cfg_attr(not(feature = "mockable"), warn(missing_docs))]
 #![cfg_attr(feature = "mockable", allow(missing_docs))]
 

--- a/jason/src/media/constraints.rs
+++ b/jason/src/media/constraints.rs
@@ -295,9 +295,10 @@ impl<C> VideoTrackConstraints<C> {
 
 impl VideoTrackConstraints<DeviceVideoTrackConstraints> {
     /// Indicates whether the provided [`platform::MediaStreamTrack`] satisfies
-    /// device [`VideoTrackConstraints::constraints`].
+    /// this [`VideoTrackConstraints`].
     ///
-    /// Returns `false` if [`VideoTrackConstraints::constraints`] is not set.
+    /// Returns `false` if this [`VideoTrackConstraints`] doesn't have any
+    /// constraints configured.
     #[inline]
     #[must_use]
     pub fn satisfies<T: AsRef<platform::MediaStreamTrack>>(
@@ -313,9 +314,10 @@ impl VideoTrackConstraints<DeviceVideoTrackConstraints> {
 
 impl VideoTrackConstraints<DisplayVideoTrackConstraints> {
     /// Indicates whether the provided [`platform::MediaStreamTrack`] satisfies
-    /// device [`VideoTrackConstraints::constraints`].
+    /// this [`VideoTrackConstraints`].
     ///
-    /// Returns `false` if [`VideoTrackConstraints::constraints`] is not set.
+    /// Returns `false` if this [`VideoTrackConstraints`] doesn't have any
+    /// constraints configured.
     #[inline]
     #[must_use]
     pub fn satisfies<T: AsRef<platform::MediaStreamTrack>>(
@@ -555,8 +557,8 @@ impl MediaStreamSettings {
         }
     }
 
-    /// Sets the underlying [`AudioMediaTracksSettings::enabled`] to the
-    /// given value.
+    /// Sets the underlying `enabled` field of this [`AudioMediaTracksSettings`]
+    /// to the given value.
     #[inline]
     pub fn set_audio_publish(&mut self, enabled: bool) {
         self.audio.enabled = enabled;

--- a/jason/src/media/constraints.rs
+++ b/jason/src/media/constraints.rs
@@ -295,9 +295,9 @@ impl<C> VideoTrackConstraints<C> {
 
 impl VideoTrackConstraints<DeviceVideoTrackConstraints> {
     /// Indicates whether the provided [`platform::MediaStreamTrack`] satisfies
-    /// this [`VideoTrackConstraints`].
+    /// these [`VideoTrackConstraints`].
     ///
-    /// Returns `false` if this [`VideoTrackConstraints`] doesn't have any
+    /// Returns `false` if these [`VideoTrackConstraints`] don't have any
     /// constraints configured.
     #[inline]
     #[must_use]
@@ -314,9 +314,9 @@ impl VideoTrackConstraints<DeviceVideoTrackConstraints> {
 
 impl VideoTrackConstraints<DisplayVideoTrackConstraints> {
     /// Indicates whether the provided [`platform::MediaStreamTrack`] satisfies
-    /// this [`VideoTrackConstraints`].
+    /// these [`VideoTrackConstraints`].
     ///
-    /// Returns `false` if this [`VideoTrackConstraints`] doesn't have any
+    /// Returns `false` if these [`VideoTrackConstraints`] don't have any
     /// constraints configured.
     #[inline]
     #[must_use]
@@ -557,8 +557,8 @@ impl MediaStreamSettings {
         }
     }
 
-    /// Sets the underlying `enabled` field of this [`AudioMediaTracksSettings`]
-    /// to the given value.
+    /// Sets the underlying `enabled` field of these
+    /// [`AudioMediaTracksSettings`] to the given value.
     #[inline]
     pub fn set_audio_publish(&mut self, enabled: bool) {
         self.audio.enabled = enabled;

--- a/jason/src/peer/media/receiver/mod.rs
+++ b/jason/src/peer/media/receiver/mod.rs
@@ -174,7 +174,7 @@ impl Receiver {
     /// [`platform::Transceiver`] to this [`Receiver`].
     ///
     /// Sets [`platform::MediaStreamTrack::enabled`] same as
-    /// [`Receiver::enabled_individual`] of this [`Receiver`].
+    /// `enabled_individual` of this [`Receiver`].
     pub fn set_remote_track(
         &self,
         transceiver: platform::Transceiver,

--- a/jason/src/peer/media/sender/component.rs
+++ b/jason/src/peer/media/sender/component.rs
@@ -365,13 +365,14 @@ impl State {
         matches!(self.local_track_state.get(), LocalTrackState::NeedUpdate)
     }
 
-    /// Transits [`State::local_track_state`] to a failed state.
+    /// Marks inner `local_track_state` of this [`State`] as failed with the
+    /// provided `error`.
     #[inline]
     pub fn failed_local_stream_update(&self, error: Traced<PeerError>) {
         self.local_track_state.set(LocalTrackState::Failed(error));
     }
 
-    /// Transits [`State::local_track_state`] to a stable state.
+    /// Marks inner `local_track_state` of this [`State`] as stable.
     #[inline]
     pub fn local_stream_updated(&self) {
         self.local_track_state.set(LocalTrackState::Stable);

--- a/jason/src/peer/media/sender/component.rs
+++ b/jason/src/peer/media/sender/component.rs
@@ -365,14 +365,14 @@ impl State {
         matches!(self.local_track_state.get(), LocalTrackState::NeedUpdate)
     }
 
-    /// Marks inner `local_track_state` of this [`State`] as failed with the
+    /// Marks an inner `local_track_state` of this [`State`] as failed with the
     /// provided `error`.
     #[inline]
     pub fn failed_local_stream_update(&self, error: Traced<PeerError>) {
         self.local_track_state.set(LocalTrackState::Failed(error));
     }
 
-    /// Marks inner `local_track_state` of this [`State`] as stable.
+    /// Marks an inner `local_track_state` of this [`State`] as stable.
     #[inline]
     pub fn local_stream_updated(&self) {
         self.local_track_state.set(LocalTrackState::Stable);

--- a/jason/src/peer/mod.rs
+++ b/jason/src/peer/mod.rs
@@ -659,9 +659,9 @@ impl PeerConnection {
     /// [`Sender`]s are chosen based on the provided
     /// [`LocalStreamUpdateCriteria`].
     ///
-    /// First of all make sure that [`PeerConnection`] [`Sender`]s are up to
-    /// date and they are synchronized with a real object state. If there are no
-    /// [`Sender`]s. configured in this [`PeerConnection`], then this method is
+    /// First of all makes sure that [`PeerConnection`] [`Sender`]s are
+    /// up-to-date and synchronized with a real object state. If there are no
+    /// [`Sender`]s configured in this [`PeerConnection`], then this method is
     /// no-op.
     ///
     /// Secondly, make sure that configured [`LocalTracksConstraints`] are up to

--- a/jason/src/peer/mod.rs
+++ b/jason/src/peer/mod.rs
@@ -656,12 +656,13 @@ impl PeerConnection {
     }
 
     /// Updates [`local::Track`]s being used in [`PeerConnection`]s [`Sender`]s.
-    /// [`Sender`]s are chosen based on provided [`LocalStreamUpdateCriteria`].
+    /// [`Sender`]s are chosen based on the provided
+    /// [`LocalStreamUpdateCriteria`].
     ///
     /// First of all make sure that [`PeerConnection`] [`Sender`]s are up to
-    /// date (you set those with [`State::senders`]) and [`State::senders`] are
-    /// synchronized with a real object state. If there are no senders
-    /// configured in this [`PeerConnection`], then this method is no-op.
+    /// date and they are synchronized with a real object state. If there are no
+    /// [`Sender`]s. configured in this [`PeerConnection`], then this method is
+    /// no-op.
     ///
     /// Secondly, make sure that configured [`LocalTracksConstraints`] are up to
     /// date.

--- a/jason/src/platform/wasm/transceiver.rs
+++ b/jason/src/platform/wasm/transceiver.rs
@@ -193,13 +193,13 @@ mod tests {
     fn enable_works_correctly() {
         use TransceiverDirection as D;
 
-        for (init, enable_dir, result) in &[
+        for (init, enable_dir, result) in [
             (D::INACTIVE, D::SEND, D::SEND),
             (D::INACTIVE, D::RECV, D::RECV),
             (D::SEND, D::RECV, D::all()),
             (D::RECV, D::SEND, D::all()),
         ] {
-            assert_eq!(*init | *enable_dir, *result);
+            assert_eq!(init | enable_dir, result);
         }
     }
 
@@ -207,13 +207,13 @@ mod tests {
     fn disable_works_correctly() {
         use TransceiverDirection as D;
 
-        for (init, disable_dir, result) in &[
+        for (init, disable_dir, result) in [
             (D::SEND, D::SEND, D::INACTIVE),
             (D::RECV, D::RECV, D::INACTIVE),
             (D::all(), D::SEND, D::RECV),
             (D::all(), D::RECV, D::SEND),
         ] {
-            assert_eq!(*init - *disable_dir, *result);
+            assert_eq!(init - disable_dir, result);
         }
     }
 
@@ -222,13 +222,13 @@ mod tests {
         use RtcRtpTransceiverDirection as S;
         use TransceiverDirection as D;
 
-        for (trnscvr_dir, sys_dir) in &[
+        for (trnscvr_dir, sys_dir) in [
             (D::SEND, S::Sendonly),
             (D::RECV, S::Recvonly),
             (D::all(), S::Sendrecv),
             (D::INACTIVE, S::Inactive),
         ] {
-            assert_eq!(S::from(*trnscvr_dir), *sys_dir);
+            assert_eq!(S::from(trnscvr_dir), sys_dir);
         }
     }
 
@@ -237,13 +237,13 @@ mod tests {
         use RtcRtpTransceiverDirection as S;
         use TransceiverDirection as D;
 
-        for (sys_dir, trnscvr_dir) in &[
+        for (sys_dir, trnscvr_dir) in [
             (S::Sendonly, D::SEND),
             (S::Recvonly, D::RECV),
             (S::Sendrecv, D::all()),
             (S::Inactive, D::INACTIVE),
         ] {
-            assert_eq!(D::from(*sys_dir), *trnscvr_dir);
+            assert_eq!(D::from(sys_dir), trnscvr_dir);
         }
     }
 }

--- a/jason/src/room.rs
+++ b/jason/src/room.rs
@@ -1213,7 +1213,6 @@ impl InnerRoom {
     /// [`MediaKind`] in all [`PeerConnection`]s of this [`Room`].
     ///
     /// [`TransceiverSide`]: crate::peer::TransceiverSide
-    #[allow(clippy::manual_filter_map)]
     async fn toggle_media_state(
         &self,
         state: MediaState,
@@ -1243,7 +1242,6 @@ impl InnerRoom {
     /// [`PeerId`] and [`TrackId`] to the provided [`MediaState`]s.
     ///
     /// [`TransceiverSide`]: crate::peer::TransceiverSide
-    #[allow(clippy::manual_filter_map)]
     async fn update_media_states(
         &self,
         desired_states: HashMap<PeerId, HashMap<TrackId, MediaState>>,

--- a/jason/src/room.rs
+++ b/jason/src/room.rs
@@ -1644,8 +1644,8 @@ impl EventHandler for InnerRoom {
 
     /// Disposes specified [`PeerConnection`]s.
     async fn on_peers_removed(&self, peer_ids: Vec<PeerId>) -> Self::Output {
-        for id in &peer_ids {
-            self.peers.state().remove(*id);
+        for id in peer_ids {
+            self.peers.state().remove(id);
         }
         Ok(())
     }

--- a/jason/tests/web.rs
+++ b/jason/tests/web.rs
@@ -1,4 +1,5 @@
 #![cfg(target_arch = "wasm32")]
+#![forbid(non_ascii_idents, unsafe_code)]
 
 /// Analog for [`assert_eq`] but for [`js_callback`] macro.
 /// Simply use it as [`assert_eq`]. For use cases and reasons

--- a/mock/control-api/src/lib.rs
+++ b/mock/control-api/src/lib.rs
@@ -4,6 +4,7 @@
 //! [Control API]: https://tinyurl.com/yxsqplq7
 
 #![allow(clippy::module_name_repetitions)]
+#![forbid(unsafe_code, non_ascii_idents)]
 
 pub mod api;
 pub mod callback;

--- a/mock/control-api/src/lib.rs
+++ b/mock/control-api/src/lib.rs
@@ -4,7 +4,7 @@
 //! [Control API]: https://tinyurl.com/yxsqplq7
 
 #![allow(clippy::module_name_repetitions)]
-#![forbid(unsafe_code, non_ascii_idents)]
+#![forbid(non_ascii_idents, unsafe_code)]
 
 pub mod api;
 pub mod callback;

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -25,7 +25,7 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
-#![forbid(unsafe_code, non_ascii_idents)]
+#![forbid(non_ascii_idents, unsafe_code)]
 
 pub mod state;
 pub mod stats;

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -25,7 +25,7 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
-#![forbid(unsafe_code)]
+#![forbid(unsafe_code, non_ascii_idents)]
 
 pub mod state;
 pub mod stats;

--- a/proto/control-api/build.rs
+++ b/proto/control-api/build.rs
@@ -1,3 +1,5 @@
+#![forbid(non_ascii_idents, unsafe_code)]
+
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/proto/control-api/build.rs
+++ b/proto/control-api/build.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 /// gRPC Protobuf specs compilation.
 #[cfg(feature = "grpc")]
 mod grpc {
-    use std::{borrow::Cow, error::Error, fs, io};
+    use std::{error::Error, fs, io};
 
     /// Path to Protobuf source files.
     const GRPC_DIR: &str = "src/grpc";
@@ -85,8 +85,7 @@ mod grpc {
                 .map(|entry| entry.path())
                 .filter(|path| {
                     path.extension().map_or(false, |ext| {
-                        path.is_file()
-                            && ext.to_string_lossy() == Cow::from("proto")
+                        path.is_file() && ext.to_string_lossy() == *"proto"
                     })
                 })
                 .filter_map(|path| {

--- a/proto/control-api/src/lib.rs
+++ b/proto/control-api/src/lib.rs
@@ -4,7 +4,7 @@
 //! [Control API]: https://tinyurl.com/yxsqplq7
 
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
-#![forbid(unsafe_code)]
+#![forbid(unsafe_code, non_ascii_idents)]
 
 #[cfg(feature = "grpc")]
 pub mod grpc;

--- a/proto/control-api/src/lib.rs
+++ b/proto/control-api/src/lib.rs
@@ -4,7 +4,7 @@
 //! [Control API]: https://tinyurl.com/yxsqplq7
 
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
-#![forbid(unsafe_code, non_ascii_idents)]
+#![forbid(non_ascii_idents, unsafe_code)]
 
 #[cfg(feature = "grpc")]
 pub mod grpc;

--- a/src/api/control/callback/url.rs
+++ b/src/api/control/callback/url.rs
@@ -113,13 +113,12 @@ mod tests {
             ("grpc://example.com", "http://example.com"),
             ("grpc://127.0.0.1", "http://127.0.0.1"),
         ] {
-            let callback_url =
-                CallbackUrl::try_from((*url).to_string()).unwrap();
+            let callback_url = CallbackUrl::try_from(url.to_string()).unwrap();
             match callback_url {
                 CallbackUrl::Grpc(grpc_callback_url) => {
                     assert_eq!(
-                        grpc_callback_url.addr(),
-                        (*expected_callback_url).to_string()
+                        &grpc_callback_url.addr(),
+                        expected_callback_url,
                     );
                 }
             }
@@ -133,7 +132,7 @@ mod tests {
             "asdf://127.0.0.1",
             "asdf://127.0.0.1:9090",
         ] {
-            let err = CallbackUrl::try_from((*url).to_string()).unwrap_err();
+            let err = CallbackUrl::try_from(url.to_string()).unwrap_err();
             match err {
                 CallbackUrlParseError::UnsupportedScheme => {}
                 _ => {
@@ -151,7 +150,7 @@ mod tests {
             "example.com",
             "example.com:9090",
         ] {
-            let err = CallbackUrl::try_from((*url).to_string()).unwrap_err();
+            let err = CallbackUrl::try_from(url.to_string()).unwrap_err();
             match err {
                 CallbackUrlParseError::UrlParseErr(e) => match e {
                     ParseError::RelativeUrlWithoutBase => {}

--- a/src/api/control/callback/url.rs
+++ b/src/api/control/callback/url.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn successful_parse_grpc_url() {
-        for (url, expected_callback_url) in &[
+        for (url, expected_callback_url) in [
             ("grpc://127.0.0.1:9090", "http://127.0.0.1:9090"),
             ("grpc://example.com:9090", "http://example.com:9090"),
             ("grpc://example.com", "http://example.com"),
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn error_on_unsupported_scheme() {
-        for url in &[
+        for url in [
             "asdf://example.com:9090",
             "asdf://127.0.0.1",
             "asdf://127.0.0.1:9090",
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn error_on_url_without_scheme() {
-        for url in &[
+        for url in [
             "127.0.0.1",
             "127.0.0.1:9090",
             "example.com",

--- a/src/api/control/member.rs
+++ b/src/api/control/member.rs
@@ -231,7 +231,7 @@ impl MemberSpec {
             MemberElement::WebRtcPlayEndpoint { spec } => {
                 Some((id.clone().into(), spec))
             }
-            _ => None,
+            MemberElement::WebRtcPublishEndpoint { .. } => None,
         })
     }
 
@@ -271,7 +271,7 @@ impl MemberSpec {
             MemberElement::WebRtcPublishEndpoint { spec } => {
                 Some((id.clone().into(), spec))
             }
-            _ => None,
+            MemberElement::WebRtcPlayEndpoint { .. } => None,
         })
     }
 

--- a/src/api/control/refs/fid.rs
+++ b/src/api/control/refs/fid.rs
@@ -153,7 +153,7 @@ mod specs {
 
     #[test]
     fn returns_error_on_missing_path() {
-        for fid_str in &[
+        for fid_str in [
             "room_id//endpoint_id",
             "//endpoint_id",
             "//member_id/endpoint_id",
@@ -171,7 +171,7 @@ mod specs {
 
     #[test]
     fn returns_error_on_too_many_paths() {
-        for fid_str in &[
+        for fid_str in [
             "room_id/member_id/endpoint_id/something_else",
             "room_id/member_id/endpoint_id/",
             "room_id/member_id/endpoint_id////",
@@ -237,7 +237,7 @@ mod specs {
 
     #[test]
     fn serializes_into_original_fid() {
-        for fid_str in &[
+        for fid_str in [
             "room_id",
             "room_id/member_id",
             "room_id/member_id/endpoint_id",

--- a/src/api/control/refs/fid.rs
+++ b/src/api/control/refs/fid.rs
@@ -159,7 +159,7 @@ mod specs {
             "//member_id/endpoint_id",
             "/member_id",
         ] {
-            match StatefulFid::try_from((*fid_str).to_string()) {
+            match StatefulFid::try_from(fid_str.to_string()) {
                 Ok(f) => unreachable!("Unexpected successful parse: {}", f),
                 Err(e) => match e {
                     ParseFidError::MissingPath(_) => (),
@@ -176,7 +176,7 @@ mod specs {
             "room_id/member_id/endpoint_id/",
             "room_id/member_id/endpoint_id////",
         ] {
-            match StatefulFid::try_from((*fid_str).to_string()) {
+            match StatefulFid::try_from(fid_str.to_string()) {
                 Ok(f) => unreachable!("Unexpected successful parse: {}", f),
                 Err(e) => match e {
                     ParseFidError::TooManyPaths(_) => (),
@@ -242,8 +242,8 @@ mod specs {
             "room_id/member_id",
             "room_id/member_id/endpoint_id",
         ] {
-            let fid = StatefulFid::try_from((*fid_str).to_string()).unwrap();
-            assert_eq!((*fid_str).to_string(), fid.to_string());
+            let fid = StatefulFid::try_from(fid_str.to_string()).unwrap();
+            assert_eq!(fid_str, &fid.to_string());
         }
     }
 }

--- a/src/api/control/refs/local_uri.rs
+++ b/src/api/control/refs/local_uri.rs
@@ -353,9 +353,8 @@ mod specs {
             "local://room_id/member_id/endpoint_id",
         ] {
             let local_uri =
-                StatefulLocalUri::try_from((*local_uri_str).to_string())
-                    .unwrap();
-            assert_eq!((*local_uri_str).to_string(), local_uri.to_string());
+                StatefulLocalUri::try_from(local_uri_str.to_string()).unwrap();
+            assert_eq!(local_uri_str, &local_uri.to_string());
         }
     }
 
@@ -366,7 +365,7 @@ mod specs {
             "local:////endpoint_id",
             "local:///member_id/endpoint_id",
         ] {
-            match StatefulLocalUri::try_from((*local_uri_str).to_string()) {
+            match StatefulLocalUri::try_from(local_uri_str.to_string()) {
                 Ok(_) => unreachable!(),
                 Err(e) => match e {
                     LocalUriParseError::MissingPaths(_) => (),

--- a/src/api/control/refs/local_uri.rs
+++ b/src/api/control/refs/local_uri.rs
@@ -347,7 +347,7 @@ mod specs {
 
     #[test]
     fn properly_serialize() {
-        for local_uri_str in &[
+        for local_uri_str in [
             "local://room_id",
             "local://room_id/member_id",
             "local://room_id/member_id/endpoint_id",
@@ -361,7 +361,7 @@ mod specs {
 
     #[test]
     fn return_error_when_local_uri_not_full() {
-        for local_uri_str in &[
+        for local_uri_str in [
             "local://room_id//endpoint_id",
             "local:////endpoint_id",
             "local:///member_id/endpoint_id",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::module_name_repetitions)]
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+#![forbid(unsafe_code, non_ascii_idents)]
 
 #[macro_use]
 pub mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::module_name_repetitions)]
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
-#![forbid(unsafe_code, non_ascii_idents)]
+#![forbid(non_ascii_idents, unsafe_code)]
 
 #[macro_use]
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 //! Medea media server application.
 
+#![forbid(non_ascii_idents, unsafe_code)]
+
 use actix::{Actor, System};
 use failure::Error;
 use medea::{

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -37,7 +37,8 @@
 //! 2. Implement your changing logic in the [`PeerChangeHandler`]
 //!    implementation.
 //! 3. Create a function in the [`PeerChangesScheduler`] which will schedule
-//!    your change by adding it into the [`Context::peer_changes_queue`].
+//!    your change by adding it into the `peer_changes_queue` of the
+//!    [`Context`].
 //!
 //! # Applying changes regardless of [`Peer`] state
 //!
@@ -576,7 +577,7 @@ impl PeerChange {
 impl<T> PeerChangeHandler for Peer<T> {
     type Output = PeerChange;
 
-    /// Inserts provided [`MediaTrack`] into [`Context::senders`].
+    /// Inserts provided [`MediaTrack`] into the `senders` of this [`Context`].
     #[inline]
     fn on_add_send_track(&mut self, track: Rc<MediaTrack>) -> Self::Output {
         self.context.senders.insert(track.id(), Rc::clone(&track));
@@ -584,7 +585,8 @@ impl<T> PeerChangeHandler for Peer<T> {
         PeerChange::AddSendTrack(track)
     }
 
-    /// Inserts provided [`MediaTrack`] into [`Context::receivers`].
+    /// Inserts provided [`MediaTrack`] into the `receivers` of this
+    /// [`Context`].
     #[inline]
     fn on_add_recv_track(&mut self, track: Rc<MediaTrack>) -> Self::Output {
         self.context.receivers.insert(track.id(), Rc::clone(&track));
@@ -655,7 +657,7 @@ impl<T> PeerChangeHandler for Peer<T> {
         PeerChange::RemoveTrack(track_id)
     }
 
-    /// Sets [`Context::ice_restart`] flag to `true`.
+    /// Sets the `ice_restart` flag of this [`Context`] to `true`.
     #[inline]
     fn on_ice_restart(&mut self) -> Self::Output {
         self.context.ice_restart = true;
@@ -1217,7 +1219,7 @@ impl Peer<Stable> {
     /// Changes [`Peer`] state to [`WaitLocalSdp`] and discards previously saved
     /// [SDP] Offer and Answer.
     ///
-    /// Resets [`Context::local_sdp`] and [`Context::remote_sdp`].
+    /// Resets the `local_sdp` and the `remote_sdp` of this [`Context`].
     ///
     /// [SDP]: https://tools.ietf.org/html/rfc4317
     #[inline]
@@ -1238,7 +1240,7 @@ impl Peer<Stable> {
     /// Changes [`Peer`] state to [`WaitLocalSdp`] and discards previously saved
     /// [SDP] Offer and Answer.
     ///
-    /// Resets [`Context::local_sdp`] and [`Context::remote_sdp`].
+    /// Resets the `local_sdp` and the `remote_sdp` of this [`Context`].
     ///
     /// [SDP]: https://tools.ietf.org/html/rfc4317
     #[inline]

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -577,7 +577,7 @@ impl PeerChange {
 impl<T> PeerChangeHandler for Peer<T> {
     type Output = PeerChange;
 
-    /// Inserts provided [`MediaTrack`] into the `senders` of this [`Context`].
+    /// Inserts the provided [`MediaTrack`] into `senders` of this [`Context`].
     #[inline]
     fn on_add_send_track(&mut self, track: Rc<MediaTrack>) -> Self::Output {
         self.context.senders.insert(track.id(), Rc::clone(&track));
@@ -585,7 +585,7 @@ impl<T> PeerChangeHandler for Peer<T> {
         PeerChange::AddSendTrack(track)
     }
 
-    /// Inserts provided [`MediaTrack`] into the `receivers` of this
+    /// Inserts the provided [`MediaTrack`] into `receivers` of this
     /// [`Context`].
     #[inline]
     fn on_add_recv_track(&mut self, track: Rc<MediaTrack>) -> Self::Output {

--- a/src/media/peer.rs
+++ b/src/media/peer.rs
@@ -1464,7 +1464,7 @@ impl<'a> PeerChangesScheduler<'a> {
 
     /// Removes [`Track`]s with a provided [`TrackId`]s from this [`Peer`].
     pub fn remove_tracks(&mut self, track_ids: &[TrackId]) {
-        track_ids.iter().for_each(|id| {
+        for id in track_ids {
             let changes_indexes_to_remove: Vec<_> = self
                 .context
                 .peer_changes_queue
@@ -1489,7 +1489,7 @@ impl<'a> PeerChangesScheduler<'a> {
                     self.context.peer_changes_queue.remove(remove_index);
                 }
             }
-        });
+        }
     }
 }
 

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -128,7 +128,7 @@ impl Handler<OsSignal> for GracefulShutdown {
             return future::ready(()).boxed_local();
         }
 
-        let subs = mem::replace(&mut self.subs, BTreeMap::new());
+        let subs = mem::take(&mut self.subs);
         let ordered_subs: Vec<_> = subs
             .into_iter()
             .rev()

--- a/src/signalling/peers/metrics/flowing_detector.rs
+++ b/src/signalling/peers/metrics/flowing_detector.rs
@@ -703,7 +703,6 @@ impl PeerStat {
 
     /// Returns last update time of the tracks with provided [`MediaDirection`]
     /// and [`MediaType`].
-    #[allow(clippy::manual_filter_map)]
     fn get_tracks_last_update(
         &self,
         direction: MediaDirection,

--- a/src/signalling/peers/metrics/flowing_detector.rs
+++ b/src/signalling/peers/metrics/flowing_detector.rs
@@ -656,20 +656,19 @@ impl PeerStat {
     /// Updates `recv_traffic_state` based on current `receivers` state.
     /// Supposed to be called after you finished updating `receivers`.
     fn update_recv_traffic_state(&mut self) {
-        for track_media_type in &[TrackMediaType::Video, TrackMediaType::Audio]
-        {
-            let media_type = (*track_media_type).into();
+        for track_media_type in [TrackMediaType::Video, TrackMediaType::Audio] {
+            let media_type = track_media_type.into();
             let cnt_flowing = self
                 .receivers
                 .values()
-                .filter(|rx| rx.media_type == *track_media_type)
+                .filter(|rx| rx.media_type == track_media_type)
                 .filter(|rx| rx.is_flowing())
                 .count();
             if cnt_flowing != 0
                 && cnt_flowing
                     >= self
                         .tracks_spec
-                        .get_by_kind(*track_media_type, MediaDirection::Play)
+                        .get_by_kind(track_media_type, MediaDirection::Play)
             {
                 self.recv_traffic_state.started(media_type);
             } else {
@@ -681,20 +680,19 @@ impl PeerStat {
     /// Updates `send_traffic_state` based on current `senders` state. Supposed
     /// to be called after you finished updating `senders`.
     fn update_send_traffic_state(&mut self) {
-        for track_media_type in &[TrackMediaType::Video, TrackMediaType::Audio]
-        {
-            let media_type = (*track_media_type).into();
+        for track_media_type in [TrackMediaType::Video, TrackMediaType::Audio] {
+            let media_type = track_media_type.into();
             let cnt_flowing = self
                 .senders
                 .values()
-                .filter(|rx| rx.media_type == *track_media_type)
+                .filter(|rx| rx.media_type == track_media_type)
                 .filter(|rx| rx.is_flowing())
                 .count();
             if cnt_flowing != 0
                 && cnt_flowing
                     >= self
                         .tracks_spec
-                        .get_by_kind(*track_media_type, MediaDirection::Publish)
+                        .get_by_kind(track_media_type, MediaDirection::Publish)
             {
                 self.send_traffic_state.started(media_type);
             } else {
@@ -705,7 +703,7 @@ impl PeerStat {
 
     /// Returns last update time of the tracks with provided [`MediaDirection`]
     /// and [`MediaType`].
-    #[allow(clippy::filter_map)]
+    #[allow(clippy::manual_filter_map)]
     fn get_tracks_last_update(
         &self,
         direction: MediaDirection,

--- a/src/signalling/peers/metrics/quality_meter.rs
+++ b/src/signalling/peers/metrics/quality_meter.rs
@@ -580,8 +580,8 @@ mod tests {
         meter.add_packets_lost(StatId::from("111"), 0);
         meter.add_packets_sent(StatId::from("111"), 1000);
         meter.add_rtt(Duration::from_millis(0));
-        for jitter in &[0, 0, 0] {
-            meter.add_jitter(Duration::from_millis(*jitter));
+        for jitter in [0, 0, 0] {
+            meter.add_jitter(Duration::from_millis(jitter));
         }
 
         assert_eq!(meter.calculate().unwrap(), ConnectionQualityScore::High);
@@ -591,10 +591,10 @@ mod tests {
     fn regular_normal_call() {
         let mut meter = QualityMeter::new(STATS_TTL);
 
-        for jitter in &[0, 10, 12, 10] {
-            meter.add_jitter(Duration::from_millis(*jitter));
+        for jitter in [0, 10, 12, 10] {
+            meter.add_jitter(Duration::from_millis(jitter));
         }
-        for (packet_lost, packets_received) in &[
+        for (packet_lost, packets_received) in [
             (0, 45),
             (0, 50),
             (0, 95),
@@ -603,11 +603,11 @@ mod tests {
             (0, 158),
             (0, 197),
         ] {
-            meter.add_packets_lost(StatId::from("a"), *packet_lost);
-            meter.add_packets_sent(StatId::from("a"), *packets_received);
+            meter.add_packets_lost(StatId::from("a"), packet_lost);
+            meter.add_packets_sent(StatId::from("a"), packets_received);
         }
-        for rtt in &[20, 30, 20, 30] {
-            meter.add_rtt(Duration::from_millis(*rtt));
+        for rtt in [20, 30, 20, 30] {
+            meter.add_rtt(Duration::from_millis(rtt));
         }
 
         assert_eq!(meter.calculate().unwrap(), ConnectionQualityScore::High);
@@ -617,10 +617,10 @@ mod tests {
     fn bad_call() {
         let mut meter = QualityMeter::new(STATS_TTL);
 
-        for jitter in &[10, 20, 15, 16, 11] {
-            meter.add_jitter(Duration::from_millis(*jitter));
+        for jitter in [10, 20, 15, 16, 11] {
+            meter.add_jitter(Duration::from_millis(jitter));
         }
-        for (packet_lost, packets_sent) in &[
+        for (packet_lost, packets_sent) in [
             (3, 45),
             (6, 50),
             (7, 95),
@@ -630,11 +630,11 @@ mod tests {
             (15, 197),
             (19, 217),
         ] {
-            meter.add_packets_lost(StatId::from("a"), *packet_lost);
-            meter.add_packets_sent(StatId::from("a"), *packets_sent);
+            meter.add_packets_lost(StatId::from("a"), packet_lost);
+            meter.add_packets_sent(StatId::from("a"), packets_sent);
         }
-        for rtt in &[150, 160, 170, 150] {
-            meter.add_rtt(Duration::from_millis(*rtt));
+        for rtt in [150, 160, 170, 150] {
+            meter.add_rtt(Duration::from_millis(rtt));
         }
 
         assert_eq!(meter.calculate().unwrap(), ConnectionQualityScore::Low);
@@ -646,8 +646,8 @@ mod tests {
         meter.add_packets_lost(StatId::from("a"), 100);
         meter.add_packets_sent(StatId::from("a"), 100);
         meter.add_rtt(Duration::from_millis(1000));
-        for jitter in &[10, 1000, 3000] {
-            meter.add_jitter(Duration::from_millis(*jitter));
+        for jitter in [10, 1000, 3000] {
+            meter.add_jitter(Duration::from_millis(jitter));
         }
 
         assert_eq!(meter.calculate().unwrap(), ConnectionQualityScore::Poor);

--- a/src/signalling/peers/traffic_watcher.rs
+++ b/src/signalling/peers/traffic_watcher.rs
@@ -388,7 +388,7 @@ impl Handler<TrafficFlows> for PeersTrafficWatcherImpl {
                             room.handler.peer_started(peer.peer_id);
                         }
                     }
-                    _ => (),
+                    PeerState::Started => (),
                 }
             }
         }

--- a/src/signalling/room/dynamic_api.rs
+++ b/src/signalling/room/dynamic_api.rs
@@ -371,13 +371,13 @@ impl Handler<Delete> for Room {
                 }
             }
         }
-        member_ids.into_iter().for_each(|fid| {
+        for fid in member_ids {
             self.delete_member(&fid.member_id(), ctx);
-        });
-        endpoint_ids.into_iter().for_each(|fid| {
+        }
+        for fid in endpoint_ids {
             let (_, member_id, endpoint_id) = fid.take_all();
             self.delete_endpoint(&member_id, endpoint_id);
-        });
+        }
     }
 }
 

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1,3 +1,5 @@
+#![forbid(non_ascii_idents, unsafe_code)]
+
 mod browser;
 mod conf;
 mod control;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::module_name_repetitions)]
+#![forbid(non_ascii_idents, unsafe_code)]
 
 mod callbacks;
 mod grpc_control_api;


### PR DESCRIPTION
## Synopsis

Rust [v1.53](https://github.com/rust-lang/rust/releases/tag/1.53.0) is out, let's upgrade.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
